### PR TITLE
feat(parser-next): Phase 2S W0 — graphql assembly substrate

### DIFF
--- a/smear-parser-next/src/graphql/ast/mod.rs
+++ b/smear-parser-next/src/graphql/ast/mod.rs
@@ -1,0 +1,20 @@
+//! GraphQL AST node types.
+//!
+//! Copied type-only from the frozen `smear-parser` crate (`graphql/ast/`): the node
+//! types the productions return, keyed by the source slice `S` with spans pinned to
+//! [`SimpleSpan`](tokora::SimpleSpan). The parser fns that lived beside them in the
+//! frozen crate are *not* copied — the productions are rebuilt on the atom layer,
+//! wave by wave.
+
+use std::vec::Vec;
+
+pub use name::*;
+pub use ty::*;
+pub use value::*;
+
+mod name;
+mod ty;
+mod value;
+
+/// The default container type used for AST collections (lists, objects).
+pub type DefaultVec<T> = Vec<T>;

--- a/smear-parser-next/src/graphql/ast/name.rs
+++ b/smear-parser-next/src/graphql/ast/name.rs
@@ -1,0 +1,16 @@
+use tokora::SimpleSpan;
+
+/// A GraphQL name identifier.
+///
+/// Represents a valid GraphQL name as defined by the specification. Names are
+/// used throughout GraphQL for field names, type names, argument names, directive
+/// names, and other identifiers.
+///
+/// ## Grammar
+///
+/// ```text
+/// Name ::= [_A-Za-z][_0-9A-Za-z]*
+/// ```
+///
+/// Spec: [Name](https://spec.graphql.org/draft/#sec-Names)
+pub type Name<V, S = SimpleSpan> = crate::ident::Ident<V, S>;

--- a/smear-parser-next/src/graphql/ast/ty.rs
+++ b/smear-parser-next/src/graphql/ast/ty.rs
@@ -1,0 +1,67 @@
+use std::{boxed::Box, rc::Rc, sync::Arc};
+
+use derive_more::{From, IsVariant, TryUnwrap, Unwrap};
+use smear_scaffold::ast::{ListType, NamedType};
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+};
+
+macro_rules! ty {
+  ($(
+    $(#[$meta:meta])*
+    $ty:ident<$name:ident>), +$(,)?
+  ) => {
+    paste::paste! {
+      $(
+        $(#[$meta])*
+        #[derive(Debug, Clone, From, IsVariant, Unwrap, TryUnwrap)]
+        #[unwrap(ref, ref_mut)]
+        #[try_unwrap(ref, ref_mut)]
+        pub enum $name<Name> {
+          /// A named type referencing a schema-defined type.
+          Name(NamedType<Name>),
+
+          /// A list type containing elements of another type.
+          List($ty<ListType<Self>>),
+        }
+
+        impl<Name> From<ListType<Self>> for $name<Name> {
+          #[inline]
+          fn from(ty: ListType<Self>) -> Self {
+            Self::List(<$ty<ListType<Self>>>::new(ty))
+          }
+        }
+
+        impl<Name> AsSpan<Span> for $name<Name> {
+          #[inline]
+          fn as_span(&self) -> &Span {
+            match self {
+              Self::Name(ty) => ty.span(),
+              Self::List(ty) => ty.span(),
+            }
+          }
+        }
+
+        impl<Name> IntoSpan<Span> for $name<Name> {
+          #[inline]
+          fn into_span(self) -> Span {
+            match self {
+              Self::Name(ty) => ty.into_span(),
+              Self::List(ty) => *ty.span(),
+            }
+          }
+        }
+      )*
+    }
+  };
+}
+
+ty!(
+  /// GraphQL type using `Box` for recursive list types.
+  Box<Type>,
+  /// GraphQL type using `Rc` for recursive list types with reference counting.
+  Rc<RcType>,
+  /// GraphQL type using `Arc` for recursive list types with atomic reference counting.
+  Arc<ArcType>,
+);

--- a/smear-parser-next/src/graphql/ast/value.rs
+++ b/smear-parser-next/src/graphql/ast/value.rs
@@ -1,0 +1,151 @@
+use derive_more::{From, IsVariant, TryUnwrap, Unwrap};
+use smear_scaffold::ast as scaffold;
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+};
+
+use super::{DefaultVec, Name};
+
+pub use crate::value::{
+  BlockStringValue, BooleanValue, EnumValue, FloatValue, InlineStringValue, IntValue, NullValue,
+  StringValue,
+};
+
+/// A GraphQL variable value that can appear in queries and mutations.
+pub type VariableValue<S> = crate::value::VariableValue<Name<S>>;
+
+/// List value in GraphQL (can contain variables).
+pub type List<S, Container = DefaultVec<InputValue<S>>> = scaffold::List<InputValue<S>, Container>;
+
+/// Object value in GraphQL (can contain variables).
+pub type Object<S, Container = DefaultVec<InputValue<S>>> =
+  scaffold::Object<Name<S>, InputValue<S>, Container>;
+
+/// Object field in GraphQL (can contain variables).
+pub type ObjectField<S> = scaffold::ObjectField<Name<S>, InputValue<S>>;
+
+/// Constant list value in GraphQL (no variables).
+pub type ConstList<S, Container = DefaultVec<ConstInputValue<S>>> =
+  scaffold::List<ConstInputValue<S>, Container>;
+
+/// Constant object value in GraphQL (no variables).
+pub type ConstObject<S, Container = DefaultVec<ConstInputValue<S>>> =
+  scaffold::Object<Name<S>, ConstInputValue<S>, Container>;
+
+/// Constant object field in GraphQL (no variables).
+pub type ConstObjectField<S> = scaffold::ObjectField<Name<S>, ConstInputValue<S>>;
+
+/// GraphQL input value (executable context).
+#[derive(Debug, Clone, From, IsVariant, Unwrap, TryUnwrap)]
+#[unwrap(ref, ref_mut)]
+#[try_unwrap(ref, ref_mut)]
+pub enum InputValue<S> {
+  /// Variable reference (e.g., `$userId`).
+  Variable(VariableValue<S>),
+  /// Boolean value (`true` or `false`).
+  Boolean(BooleanValue),
+  /// String value (inline or block string).
+  String(StringValue<S>),
+  /// Floating-point number.
+  Float(FloatValue<S>),
+  /// Integer number.
+  Int(IntValue<S>),
+  /// Enum value name.
+  Enum(EnumValue<S>),
+  /// The `null` literal.
+  Null(NullValue<S>),
+  /// List of values.
+  List(scaffold::List<InputValue<S>>),
+  /// Object value with named fields.
+  Object(scaffold::Object<Name<S>, InputValue<S>>),
+}
+
+impl<S> AsSpan<Span> for InputValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    match self {
+      Self::Variable(v) => v.as_span(),
+      Self::Boolean(v) => v.as_span(),
+      Self::String(v) => v.as_span(),
+      Self::Float(v) => v.as_span(),
+      Self::Int(v) => v.as_span(),
+      Self::Enum(v) => v.as_span(),
+      Self::Null(v) => v.as_span(),
+      Self::List(v) => v.as_span(),
+      Self::Object(v) => v.as_span(),
+    }
+  }
+}
+
+impl<S> IntoSpan<Span> for InputValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    match self {
+      Self::Variable(v) => v.into_span(),
+      Self::Boolean(v) => v.into_span(),
+      Self::String(v) => v.into_span(),
+      Self::Float(v) => v.into_span(),
+      Self::Int(v) => v.into_span(),
+      Self::Enum(v) => v.into_span(),
+      Self::Null(v) => v.into_span(),
+      Self::List(v) => v.into_span(),
+      Self::Object(v) => v.into_span(),
+    }
+  }
+}
+
+/// GraphQL constant input value (schema context).
+#[derive(Debug, Clone, IsVariant, Unwrap, TryUnwrap)]
+#[unwrap(ref, ref_mut)]
+#[try_unwrap(ref, ref_mut)]
+pub enum ConstInputValue<S> {
+  /// Boolean value (`true` or `false`).
+  Boolean(BooleanValue),
+  /// String value (inline or block string).
+  String(StringValue<S>),
+  /// Floating-point number.
+  Float(FloatValue<S>),
+  /// Integer number.
+  Int(IntValue<S>),
+  /// Enum value name.
+  Enum(EnumValue<S>),
+  /// The `null` literal.
+  Null(NullValue<S>),
+  /// List of constant values.
+  List(scaffold::List<ConstInputValue<S>>),
+  /// Object value with named fields (all values must be constant).
+  Object(scaffold::Object<Name<S>, ConstInputValue<S>>),
+}
+
+impl<S> AsSpan<Span> for ConstInputValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    match self {
+      Self::Boolean(v) => v.as_span(),
+      Self::String(v) => v.as_span(),
+      Self::Float(v) => v.as_span(),
+      Self::Int(v) => v.as_span(),
+      Self::Enum(v) => v.as_span(),
+      Self::Null(v) => v.as_span(),
+      Self::List(v) => v.as_span(),
+      Self::Object(v) => v.as_span(),
+    }
+  }
+}
+
+impl<S> IntoSpan<Span> for ConstInputValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    match self {
+      Self::Boolean(v) => v.into_span(),
+      Self::String(v) => v.into_span(),
+      Self::Float(v) => v.into_span(),
+      Self::Int(v) => v.into_span(),
+      Self::Enum(v) => v.into_span(),
+      Self::Null(v) => v.into_span(),
+      Self::List(v) => v.into_span(),
+      Self::Object(v) => v.into_span(),
+    }
+  }
+}

--- a/smear-parser-next/src/graphql/error.rs
+++ b/smear-parser-next/src/graphql/error.rs
@@ -1,0 +1,673 @@
+//! The GraphQL dialect error and the `From` glue that makes it a
+//! [`ParseCtx`](crate::combinator::ParseCtx) error.
+//!
+//! The error family — [`Expectation`], [`Unclosed`], [`ErrorData`], [`Error`], and
+//! the [`Errors`] container — is copied from the frozen `smear-parser` crate
+//! (`graphql/error.rs`), re-keyed to the source slice `S`. [`GraphqlError`] and
+//! [`GraphqlErrors`] pin `S` and the token to the concrete GraphQL syntactic token,
+//! the one dialect-specific instantiation the entry runners and tests name.
+//!
+//! The atoms speak tokora's generic error families ([`UnexpectedToken`],
+//! [`SeparatedError`], the container/`TooFew` families, [`UnexpectedEot`], and the
+//! lexer errors). tokora 0.3.0's `ComposableEmitter` bundle and `From*` blankets
+//! shrink the old twelve-impl set to the handful of `From` conversions the atoms'
+//! bounds actually demand; each lands here so [`Fatal`](tokora::emitter::Fatal)
+//! over [`GraphqlErrors`] is a complete [`ParseCtx`](crate::combinator::ParseCtx)
+//! over both `str` and `[u8]` syntactic lexers — proven by the module's compile
+//! test.
+
+use derive_more::{AsMut, AsRef, Deref, DerefMut, From, Into, IsVariant, TryUnwrap, Unwrap};
+use smear_lexer::{
+  graphql::{error::LexerErrors, syntactic::SyntacticToken},
+  tokora::error::UnexpectedEnd,
+};
+use smear_scaffold::hints::{
+  EnumTypeExtensionHint, InputObjectTypeExtensionHint, InterfaceTypeExtensionHint,
+  ObjectFieldValueHint, ObjectTypeExtensionHint, SchemaExtensionHint, UnionTypeExtensionHint,
+};
+use tokora::{
+  SimpleSpan as Span,
+  error::{
+    UnexpectedEot,
+    syntax::{FullContainer, MissingSyntax, TooFew},
+    token::{MissingToken, SeparatedError, UnexpectedToken as TokUnexpectedToken},
+  },
+  utils::CowStr,
+};
+
+use super::GraphQL;
+
+/// Hints for parsing a variable value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, IsVariant, derive_more::Display)]
+#[non_exhaustive]
+pub enum VariableValueHint {
+  /// A name was expected.
+  #[display("name")]
+  Name,
+  /// A dollar `$` was expected.
+  #[display("dollar")]
+  Dollar,
+}
+
+/// Expectations for the GraphQL parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Expectation {
+  /// An inline string was expected.
+  InlineString,
+  /// A block string was expected.
+  BlockString,
+  /// A `$` was expected.
+  Dollar,
+  /// A `(` was expected.
+  LParen,
+  /// A `)` was expected.
+  RParen,
+  /// A `...` was expected.
+  Spread,
+  /// A `:` was expected.
+  Colon,
+  /// A `=` was expected.
+  Equal,
+  /// A `@` was expected.
+  At,
+  /// A `[` was expected.
+  LBracket,
+  /// A `]` was expected.
+  RBracket,
+  /// A `{` was expected.
+  LBrace,
+  /// A `}` was expected.
+  RBrace,
+  /// A `|` was expected.
+  Pipe,
+  /// A `!` was expected.
+  Bang,
+  /// A `&` was expected.
+  Ampersand,
+
+  /// Const input value was expected.
+  ConstInputValue,
+  /// Input value was expected.
+  InputValue,
+  /// Fragment name was expected.
+  FragmentName,
+  /// A name was expected.
+  Name,
+  /// An operation name was expected.
+  OperationName,
+  /// An directive location was expected.
+  DirectiveLocation,
+  /// Either a fragment spread or an inline fragment was expected.
+  FragmentSpreadOrInlineFragment,
+  /// A number was expected.
+  IntValue,
+  /// A boolean was expected.
+  BooleanValue,
+  /// A float was expected.
+  FloatValue,
+  /// A null value was expected.
+  NullValue,
+  /// An enum value was expected.
+  EnumValue,
+  /// A string value was expected.
+  StringValue,
+  /// A keyword was expected.
+  Keyword(&'static str),
+}
+
+/// An unexpected token error carrying the found token and the expectation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnexpectedToken<T, TK> {
+  found: Option<T>,
+  expected: TK,
+}
+
+impl<T, TK> UnexpectedToken<T, TK> {
+  /// Creates an unexpected token error without a found token.
+  #[inline]
+  pub const fn new(expected: TK) -> Self {
+    Self::maybe_found(None, expected)
+  }
+
+  /// Creates a new unexpected token error.
+  #[inline]
+  pub const fn maybe_found(found: Option<T>, expected: TK) -> Self {
+    Self { found, expected }
+  }
+
+  /// Creates a new unexpected token error with a found token.
+  #[inline]
+  pub const fn with_found(found: T, expected: TK) -> Self {
+    Self::maybe_found(Some(found), expected)
+  }
+
+  /// Returns the found token, if any.
+  #[inline]
+  pub const fn found(&self) -> Option<&T> {
+    self.found.as_ref()
+  }
+
+  /// Returns the expectation.
+  #[inline]
+  pub const fn expected(&self) -> &TK {
+    &self.expected
+  }
+}
+
+/// An unexpected keyword error.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UnexpectedKeyword<S> {
+  found: S,
+  expected: &'static str,
+}
+
+impl<S> UnexpectedKeyword<S> {
+  /// Creates a new unexpected keyword error.
+  #[inline]
+  pub const fn new(found: S, expected_kw: &'static str) -> Self {
+    Self {
+      found,
+      expected: expected_kw,
+    }
+  }
+
+  /// Returns the found keyword.
+  #[inline]
+  pub const fn found(&self) -> &S {
+    &self.found
+  }
+
+  /// Returns the name of the expected keyword.
+  #[inline]
+  pub const fn expected(&self) -> &'static str {
+    self.expected
+  }
+}
+
+/// Represents an unclosed delimiter in GraphQL source.
+#[derive(Debug, Copy, Clone, IsVariant)]
+pub enum Unclosed {
+  /// An unclosed list (missing `]`).
+  List,
+  /// An unclosed object (missing `}`).
+  Object,
+}
+
+/// The data of a parser error.
+#[derive(Debug, Clone, From, IsVariant, Unwrap, TryUnwrap)]
+#[unwrap(ref, ref_mut)]
+#[try_unwrap(ref, ref_mut)]
+pub enum ErrorData<S, T, Char = char, Exp = Expectation, StateError = ()> {
+  /// One or more errors from the lexer.
+  Lexer(LexerErrors<Char, StateError>),
+  /// An integer value could not be parsed due to overflow.
+  #[from(skip)]
+  IntOverflow(S),
+  /// A floating point value could not be parsed due to overflow.
+  #[from(skip)]
+  FloatOverflow(S),
+  /// An enum value is invalid.
+  #[from(skip)]
+  InvalidEnumValue(S),
+  /// A boolean value is invalid.
+  #[from(skip)]
+  InvalidBooleanValue(S),
+  /// A null value is invalid.
+  #[from(skip)]
+  InvalidNullValue(S),
+  /// A fragment name is invalid.
+  #[from(skip)]
+  InvalidFragmentName(S),
+  /// A list or object was not closed.
+  Unclosed(Unclosed),
+  /// An unexpected token was found.
+  UnexpectedToken(UnexpectedToken<T, Exp>),
+  /// An unexpected keyword was found.
+  UnexpectedKeyword(UnexpectedKeyword<S>),
+  /// An unexpected end was found in a variable value.
+  UnexpectedEndOfVariableValue(UnexpectedEnd<VariableValueHint>),
+  /// An unexpected end was found in an object field value.
+  UnexpectedEndOfObjectFieldValue(UnexpectedEnd<ObjectFieldValueHint>),
+  /// An unknown directive location was found.
+  #[from(skip)]
+  UnknownDirectiveLocation(S),
+  /// An unknown operation type was found.
+  #[from(skip)]
+  UnknownOperationType(S),
+  /// An unexpected end was found in an object type extension.
+  UnexpectedEndOfObjectExtension(UnexpectedEnd<ObjectTypeExtensionHint>),
+  /// An unexpected end was found in an interface type extension.
+  UnexpectedEndOfInterfaceExtension(UnexpectedEnd<InterfaceTypeExtensionHint>),
+  /// An unexpected end was found in an enum type extension.
+  UnexpectedEndOfEnumExtension(UnexpectedEnd<EnumTypeExtensionHint>),
+  /// An unexpected end was found in an input object type extension.
+  UnexpectedEndOfInputObjectExtension(UnexpectedEnd<InputObjectTypeExtensionHint>),
+  /// An unexpected end was found in a union type extension.
+  UnexpectedEndOfUnionExtension(UnexpectedEnd<UnionTypeExtensionHint>),
+  /// An unexpected end was found in a schema extension.
+  UnexpectedEndOfSchemaExtension(UnexpectedEnd<SchemaExtensionHint>),
+  /// An end of input was found.
+  EndOfInput,
+  /// Some other error.
+  Other(std::borrow::Cow<'static, str>),
+}
+
+/// A parser error.
+#[derive(Debug, Clone)]
+pub struct Error<S, T, Char = char, Exp = Expectation, StateError = ()> {
+  span: Span,
+  data: ErrorData<S, T, Char, Exp, StateError>,
+}
+
+impl<S, T, Char, Exp, StateError> Error<S, T, Char, Exp, StateError> {
+  /// Creates a new error.
+  #[inline]
+  pub const fn new(span: Span, data: ErrorData<S, T, Char, Exp, StateError>) -> Self {
+    Self { span, data }
+  }
+
+  /// Creates an unexpected token error.
+  #[inline]
+  pub const fn unexpected_token(found: T, expected: Exp, span: Span) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedToken(UnexpectedToken::with_found(found, expected)),
+    )
+  }
+
+  /// Creates an unexpected end in variable value error.
+  #[inline]
+  pub const fn unexpected_end_of_variable_value(hint: VariableValueHint, span: Span) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfVariableValue(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("variable value"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unexpected keyword error.
+  #[inline]
+  pub const fn unexpected_keyword(found: S, expected_kw: &'static str, span: Span) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedKeyword(UnexpectedKeyword::new(found, expected_kw)),
+    )
+  }
+
+  /// Creates an unexpected end in object field value error.
+  #[inline]
+  pub const fn unexpected_end_of_object_field_value(
+    hint: ObjectFieldValueHint,
+    span: Span,
+  ) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfObjectFieldValue(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("object field value"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unexpected end in object type extension error.
+  #[inline]
+  pub const fn unexpected_end_of_object_extension(
+    span: Span,
+    hint: ObjectTypeExtensionHint,
+  ) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfObjectExtension(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("object type extension"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unexpected end in interface type extension error.
+  #[inline]
+  pub const fn unexpected_end_of_interface_extension(
+    span: Span,
+    hint: InterfaceTypeExtensionHint,
+  ) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfInterfaceExtension(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("interface type extension"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unexpected end in enum type extension error.
+  #[inline]
+  pub const fn unexpected_end_of_enum_extension(span: Span, hint: EnumTypeExtensionHint) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfEnumExtension(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("enum type extension"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unexpected end in input object type extension error.
+  #[inline]
+  pub const fn unexpected_end_of_input_object_extension(
+    span: Span,
+    hint: InputObjectTypeExtensionHint,
+  ) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfInputObjectExtension(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("input object type extension"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unexpected end in union type extension error.
+  #[inline]
+  pub const fn unexpected_end_of_union_extension(span: Span, hint: UnionTypeExtensionHint) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfUnionExtension(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("union type extension"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unexpected end in schema extension error.
+  #[inline]
+  pub const fn unexpected_end_of_schema_extension(span: Span, hint: SchemaExtensionHint) -> Self {
+    Self::new(
+      span,
+      ErrorData::UnexpectedEndOfSchemaExtension(UnexpectedEnd::with_name(
+        0,
+        CowStr::from_static("schema extension"),
+        hint,
+      )),
+    )
+  }
+
+  /// Creates an unclosed list error.
+  #[inline]
+  pub const fn unclosed_list(span: Span) -> Self {
+    Self::new(span, ErrorData::Unclosed(Unclosed::List))
+  }
+
+  /// Creates an unclosed object error.
+  #[inline]
+  pub const fn unclosed_object(span: Span) -> Self {
+    Self::new(span, ErrorData::Unclosed(Unclosed::Object))
+  }
+
+  /// Creates an error from a lexer error.
+  #[inline]
+  pub const fn from_lexer_errors(err: LexerErrors<Char, StateError>, span: Span) -> Self {
+    Self::new(span, ErrorData::Lexer(err))
+  }
+
+  /// Creates an invalid fragment name error.
+  #[inline]
+  pub const fn invalid_fragment_name(value: S, span: Span) -> Self {
+    Self::new(span, ErrorData::InvalidFragmentName(value))
+  }
+
+  /// Creates an invalid enum value error.
+  #[inline]
+  pub const fn invalid_enum_value(value: S, span: Span) -> Self {
+    Self::new(span, ErrorData::InvalidEnumValue(value))
+  }
+
+  /// Creates an invalid boolean value error.
+  #[inline]
+  pub const fn invalid_boolean_value(value: S, span: Span) -> Self {
+    Self::new(span, ErrorData::InvalidBooleanValue(value))
+  }
+
+  /// Creates an invalid null value error.
+  #[inline]
+  pub const fn invalid_null_value(value: S, span: Span) -> Self {
+    Self::new(span, ErrorData::InvalidNullValue(value))
+  }
+
+  /// Creates an unknown directive location error.
+  #[inline]
+  pub const fn unknown_directive_location(value: S, span: Span) -> Self {
+    Self::new(span, ErrorData::UnknownDirectiveLocation(value))
+  }
+
+  /// Creates an unknown operation type error.
+  #[inline]
+  pub const fn unknown_operation_type(value: S, span: Span) -> Self {
+    Self::new(span, ErrorData::UnknownOperationType(value))
+  }
+
+  /// Creates an unexpected end of input error.
+  #[inline]
+  pub const fn unexpected_end_of_input(span: Span) -> Self {
+    Self::new(span, ErrorData::EndOfInput)
+  }
+
+  /// Returns the span of the error.
+  #[inline]
+  pub const fn span(&self) -> Span {
+    self.span
+  }
+
+  /// Returns the data of the error.
+  #[inline]
+  pub const fn data(&self) -> &ErrorData<S, T, Char, Exp, StateError> {
+    &self.data
+  }
+
+  /// Returns a mutable reference to the data of the error.
+  #[inline]
+  pub const fn data_mut(&mut self) -> &mut ErrorData<S, T, Char, Exp, StateError> {
+    &mut self.data
+  }
+
+  /// Consumes the error and returns its data.
+  #[inline]
+  pub fn into_data(self) -> ErrorData<S, T, Char, Exp, StateError> {
+    self.data
+  }
+}
+
+type DefaultErrorsContainer<S, T, Char = char, Exp = Expectation, StateError = ()> =
+  std::vec::Vec<Error<S, T, Char, Exp, StateError>>;
+
+/// A container for storing multiple parser errors.
+#[derive(Debug, Clone, From, Into, Deref, DerefMut, AsMut, AsRef)]
+pub struct Errors<S, T, Char = char, Exp = Expectation, StateError = ()>(
+  DefaultErrorsContainer<S, T, Char, Exp, StateError>,
+);
+
+impl<S, T, Char, Exp, StateError> Default for Errors<S, T, Char, Exp, StateError> {
+  #[inline(always)]
+  fn default() -> Self {
+    Self(DefaultErrorsContainer::default())
+  }
+}
+
+impl<S, T, Exp, Char, StateError> From<Error<S, T, Char, Exp, StateError>>
+  for Errors<S, T, Char, Exp, StateError>
+{
+  #[inline(always)]
+  fn from(error: Error<S, T, Char, Exp, StateError>) -> Self {
+    Self(core::iter::once(error).collect())
+  }
+}
+
+impl<S, T, Char, Exp, StateError> Errors<S, T, Char, Exp, StateError> {
+  /// Creates a new empty errors container with the given capacity.
+  #[inline]
+  pub fn with_capacity(capacity: usize) -> Self {
+    Self(DefaultErrorsContainer::with_capacity(capacity))
+  }
+}
+
+impl<S, T, Char, Exp, StateError> IntoIterator for Errors<S, T, Char, Exp, StateError> {
+  type Item = Error<S, T, Char, Exp, StateError>;
+  type IntoIter = <DefaultErrorsContainer<S, T, Char, Exp, StateError> as IntoIterator>::IntoIter;
+
+  #[inline(always)]
+  fn into_iter(self) -> Self::IntoIter {
+    self.0.into_iter()
+  }
+}
+
+impl<S, T, Char, Exp, StateError> Extend<Error<S, T, Char, Exp, StateError>>
+  for Errors<S, T, Char, Exp, StateError>
+{
+  #[inline(always)]
+  fn extend<I: IntoIterator<Item = Error<S, T, Char, Exp, StateError>>>(&mut self, iter: I) {
+    self.0.extend(iter);
+  }
+}
+
+/// The GraphQL dialect error, keyed to the source slice `S` and the concrete
+/// GraphQL syntactic token.
+pub type GraphqlError<S> = Error<S, SyntacticToken<S>, char, Expectation>;
+
+/// The GraphQL dialect error container — the error type a
+/// [`ParseCtx`](crate::combinator::ParseCtx) over a GraphQL lexer emits.
+pub type GraphqlErrors<S> = Errors<S, SyntacticToken<S>, char, Expectation>;
+
+// ---- `From` glue -----------------------------------------------------------
+//
+// The atoms bound `ErrorOf: From<…>` over tokora's generic error families; each
+// conversion below lands the dialect side. Kinds and the `Lang` marker stay
+// generic so the bound is satisfied for `Lang = GraphQL` (and any other marker a
+// production pins); the found token and slice are the dialect's concrete types.
+// Diagnostics-carrying families (missing separator/element, full container, too
+// few, lexer errors) map to `Other` exactly as the frozen glue did — these are
+// emitter paths a `Vec` container and a fail-fast context rarely reach.
+
+impl<'a, S, Kind: Clone, Lang: ?Sized>
+  From<TokUnexpectedToken<'a, SyntacticToken<S>, Kind, Span, Lang>> for GraphqlErrors<S>
+{
+  #[inline]
+  fn from(err: TokUnexpectedToken<'a, SyntacticToken<S>, Kind, Span, Lang>) -> Self {
+    let (span, found, _expected) = err.into_components();
+    match found {
+      Some(token) => GraphqlError::unexpected_token(token, Expectation::Name, span).into(),
+      None => GraphqlError::unexpected_end_of_input(span).into(),
+    }
+  }
+}
+
+impl<'a, S, Kind: Clone, Lang: ?Sized> From<SeparatedError<'a, SyntacticToken<S>, Kind, Span, Lang>>
+  for GraphqlErrors<S>
+{
+  #[inline]
+  fn from(err: SeparatedError<'a, SyntacticToken<S>, Kind, Span, Lang>) -> Self {
+    Self::from(err.into_inner())
+  }
+}
+
+impl<S, Kind: Clone, Lang: ?Sized> From<MissingToken<'_, Kind, usize, Lang>> for GraphqlErrors<S> {
+  #[inline]
+  fn from(err: MissingToken<'_, Kind, usize, Lang>) -> Self {
+    let off = err.offset();
+    GraphqlError::new(
+      Span::new(off, off),
+      ErrorData::Other(std::borrow::Cow::Borrowed("missing token")),
+    )
+    .into()
+  }
+}
+
+impl<S, Lang: ?Sized> From<MissingSyntax<usize, Lang>> for GraphqlErrors<S> {
+  #[inline]
+  fn from(err: MissingSyntax<usize, Lang>) -> Self {
+    let off = err.offset();
+    GraphqlError::new(
+      Span::new(off, off),
+      ErrorData::Other(std::borrow::Cow::Borrowed("missing element")),
+    )
+    .into()
+  }
+}
+
+impl<S, Lang: ?Sized> From<FullContainer<Span, Lang>> for GraphqlErrors<S> {
+  #[inline]
+  fn from(err: FullContainer<Span, Lang>) -> Self {
+    GraphqlError::new(
+      *err.span(),
+      ErrorData::Other(std::borrow::Cow::Borrowed("container full")),
+    )
+    .into()
+  }
+}
+
+impl<S, Lang: ?Sized> From<TooFew<Span, Lang>> for GraphqlErrors<S> {
+  #[inline]
+  fn from(err: TooFew<Span, Lang>) -> Self {
+    GraphqlError::new(
+      err.span(),
+      ErrorData::Other(std::borrow::Cow::Borrowed("too few elements")),
+    )
+    .into()
+  }
+}
+
+impl<S, Lang: ?Sized> From<UnexpectedEot<usize, Lang>> for GraphqlErrors<S> {
+  #[inline]
+  fn from(err: UnexpectedEot<usize, Lang>) -> Self {
+    let off = err.offset();
+    GraphqlError::unexpected_end_of_input(Span::new(off, off)).into()
+  }
+}
+
+impl<S, Char, StateError> From<LexerErrors<Char, StateError>> for GraphqlErrors<S> {
+  #[inline]
+  fn from(_err: LexerErrors<Char, StateError>) -> Self {
+    GraphqlError::new(
+      Span::new(0, 0),
+      ErrorData::Other(std::borrow::Cow::Borrowed("lexer error")),
+    )
+    .into()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use smear_lexer::graphql::syntactic::SyntacticLexer;
+  use tokora::{FatalContext, Lexer, ParseCtx};
+
+  use super::{GraphQL, GraphqlErrors};
+
+  fn assert_parse_ctx<'inp, L, Ctx>()
+  where
+    L: Lexer<'inp>,
+    Ctx: ParseCtx<'inp, L, GraphQL>,
+  {
+  }
+
+  #[test]
+  fn graphql_error_is_parse_ctx_over_str_and_slice() {
+    // `Fatal<GraphqlErrors<slice>>` is a complete `ParseCtx` over both source
+    // representations — the whole point of the `From` glue above.
+    assert_parse_ctx::<
+      SyntacticLexer<'_, str>,
+      FatalContext<'_, SyntacticLexer<'_, str>, GraphqlErrors<&str>, GraphQL>,
+    >();
+    assert_parse_ctx::<
+      SyntacticLexer<'_, [u8]>,
+      FatalContext<'_, SyntacticLexer<'_, [u8]>, GraphqlErrors<&[u8]>, GraphQL>,
+    >();
+  }
+}

--- a/smear-parser-next/src/graphql/keyword.rs
+++ b/smear-parser-next/src/graphql/keyword.rs
@@ -1,0 +1,37 @@
+//! Typed keyword atoms for the GraphQL dialect.
+//!
+//! Each keyword the grammar names gets a committed/declining atom pair through
+//! [`typed_keyword_atom!`](crate::typed_keyword_atom), which maps the matched
+//! keyword onto its typed node. Every GraphQL keyword is soft/contextual — the
+//! dialect has no strict keywords, so `ident` still accepts these spellings — and
+//! these atoms only match a keyword *where a production asks for it*: the committed
+//! form errors on anything else, the `try_` form declines without consuming.
+//!
+//! The typed nodes ([`On`], [`Query`], …) are the lexer's keyword vocabulary
+//! (`smear_lexer::keywords`), re-exported here so the productions and their AST
+//! node types can name them; the atoms feed each its matched span through the
+//! node's `new` constructor.
+
+pub use smear_lexer::keywords::{
+  Directive, Enum, Extend, Fragment, Implements, Input, Interface, Mutation, On, Query, Repeatable,
+  Scalar, Schema, Subscription, Type, Union,
+};
+
+crate::typed_keyword_atom!(
+  query / try_query => "query" => Query,
+  mutation / try_mutation => "mutation" => Mutation,
+  subscription / try_subscription => "subscription" => Subscription,
+  fragment / try_fragment => "fragment" => Fragment,
+  on / try_on => "on" => On,
+  schema / try_schema => "schema" => Schema,
+  extend / try_extend => "extend" => Extend,
+  scalar / try_scalar => "scalar" => Scalar,
+  r#type / try_type => "type" => Type,
+  interface / try_interface => "interface" => Interface,
+  union / try_union => "union" => Union,
+  r#enum / try_enum => "enum" => Enum,
+  input / try_input => "input" => Input,
+  directive / try_directive => "directive" => Directive,
+  implements / try_implements => "implements" => Implements,
+  repeatable / try_repeatable => "repeatable" => Repeatable,
+);

--- a/smear-parser-next/src/graphql/kinds.rs
+++ b/smear-parser-next/src/graphql/kinds.rs
@@ -20,7 +20,7 @@
 ///
 /// Discriminants are the declaration index (default `#[repr(u16)]` numbering), so
 /// [`raw`](Self::raw) is a plain cast and the space round-trips through a
-/// declaration-order array — the property [`kind_decl_index_is_stable`] pins.
+/// declaration-order array — the property `kind_decl_index_is_stable` pins.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u16)]
 pub enum SyntaxKind {

--- a/smear-parser-next/src/graphql/kinds.rs
+++ b/smear-parser-next/src/graphql/kinds.rs
@@ -1,0 +1,364 @@
+//! The GraphQL dialect's unified [`SyntaxKind`] space.
+//!
+//! One `#[repr(u16)]` enum holds every kind the lossless CST can carry: the token
+//! *images* committed tokens enter the tree as, the node kinds the assemblies open
+//! with [`node`](tokora::parser::node), and the `Root`/`Error`/`Gap` bookkeeping
+//! kinds the sink needs. One enum, one space — a token kind and a node kind can
+//! never collide (tokora guide `ch16_lossless_cst.md`).
+//!
+//! A kind is a plain `u16` ([`SyntaxKind::raw`]); it is *data*, not a lexer type,
+//! so naming one here breaks no Lego rule. Assemblies open nodes with their own
+//! `K::X.raw()`; atoms never open nodes. The tail (lossless) waves add
+//! `rowan::Language` and the token mapper over this same space, so no shipped
+//! production is re-touched — the space is declared complete now.
+//!
+//! The tombstone value `u16::MAX` is reserved crate-wide by tokora; nothing here
+//! maps to it (default discriminants keep every kind far below it).
+
+/// The unified GraphQL syntax-kind space: token images, node kinds, and the
+/// `Root`/`Error`/`Gap` bookkeeping kinds, in one `#[repr(u16)]` enum.
+///
+/// Discriminants are the declaration index (default `#[repr(u16)]` numbering), so
+/// [`raw`](Self::raw) is a plain cast and the space round-trips through a
+/// declaration-order array — the property [`kind_decl_index_is_stable`] pins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u16)]
+pub enum SyntaxKind {
+  // ---- Token images (committed tokens enter the tree through the mapper) ----
+  /// A `Name` token (identifier).
+  Name,
+  /// An integer literal token.
+  Int,
+  /// A float literal token.
+  Float,
+  /// An inline (single-line) string literal token.
+  String,
+  /// A block (triple-quoted) string literal token.
+  BlockString,
+  /// A `$` token.
+  Dollar,
+  /// A `(` token.
+  LParen,
+  /// A `)` token.
+  RParen,
+  /// A `...` token.
+  Spread,
+  /// A `:` token.
+  Colon,
+  /// A `=` token.
+  Equal,
+  /// An `@` token.
+  At,
+  /// A `[` token.
+  LBracket,
+  /// A `]` token.
+  RBracket,
+  /// A `{` token.
+  LBrace,
+  /// A `}` token.
+  RBrace,
+  /// A `|` token.
+  Pipe,
+  /// A `!` token.
+  Bang,
+  /// An `&` token.
+  Ampersand,
+
+  // ---- Trivia token images (surfaced only by the lossless lexer) ----
+  /// A run of space characters.
+  Space,
+  /// A run of tab characters.
+  Tab,
+  /// A line terminator.
+  Newline,
+  /// A `,` (insignificant comma).
+  Comma,
+  /// A `#` comment.
+  Comment,
+  /// A byte-order mark.
+  Bom,
+
+  // ---- Value node kinds (Wave 1) ----
+  /// A `Variable` value (`$name`).
+  Variable,
+  /// An `IntValue`.
+  IntValue,
+  /// A `FloatValue`.
+  FloatValue,
+  /// A `StringValue`.
+  StringValue,
+  /// A `BooleanValue`.
+  BooleanValue,
+  /// A `NullValue`.
+  NullValue,
+  /// An `EnumValue`.
+  EnumValue,
+  /// A `ListValue`.
+  ListValue,
+  /// An `ObjectValue`.
+  ObjectValue,
+  /// An `ObjectField` inside an object value.
+  ObjectField,
+  /// A `DefaultValue` (`= const-value`).
+  DefaultValue,
+
+  // ---- Type / argument / directive node kinds (Wave 2) ----
+  /// A `NamedType`.
+  NamedType,
+  /// A `ListType` (`[T]`).
+  ListType,
+  /// A `NonNullType` (`T!`).
+  NonNullType,
+  /// An `Argument`.
+  Argument,
+  /// An `Arguments` list (`( … )`).
+  Arguments,
+  /// A `Directive` (`@name`).
+  Directive,
+  /// A `Directives` list.
+  Directives,
+
+  // ---- Selection / executable node kinds (Wave 3) ----
+  /// A field `Alias` (`name :`).
+  Alias,
+  /// A `Field`.
+  Field,
+  /// A `SelectionSet` (`{ … }`).
+  SelectionSet,
+  /// A `FragmentSpread` (`... name`).
+  FragmentSpread,
+  /// An `InlineFragment` (`... on T { … }`).
+  InlineFragment,
+  /// A `VariableDefinition`.
+  VariableDefinition,
+  /// A `VariablesDefinition` list (`( … )`).
+  VariablesDefinition,
+  /// An `OperationDefinition`.
+  OperationDefinition,
+  /// A `FragmentDefinition`.
+  FragmentDefinition,
+  /// An `ExecutableDocument`.
+  ExecutableDocument,
+
+  // ---- SDL definition node kinds (Wave 4) ----
+  /// A `Description` (leading string literal).
+  Description,
+  /// An `InputValueDefinition`.
+  InputValueDefinition,
+  /// An `ArgumentsDefinition` (`( … )`).
+  ArgumentsDefinition,
+  /// A `FieldDefinition`.
+  FieldDefinition,
+  /// A `FieldsDefinition` (`{ … }`).
+  FieldsDefinition,
+  /// An `InputFieldsDefinition` (`{ … }`).
+  InputFieldsDefinition,
+  /// An `ImplementsInterfaces` clause.
+  ImplementsInterfaces,
+  /// A `UnionMemberTypes` clause.
+  UnionMemberTypes,
+  /// A `DirectiveLocations` clause.
+  DirectiveLocations,
+  /// An `EnumValueDefinition`.
+  EnumValueDefinition,
+  /// An `EnumValuesDefinition` (`{ … }`).
+  EnumValuesDefinition,
+  /// An `OperationType` (`query` / `mutation` / `subscription`).
+  OperationType,
+  /// A `RootOperationTypeDefinition`.
+  RootOperationTypeDefinition,
+  /// A `RootOperationTypeDefinitions` block (`{ … }`).
+  RootOperationTypeDefinitions,
+  /// A `ScalarTypeDefinition`.
+  ScalarTypeDefinition,
+  /// An `ObjectTypeDefinition`.
+  ObjectTypeDefinition,
+  /// An `InterfaceTypeDefinition`.
+  InterfaceTypeDefinition,
+  /// A `UnionTypeDefinition`.
+  UnionTypeDefinition,
+  /// An `EnumTypeDefinition`.
+  EnumTypeDefinition,
+  /// An `InputObjectTypeDefinition`.
+  InputObjectTypeDefinition,
+  /// A `DirectiveDefinition`.
+  DirectiveDefinition,
+  /// A `SchemaDefinition`.
+  SchemaDefinition,
+
+  // ---- SDL extension / document node kinds (Wave 5) ----
+  /// A `ScalarTypeExtension`.
+  ScalarTypeExtension,
+  /// An `ObjectTypeExtension`.
+  ObjectTypeExtension,
+  /// An `InterfaceTypeExtension`.
+  InterfaceTypeExtension,
+  /// A `UnionTypeExtension`.
+  UnionTypeExtension,
+  /// An `EnumTypeExtension`.
+  EnumTypeExtension,
+  /// An `InputObjectTypeExtension`.
+  InputObjectTypeExtension,
+  /// A `SchemaExtension`.
+  SchemaExtension,
+  /// A `Document` (mixed executable + type-system).
+  Document,
+  /// A `TypeSystemDocument`.
+  TypeSystemDocument,
+
+  // ---- Bookkeeping (recovery holes, gap tiles, synthetic root) ----
+  /// A recovery hole: a malformed region the sink materializes as an error node.
+  Error,
+  /// A gap tile: a hole record the sink materializes to keep the tree textually
+  /// complete.
+  Gap,
+  /// The synthetic document root.
+  Root,
+}
+
+impl SyntaxKind {
+  /// The raw `u16` the event channel and the sink speak.
+  ///
+  /// A plain cast: `#[repr(u16)]` with default discriminants makes the raw value
+  /// the declaration index.
+  #[inline]
+  pub const fn raw(self) -> u16 {
+    self as u16
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::SyntaxKind as K;
+
+  /// Every kind, in declaration order. `kind_from_raw` (added in the lossless
+  /// wave) indexes this array by raw value, so its order must match the enum's.
+  const KINDS: &[K] = &[
+    // Token images.
+    K::Name,
+    K::Int,
+    K::Float,
+    K::String,
+    K::BlockString,
+    K::Dollar,
+    K::LParen,
+    K::RParen,
+    K::Spread,
+    K::Colon,
+    K::Equal,
+    K::At,
+    K::LBracket,
+    K::RBracket,
+    K::LBrace,
+    K::RBrace,
+    K::Pipe,
+    K::Bang,
+    K::Ampersand,
+    // Trivia.
+    K::Space,
+    K::Tab,
+    K::Newline,
+    K::Comma,
+    K::Comment,
+    K::Bom,
+    // Value nodes.
+    K::Variable,
+    K::IntValue,
+    K::FloatValue,
+    K::StringValue,
+    K::BooleanValue,
+    K::NullValue,
+    K::EnumValue,
+    K::ListValue,
+    K::ObjectValue,
+    K::ObjectField,
+    K::DefaultValue,
+    // Type / argument / directive nodes.
+    K::NamedType,
+    K::ListType,
+    K::NonNullType,
+    K::Argument,
+    K::Arguments,
+    K::Directive,
+    K::Directives,
+    // Selection / executable nodes.
+    K::Alias,
+    K::Field,
+    K::SelectionSet,
+    K::FragmentSpread,
+    K::InlineFragment,
+    K::VariableDefinition,
+    K::VariablesDefinition,
+    K::OperationDefinition,
+    K::FragmentDefinition,
+    K::ExecutableDocument,
+    // SDL definition nodes.
+    K::Description,
+    K::InputValueDefinition,
+    K::ArgumentsDefinition,
+    K::FieldDefinition,
+    K::FieldsDefinition,
+    K::InputFieldsDefinition,
+    K::ImplementsInterfaces,
+    K::UnionMemberTypes,
+    K::DirectiveLocations,
+    K::EnumValueDefinition,
+    K::EnumValuesDefinition,
+    K::OperationType,
+    K::RootOperationTypeDefinition,
+    K::RootOperationTypeDefinitions,
+    K::ScalarTypeDefinition,
+    K::ObjectTypeDefinition,
+    K::InterfaceTypeDefinition,
+    K::UnionTypeDefinition,
+    K::EnumTypeDefinition,
+    K::InputObjectTypeDefinition,
+    K::DirectiveDefinition,
+    K::SchemaDefinition,
+    // SDL extension / document nodes.
+    K::ScalarTypeExtension,
+    K::ObjectTypeExtension,
+    K::InterfaceTypeExtension,
+    K::UnionTypeExtension,
+    K::EnumTypeExtension,
+    K::InputObjectTypeExtension,
+    K::SchemaExtension,
+    K::Document,
+    K::TypeSystemDocument,
+    // Bookkeeping.
+    K::Error,
+    K::Gap,
+    K::Root,
+  ];
+
+  #[test]
+  fn kind_decl_index_is_stable() {
+    // The raw value of each kind is exactly its declaration index, so the
+    // lossless `kind_from_raw` array (this same order) round-trips every kind.
+    for (index, kind) in KINDS.iter().enumerate() {
+      assert_eq!(
+        kind.raw(),
+        index as u16,
+        "declaration index drifted at {kind:?}"
+      );
+    }
+  }
+
+  #[test]
+  fn tombstone_value_is_unused() {
+    // `u16::MAX` is tokora's reserved tombstone; no kind may occupy it.
+    for kind in KINDS {
+      assert_ne!(kind.raw(), u16::MAX, "{kind:?} collides with the tombstone");
+    }
+  }
+
+  #[test]
+  fn bookkeeping_kinds_are_last_and_distinct() {
+    // `Root`/`Error`/`Gap` exist and sit past every content kind, so appending a
+    // content kind before them is caught by `kind_decl_index_is_stable`.
+    let content = KINDS.len() as u16 - 3;
+    assert_eq!(K::Error.raw(), content);
+    assert_eq!(K::Gap.raw(), content + 1);
+    assert_eq!(K::Root.raw(), content + 2);
+  }
+}

--- a/smear-parser-next/src/graphql/mod.rs
+++ b/smear-parser-next/src/graphql/mod.rs
@@ -1,0 +1,40 @@
+//! The GraphQL dialect assembly layer.
+//!
+//! Every GraphQL production is a free fn generic over `L: Lexer<'inp>` — bounded
+//! only by tokora capability traits and the [`ParseCtx`](crate::combinator::ParseCtx)
+//! bundle — with the `Lang` type parameter pinned to the [`GraphQL`] marker and
+//! `Span = SimpleSpan`. Pinning the marker is what lets the same assemblies serve
+//! the syntactic (trivia-skipped) and lossless (trivia-preserving) suites: swap the
+//! lexer and the emitter, nothing else.
+//!
+//! This module carries the dialect substrate the productions build on:
+//!
+//! - [`GraphQL`] — the dialect marker,
+//! - [`kinds`] — the unified `#[repr(u16)]` [`SyntaxKind`](kinds::SyntaxKind) space
+//!   (token kinds, node kinds, and the `Root`/`Error`/`Gap` bookkeeping kinds),
+//! - [`keyword`] — the typed keyword node atoms,
+//! - [`ast`] — the AST node types the productions return,
+//! - [`error`] — the dialect error and the `From` glue that makes it a
+//!   [`ParseCtx`](crate::combinator::ParseCtx) error over every lexer and source,
+//! - [`prelude`] — the generic atom vocabulary, re-exported for productions.
+
+/// The GraphQL dialect marker.
+///
+/// Pins the `Lang` type parameter of every GraphQL production, atom
+/// instantiation, and error type, so one set of free-fn assemblies specializes to
+/// GraphQL over any lexer and source. It is a pure type-level tag — never
+/// constructed, only named in type position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GraphQL;
+
+/// The generic atom vocabulary, re-exported for GraphQL productions.
+///
+/// A production writes `use crate::graphql::prelude::*;` to pull in the combinator
+/// atoms it assembles — the [Lego bricks](crate::combinator) that name only
+/// capability traits, the [`ParseCtx`](crate::combinator::ParseCtx) bundle, and the
+/// slice/error projections, never a concrete lexer. The dialect-specific pieces
+/// ([`GraphQL`], [`kinds`], [`ast`], [`error`]) are named through `super::` at each
+/// production, keeping the marker and the kind space explicit at the use site.
+pub mod prelude {
+  pub use crate::combinator::*;
+}

--- a/smear-parser-next/src/graphql/mod.rs
+++ b/smear-parser-next/src/graphql/mod.rs
@@ -18,6 +18,7 @@
 //!   [`ParseCtx`](crate::combinator::ParseCtx) error over every lexer and source,
 //! - [`prelude`] — the generic atom vocabulary, re-exported for productions.
 
+pub mod keyword;
 pub mod kinds;
 
 /// The GraphQL dialect marker.

--- a/smear-parser-next/src/graphql/mod.rs
+++ b/smear-parser-next/src/graphql/mod.rs
@@ -18,6 +18,7 @@
 //!   [`ParseCtx`](crate::combinator::ParseCtx) error over every lexer and source,
 //! - [`prelude`] — the generic atom vocabulary, re-exported for productions.
 
+pub mod ast;
 pub mod keyword;
 pub mod kinds;
 

--- a/smear-parser-next/src/graphql/mod.rs
+++ b/smear-parser-next/src/graphql/mod.rs
@@ -2,21 +2,21 @@
 //!
 //! Every GraphQL production is a free fn generic over `L: Lexer<'inp>` — bounded
 //! only by tokora capability traits and the [`ParseCtx`](crate::combinator::ParseCtx)
-//! bundle — with the `Lang` type parameter pinned to the [`GraphQL`] marker and
+//! bundle — with the `Lang` type parameter pinned to the `GraphQL` marker and
 //! `Span = SimpleSpan`. Pinning the marker is what lets the same assemblies serve
 //! the syntactic (trivia-skipped) and lossless (trivia-preserving) suites: swap the
 //! lexer and the emitter, nothing else.
 //!
 //! This module carries the dialect substrate the productions build on:
 //!
-//! - [`GraphQL`] — the dialect marker,
-//! - [`kinds`] — the unified `#[repr(u16)]` [`SyntaxKind`](kinds::SyntaxKind) space
-//!   (token kinds, node kinds, and the `Root`/`Error`/`Gap` bookkeeping kinds),
-//! - [`keyword`] — the typed keyword node atoms,
-//! - [`ast`] — the AST node types the productions return,
-//! - [`error`] — the dialect error and the `From` glue that makes it a
+//! - `GraphQL` — the dialect marker,
+//! - `kinds` — the unified `#[repr(u16)]` `SyntaxKind` space (token kinds, node
+//!   kinds, and the `Root`/`Error`/`Gap` bookkeeping kinds),
+//! - `keyword` — the typed keyword node atoms,
+//! - `ast` — the AST node types the productions return,
+//! - `error` — the dialect error and the `From` glue that makes it a
 //!   [`ParseCtx`](crate::combinator::ParseCtx) error over every lexer and source,
-//! - [`prelude`] — the generic atom vocabulary, re-exported for productions.
+//! - `prelude` — the generic atom vocabulary, re-exported for productions.
 
 pub mod ast;
 pub mod error;
@@ -38,7 +38,7 @@ pub struct GraphQL;
 /// atoms it assembles — the [Lego bricks](crate::combinator) that name only
 /// capability traits, the [`ParseCtx`](crate::combinator::ParseCtx) bundle, and the
 /// slice/error projections, never a concrete lexer. The dialect-specific pieces
-/// ([`GraphQL`], [`kinds`], [`ast`], [`error`]) are named through `super::` at each
+/// (`GraphQL`, `kinds`, `ast`, `error`) are named through `super::` at each
 /// production, keeping the marker and the kind space explicit at the use site.
 pub mod prelude {
   pub use crate::combinator::*;

--- a/smear-parser-next/src/graphql/mod.rs
+++ b/smear-parser-next/src/graphql/mod.rs
@@ -19,6 +19,7 @@
 //! - [`prelude`] — the generic atom vocabulary, re-exported for productions.
 
 pub mod ast;
+pub mod error;
 pub mod keyword;
 pub mod kinds;
 

--- a/smear-parser-next/src/graphql/mod.rs
+++ b/smear-parser-next/src/graphql/mod.rs
@@ -18,6 +18,8 @@
 //!   [`ParseCtx`](crate::combinator::ParseCtx) error over every lexer and source,
 //! - [`prelude`] — the generic atom vocabulary, re-exported for productions.
 
+pub mod kinds;
+
 /// The GraphQL dialect marker.
 ///
 /// Pins the `Lang` type parameter of every GraphQL production, atom

--- a/smear-parser-next/src/graphql/mod.rs
+++ b/smear-parser-next/src/graphql/mod.rs
@@ -43,3 +43,6 @@ pub struct GraphQL;
 pub mod prelude {
   pub use crate::combinator::*;
 }
+
+#[cfg(test)]
+mod tests;

--- a/smear-parser-next/src/graphql/tests.rs
+++ b/smear-parser-next/src/graphql/tests.rs
@@ -1,0 +1,77 @@
+//! The GraphQL dialect's matrix test harness and an end-to-end smoke test.
+//!
+//! Mirrors `combinator/tests.rs` — drive a polymorphic parser closure over every
+//! source representation — but binds the real dialect error
+//! ([`GraphqlErrors`](super::error::GraphqlErrors)), so it is the harness the
+//! Wave 1+ production tests reuse. The smoke test drives two atoms
+//! ([`ident`](crate::combinator::ident) and
+//! [`keyword_exact`](crate::combinator::keyword_exact)) end to end through a
+//! `Fatal<GraphqlErrors>` context over both `str` and `[u8]`, proving the
+//! substrate — atoms, the dialect error, and its `From` glue — hangs together.
+//!
+//! The `Lang` marker is `GraphQL` at the type level ([`error`](super::error)'s
+//! `ParseCtx` compile test pins that); the runners here take the default marker
+//! because tokora's `Parser::with_parser*` constructors bind the driving closure's
+//! `ParseInput` at `Lang = ()`. The marker is inert at runtime, so the atoms behave
+//! identically — the entry runner (a later wave) owns marker-pinned driving.
+
+use smear_lexer::graphql::syntactic::SyntacticLexer;
+use tokora::{FatalContext, InputRef, Parse, Parser};
+
+use super::error::GraphqlErrors;
+use crate::combinator::{ident, keyword_exact};
+
+/// The fatal context a `str`-sourced GraphQL parse runs under.
+type StrCtx<'inp> = FatalContext<'inp, SyntacticLexer<'inp, str>, GraphqlErrors<&'inp str>>;
+/// The fatal context a `[u8]`-sourced GraphQL parse runs under.
+type SliceCtx<'inp> = FatalContext<'inp, SyntacticLexer<'inp, [u8]>, GraphqlErrors<&'inp [u8]>>;
+
+/// Drives `f` over a `str` source under `Fatal<GraphqlErrors<&str>>`.
+fn drive_str<'inp, O>(
+  f: impl for<'c> FnMut(
+    &mut InputRef<'inp, 'c, SyntacticLexer<'inp, str>, StrCtx<'inp>>,
+  ) -> Result<O, GraphqlErrors<&'inp str>>,
+  input: &'inp str,
+) -> Result<O, GraphqlErrors<&'inp str>> {
+  Parser::with_parser(f).parse_str(input)
+}
+
+/// Drives `f` over a `[u8]` source under `Fatal<GraphqlErrors<&[u8]>>`.
+fn drive_slice<'inp, O>(
+  f: impl for<'c> FnMut(
+    &mut InputRef<'inp, 'c, SyntacticLexer<'inp, [u8]>, SliceCtx<'inp>>,
+  ) -> Result<O, GraphqlErrors<&'inp [u8]>>,
+  input: &'inp [u8],
+) -> Result<O, GraphqlErrors<&'inp [u8]>> {
+  Parser::with_parser(f).parse_slice(input)
+}
+
+#[test]
+fn ident_commits_over_str_and_slice() {
+  // The `ident` atom drives end to end through the dialect context and yields the
+  // matched source, equal across `str` and `[u8]` modulo the slice type.
+  let out = drive_str(|inp| ident(inp).map(|id| *id.source_ref()), "hello");
+  assert_eq!(out.ok(), Some("hello"));
+
+  let out = drive_slice(|inp| ident(inp).map(|id| *id.source_ref()), b"hello");
+  assert_eq!(out.ok(), Some(&b"hello"[..]));
+}
+
+#[test]
+fn ident_errors_on_a_non_identifier() {
+  // A committed atom on the wrong token produces the real dialect error, not a
+  // panic — the `From<UnexpectedToken>` glue in action.
+  assert!(drive_str(|inp| ident(inp).map(|_| ()), "{").is_err());
+  assert!(drive_slice(|inp| ident(inp).map(|_| ()), b"{").is_err());
+}
+
+#[test]
+fn keyword_exact_commits_and_errors_over_str_and_slice() {
+  // The committed keyword atom matches its spelling …
+  assert!(drive_str(|inp| keyword_exact(inp, "query").map(|_| ()), "query").is_ok());
+  assert!(drive_slice(|inp| keyword_exact(inp, "query").map(|_| ()), b"query").is_ok());
+
+  // … and errors on any other spelling, through the dialect error.
+  assert!(drive_str(|inp| keyword_exact(inp, "query").map(|_| ()), "mutation").is_err());
+  assert!(drive_slice(|inp| keyword_exact(inp, "query").map(|_| ()), b"mutation").is_err());
+}

--- a/smear-parser-next/src/ident.rs
+++ b/smear-parser-next/src/ident.rs
@@ -1,0 +1,219 @@
+//! The [`Ident`] carrier — the identifier node the dialect `Name` types alias.
+//!
+//! Copied type-only from the frozen `smear-parser` crate (`src/ident.rs`): the
+//! span-plus-source identifier every `Name` node is built on, with the span and
+//! source accessors and the `str`/`[u8]` equivalence impls the productions and
+//! tests lean on. The parser atoms yield tokora's own
+//! [`Ident`](tokora::types::Ident); an assembly maps that into this node.
+
+// `new` is the crate-private substrate the Wave 1+ productions mint `Name` nodes
+// with; it has no in-crate caller until those productions land.
+#![allow(dead_code)]
+
+use core::fmt::Display;
+
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    cmp::Equivalent,
+    human_display::DisplayHuman,
+    sdl_display::{DisplayCompact, DisplayPretty},
+  },
+};
+
+/// An identifier.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Ident<V, S = Span> {
+  span: S,
+  value: V,
+}
+
+impl<V, S> Ident<V, S> {
+  /// Creates a new identifier with the given span and value.
+  ///
+  /// The span represents the location of the identifier in the source text,
+  /// and the value is the actual source text.
+  #[inline]
+  pub(crate) const fn new(span: S, value: V) -> Self {
+    Self { span, value }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &S {
+    &self.span
+  }
+
+  /// Returns the underlying source value.
+  #[inline]
+  pub const fn source(&self) -> V
+  where
+    V: Copy,
+  {
+    self.value
+  }
+
+  /// Returns reference of the underlying source value.
+  #[inline(always)]
+  pub const fn source_ref(&self) -> &V {
+    &self.value
+  }
+}
+
+impl<V, S> AsSpan<S> for Ident<V, S> {
+  #[inline]
+  fn as_span(&self) -> &S {
+    self.span()
+  }
+}
+
+impl<V, S> IntoSpan<S> for Ident<V, S> {
+  #[inline]
+  fn into_span(self) -> S {
+    self.span
+  }
+}
+
+impl<V, S> IntoComponents for Ident<V, S> {
+  type Components = (S, V);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.value)
+  }
+}
+
+impl<V, S> Display for Ident<V, S>
+where
+  V: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+impl<V, S> core::ops::Deref for Ident<V, S> {
+  type Target = V;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    self.source_ref()
+  }
+}
+
+impl<V, S> DisplayCompact for Ident<V, S>
+where
+  V: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.value.display().fmt(f)
+  }
+}
+
+impl<V, S> DisplayPretty for Ident<V, S>
+where
+  V: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.value.display().fmt(f)
+  }
+}
+
+impl<V, S> PartialEq<str> for Ident<V, S>
+where
+  str: Equivalent<V>,
+{
+  #[inline]
+  fn eq(&self, other: &str) -> bool {
+    other.equivalent(&self.value)
+  }
+}
+
+impl<V, S> PartialEq<&str> for Ident<V, S>
+where
+  str: Equivalent<V>,
+{
+  #[inline]
+  fn eq(&self, other: &&str) -> bool {
+    other.equivalent(&self.value)
+  }
+}
+
+impl<V, S> PartialEq<Ident<V, S>> for str
+where
+  str: Equivalent<V>,
+{
+  #[inline]
+  fn eq(&self, other: &Ident<V, S>) -> bool {
+    self.equivalent(&other.value)
+  }
+}
+
+impl<V, S> PartialEq<Ident<V, S>> for &str
+where
+  str: Equivalent<V>,
+{
+  #[inline]
+  fn eq(&self, other: &Ident<V, S>) -> bool {
+    self.equivalent(&other.value)
+  }
+}
+
+impl<V, S> PartialEq<[u8]> for Ident<V, S>
+where
+  [u8]: Equivalent<V>,
+{
+  #[inline]
+  fn eq(&self, other: &[u8]) -> bool {
+    other.equivalent(&self.value)
+  }
+}
+
+impl<V, S> PartialEq<Ident<V, S>> for [u8]
+where
+  [u8]: Equivalent<V>,
+{
+  #[inline]
+  fn eq(&self, other: &Ident<V, S>) -> bool {
+    self.equivalent(&other.value)
+  }
+}
+
+impl<V, S> Equivalent<Ident<V, S>> for str
+where
+  str: Equivalent<V>,
+{
+  #[inline]
+  fn equivalent(&self, other: &Ident<V, S>) -> bool {
+    self.equivalent(other.source_ref())
+  }
+}
+
+impl<V, S> Equivalent<Ident<V, S>> for [u8]
+where
+  [u8]: Equivalent<V>,
+{
+  #[inline]
+  fn equivalent(&self, other: &Ident<V, S>) -> bool {
+    self.equivalent(other.source_ref())
+  }
+}
+
+impl<V, S> Equivalent<[u8]> for Ident<V, S>
+where
+  [u8]: Equivalent<V>,
+{
+  #[inline]
+  fn equivalent(&self, other: &[u8]) -> bool {
+    other.equivalent(self.source_ref())
+  }
+}

--- a/smear-parser-next/src/lib.rs
+++ b/smear-parser-next/src/lib.rs
@@ -18,6 +18,15 @@ pub use smear_scaffold as scaffold;
 
 pub mod combinator;
 
+/// The [`Ident`](ident::Ident) carrier the dialect `Name` node types alias.
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
+mod ident;
+
+/// Value-node carriers shared by the dialect ASTs, copied type-only from the
+/// frozen crate.
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
+mod value;
+
 /// The GraphQL dialect: productions, syntax kinds, keyword atoms, AST node types,
 /// and the dialect error, all keyed to the [`GraphQL`](graphql::GraphQL) marker.
 #[cfg(feature = "graphql")]

--- a/smear-parser-next/src/lib.rs
+++ b/smear-parser-next/src/lib.rs
@@ -17,3 +17,8 @@ pub use smear_lexer as lexer;
 pub use smear_scaffold as scaffold;
 
 pub mod combinator;
+
+/// The GraphQL dialect: productions, syntax kinds, keyword atoms, AST node types,
+/// and the dialect error, all keyed to the [`GraphQL`](graphql::GraphQL) marker.
+#[cfg(feature = "graphql")]
+pub mod graphql;

--- a/smear-parser-next/src/value/boolean_value.rs
+++ b/smear-parser-next/src/value/boolean_value.rs
@@ -1,0 +1,100 @@
+use core::fmt::Display;
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    sdl_display::{DisplayCompact, DisplayPretty},
+  },
+};
+
+/// A boolean value literal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BooleanValue {
+  span: Span,
+  value: bool,
+}
+
+impl Display for BooleanValue {
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "{}", self.value())
+  }
+}
+
+impl AsSpan<Span> for BooleanValue {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl IntoSpan<Span> for BooleanValue {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl IntoComponents for BooleanValue {
+  type Components = (Span, bool);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.value)
+  }
+}
+
+impl AsRef<bool> for BooleanValue {
+  #[inline]
+  fn as_ref(&self) -> &bool {
+    &self.value
+  }
+}
+
+impl core::ops::Deref for BooleanValue {
+  type Target = bool;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    &self.value
+  }
+}
+
+impl BooleanValue {
+  /// Creates a new boolean value.
+  #[inline]
+  pub(crate) const fn new(span: Span, value: bool) -> Self {
+    Self { span, value }
+  }
+
+  /// Returns the span of the boolean value.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the boolean value.
+  #[inline]
+  pub const fn value(&self) -> bool {
+    self.value
+  }
+}
+
+impl DisplayCompact for BooleanValue {
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    write!(f, "{}", self.value())
+  }
+}
+
+impl DisplayPretty for BooleanValue {
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    write!(f, "{}", self.value())
+  }
+}

--- a/smear-parser-next/src/value/enum_value.rs
+++ b/smear-parser-next/src/value/enum_value.rs
@@ -1,0 +1,116 @@
+use core::fmt::Display;
+
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    human_display::DisplayHuman,
+    sdl_display::{DisplayCompact, DisplayPretty},
+  },
+};
+
+/// An enum value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EnumValue<S> {
+  source: S,
+  span: Span,
+}
+
+impl<S> Display for EnumValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+impl<S> AsSpan<Span> for EnumValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<S> IntoSpan<Span> for EnumValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<S> IntoComponents for EnumValue<S> {
+  type Components = (Span, S);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.source)
+  }
+}
+
+impl<S> core::ops::Deref for EnumValue<S> {
+  type Target = S;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    self.source_ref()
+  }
+}
+
+impl<S> EnumValue<S> {
+  /// Creates a new enum value.
+  #[inline]
+  pub(crate) const fn new(span: Span, value: S) -> Self {
+    Self {
+      source: value,
+      span,
+    }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the source of the enum value.
+  #[inline]
+  pub const fn source_ref(&self) -> &S {
+    &self.source
+  }
+
+  /// Returns the source of the enum value.
+  #[inline]
+  pub const fn source(&self) -> S
+  where
+    S: Copy,
+  {
+    self.source
+  }
+}
+
+impl<S> DisplayCompact for EnumValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.source_ref().fmt(f)
+  }
+}
+
+impl<S> DisplayPretty for EnumValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.source_ref().fmt(f)
+  }
+}

--- a/smear-parser-next/src/value/float.rs
+++ b/smear-parser-next/src/value/float.rs
@@ -1,0 +1,144 @@
+use core::fmt::Display;
+
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    human_display::DisplayHuman,
+    sdl_display::{DisplayCompact, DisplayPretty},
+    syntax_tree_display::DisplaySyntaxTree,
+  },
+};
+
+/// A floating-point value literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FloatValue<S> {
+  span: Span,
+  value: S,
+}
+
+impl<S> AsSpan<Span> for FloatValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<S> IntoSpan<Span> for FloatValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<S> IntoComponents for FloatValue<S> {
+  type Components = (Span, S);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.value)
+  }
+}
+
+impl<S> Display for FloatValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+impl<S> AsRef<S> for FloatValue<S> {
+  #[inline]
+  fn as_ref(&self) -> &S {
+    self
+  }
+}
+
+impl<S> core::ops::Deref for FloatValue<S> {
+  type Target = S;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    self.source_ref()
+  }
+}
+
+impl<S> FloatValue<S> {
+  /// Creates a new float value.
+  #[inline]
+  pub(crate) const fn new(span: Span, value: S) -> Self {
+    Self { span, value }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the source of the float.
+  #[inline]
+  pub const fn source(&self) -> S
+  where
+    S: Copy,
+  {
+    self.value
+  }
+
+  /// Returns the source of the float.
+  #[inline]
+  pub const fn source_ref(&self) -> &S {
+    &self.value
+  }
+}
+
+impl<S> DisplayCompact for FloatValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.value.fmt(f)
+  }
+}
+
+impl<S> DisplayPretty for FloatValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.value.fmt(f)
+  }
+}
+
+impl<S> DisplaySyntaxTree for FloatValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(
+    &self,
+    level: usize,
+    indent: usize,
+    f: &mut core::fmt::Formatter<'_>,
+  ) -> core::fmt::Result {
+    let padding = level * indent;
+    write!(f, "{:indent$}", "", indent = padding)?;
+    writeln!(
+      f,
+      "- FLOAT@{}..{} \"{}\"",
+      self.span.start(),
+      self.span.end(),
+      self.source_ref().display(),
+    )
+  }
+}

--- a/smear-parser-next/src/value/int.rs
+++ b/smear-parser-next/src/value/int.rs
@@ -1,0 +1,137 @@
+use core::fmt::Display;
+
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    human_display::DisplayHuman,
+    sdl_display::{DisplayCompact, DisplayPretty},
+    syntax_tree_display::DisplaySyntaxTree,
+  },
+};
+
+/// An integer value literal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IntValue<S> {
+  span: Span,
+  value: S,
+}
+
+impl<S> Display for IntValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+impl<S> AsSpan<Span> for IntValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<S> IntoSpan<Span> for IntValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<S> IntoComponents for IntValue<S> {
+  type Components = (Span, S);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.value)
+  }
+}
+
+impl<S> core::ops::Deref for IntValue<S> {
+  type Target = S;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    &self.value
+  }
+}
+
+impl<S> IntValue<S> {
+  /// Creates a new int value.
+  #[inline]
+  pub(crate) const fn new(span: Span, value: S) -> Self {
+    Self { span, value }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the source of the int.
+  #[inline]
+  pub const fn source(&self) -> S
+  where
+    S: Copy,
+  {
+    self.value
+  }
+
+  /// Returns the source of the int.
+  #[inline]
+  pub const fn source_ref(&self) -> &S {
+    &self.value
+  }
+}
+
+impl<S> DisplayCompact for IntValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.value.fmt(f)
+  }
+}
+
+impl<S> DisplayPretty for IntValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.value.fmt(f)
+  }
+}
+
+impl<S> DisplaySyntaxTree for IntValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(
+    &self,
+    level: usize,
+    indent: usize,
+    f: &mut core::fmt::Formatter<'_>,
+  ) -> core::fmt::Result {
+    let padding = level * indent;
+    write!(f, "{:indent$}", "", indent = padding)?;
+    writeln!(
+      f,
+      "- INT@{}..{} \"{}\"",
+      self.span.start(),
+      self.span.end(),
+      self.source_ref().display()
+    )
+  }
+}

--- a/smear-parser-next/src/value/mod.rs
+++ b/smear-parser-next/src/value/mod.rs
@@ -1,0 +1,30 @@
+//! Value-node carriers shared by the dialect ASTs.
+//!
+//! Copied type-only from the frozen `smear-parser` crate (`src/value/`): the
+//! boolean / enum / int / float / string / null / variable value nodes the
+//! dialect input-value enums are built from. Each is generic over the source slice
+//! `S`, keeps its span as [`SimpleSpan`](tokora::SimpleSpan), and exposes only span
+//! and source accessors — the assemblies construct them, the productions and tests
+//! read them.
+
+// The `pub(crate)` `new` constructors are the substrate the Wave 1+ value
+// productions build these nodes with; until those productions land they have no
+// in-crate caller. Kept crate-private (per the frozen crate) so only the parser
+// mints nodes — external users read them out of parse results.
+#![allow(dead_code)]
+
+pub use boolean_value::*;
+pub use enum_value::*;
+pub use float::*;
+pub use int::*;
+pub use null_value::*;
+pub use string::*;
+pub use variable::*;
+
+mod boolean_value;
+mod enum_value;
+mod float;
+mod int;
+mod null_value;
+mod string;
+mod variable;

--- a/smear-parser-next/src/value/null_value.rs
+++ b/smear-parser-next/src/value/null_value.rs
@@ -1,0 +1,116 @@
+use core::fmt::Display;
+
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    human_display::DisplayHuman,
+    sdl_display::{DisplayCompact, DisplayPretty},
+  },
+};
+
+/// A null value literal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NullValue<S> {
+  source: S,
+  span: Span,
+}
+
+impl<S> Display for NullValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+impl<S> AsSpan<Span> for NullValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<S> IntoSpan<Span> for NullValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<S> IntoComponents for NullValue<S> {
+  type Components = (Span, S);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.source)
+  }
+}
+
+impl<S> core::ops::Deref for NullValue<S> {
+  type Target = S;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    self.source_ref()
+  }
+}
+
+impl<S> NullValue<S> {
+  /// Creates a new null value.
+  #[inline]
+  pub(crate) const fn new(span: Span, value: S) -> Self {
+    Self {
+      source: value,
+      span,
+    }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the source of the null value.
+  #[inline]
+  pub const fn source_ref(&self) -> &S {
+    &self.source
+  }
+
+  /// Returns the source of the null value.
+  #[inline]
+  pub const fn source(&self) -> S
+  where
+    S: Copy,
+  {
+    self.source
+  }
+}
+
+impl<S> DisplayCompact for NullValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    self.source_ref().fmt(f)
+  }
+}
+
+impl<S> DisplayPretty for NullValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}

--- a/smear-parser-next/src/value/string.rs
+++ b/smear-parser-next/src/value/string.rs
@@ -1,0 +1,312 @@
+use core::fmt::Display;
+
+use smear_lexer::{LitBlockStr, LitInlineStr, LitStr};
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    human_display::DisplayHuman,
+    sdl_display::{DisplayCompact, DisplayPretty},
+  },
+};
+
+/// A string value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StringValue<S> {
+  span: Span,
+  lit: LitStr<S>,
+}
+
+impl<S: AsRef<str>> AsRef<str> for StringValue<S> {
+  #[inline]
+  fn as_ref(&self) -> &str {
+    self.lit.source_ref().as_ref()
+  }
+}
+
+impl<S: AsRef<[u8]>> AsRef<[u8]> for StringValue<S> {
+  #[inline]
+  fn as_ref(&self) -> &[u8] {
+    self.lit.source_ref().as_ref()
+  }
+}
+
+impl<S> AsSpan<Span> for StringValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<S> IntoSpan<Span> for StringValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<S> IntoComponents for StringValue<S> {
+  type Components = (Span, LitStr<S>);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.lit)
+  }
+}
+
+impl<S> StringValue<S> {
+  /// Creates a new string value.
+  #[inline(always)]
+  pub(crate) const fn new(span: Span, lit: LitStr<S>) -> Self {
+    Self { span, lit }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the underlying source.
+  #[inline(always)]
+  pub const fn source(&self) -> S
+  where
+    S: Copy,
+  {
+    self.lit.source()
+  }
+
+  /// Returns the reference to the underlying source.
+  #[inline(always)]
+  pub const fn source_ref(&self) -> &S {
+    self.lit.source_ref()
+  }
+
+  /// Returns the content of the string.
+  #[inline]
+  pub fn content(&self) -> &str
+  where
+    S: AsRef<str>,
+  {
+    self.lit.source_ref().as_ref().trim_matches('"')
+  }
+}
+
+impl<S> Display for StringValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+/// A inline string value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InlineStringValue<S> {
+  span: Span,
+  lit: LitInlineStr<S>,
+}
+
+impl<S: AsRef<str>> AsRef<str> for InlineStringValue<S> {
+  #[inline]
+  fn as_ref(&self) -> &str {
+    self.lit.source_ref().as_ref()
+  }
+}
+
+impl<S: AsRef<[u8]>> AsRef<[u8]> for InlineStringValue<S> {
+  #[inline]
+  fn as_ref(&self) -> &[u8] {
+    self.lit.source_ref().as_ref()
+  }
+}
+
+impl<S> AsSpan<Span> for InlineStringValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<S> IntoSpan<Span> for InlineStringValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<S> IntoComponents for InlineStringValue<S> {
+  type Components = (Span, LitInlineStr<S>);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.lit)
+  }
+}
+
+impl<S> Display for InlineStringValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+impl<S> InlineStringValue<S> {
+  /// Creates a new inline string value.
+  #[inline(always)]
+  pub(crate) const fn new(span: Span, lit: LitInlineStr<S>) -> Self {
+    Self { span, lit }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the underlying source.
+  #[inline(always)]
+  pub const fn source(&self) -> S
+  where
+    S: Copy,
+  {
+    self.lit.source()
+  }
+
+  /// Returns the reference to the underlying source.
+  #[inline(always)]
+  pub const fn source_ref(&self) -> &S {
+    self.lit.source_ref()
+  }
+
+  /// Returns the content of the inline string.
+  #[inline]
+  pub fn content(&self) -> &str
+  where
+    S: AsRef<str>,
+  {
+    self.lit.source_ref().as_ref().trim_matches('"')
+  }
+}
+
+impl<S> DisplayCompact for InlineStringValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    core::fmt::Display::fmt(&self, f)
+  }
+}
+
+/// A block string value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BlockStringValue<S> {
+  span: Span,
+  lit: LitBlockStr<S>,
+}
+
+impl<S: AsRef<str>> AsRef<str> for BlockStringValue<S> {
+  #[inline]
+  fn as_ref(&self) -> &str {
+    self.lit.source_ref().as_ref()
+  }
+}
+
+impl<S: AsRef<[u8]>> AsRef<[u8]> for BlockStringValue<S> {
+  #[inline]
+  fn as_ref(&self) -> &[u8] {
+    self.lit.source_ref().as_ref()
+  }
+}
+
+impl<S> AsSpan<Span> for BlockStringValue<S> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<S> IntoSpan<Span> for BlockStringValue<S> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<S> IntoComponents for BlockStringValue<S> {
+  type Components = (Span, LitBlockStr<S>);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.lit)
+  }
+}
+
+impl<S> Display for BlockStringValue<S>
+where
+  S: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}
+
+impl<S> BlockStringValue<S> {
+  /// Creates a new block string value.
+  #[inline(always)]
+  pub(crate) const fn new(span: Span, lit: LitBlockStr<S>) -> Self {
+    Self { span, lit }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the underlying source.
+  #[inline(always)]
+  pub const fn source(&self) -> S
+  where
+    S: Copy,
+  {
+    self.lit.source()
+  }
+
+  /// Returns the reference to the underlying source.
+  #[inline(always)]
+  pub const fn source_ref(&self) -> &S {
+    self.lit.source_ref()
+  }
+
+  /// Returns the content of the block string.
+  #[inline]
+  pub fn content(&self) -> &str
+  where
+    S: AsRef<str>,
+  {
+    self.lit.source_ref().as_ref().trim_matches('"')
+  }
+}
+
+impl<S> DisplayPretty for BlockStringValue<S>
+where
+  S: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    DisplayHuman::fmt(self.source_ref(), f)
+  }
+}

--- a/smear-parser-next/src/value/variable.rs
+++ b/smear-parser-next/src/value/variable.rs
@@ -1,0 +1,104 @@
+use core::fmt::Display;
+
+use tokora::{
+  SimpleSpan as Span,
+  span::{AsSpan, IntoSpan},
+  utils::{
+    IntoComponents,
+    human_display::DisplayHuman,
+    sdl_display::{DisplayCompact, DisplayPretty},
+  },
+};
+
+/// A variable value.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VariableValue<Name> {
+  span: Span,
+  name: Name,
+}
+
+impl<Name> AsSpan<Span> for VariableValue<Name> {
+  #[inline]
+  fn as_span(&self) -> &Span {
+    self.span()
+  }
+}
+
+impl<Name> IntoSpan<Span> for VariableValue<Name> {
+  #[inline]
+  fn into_span(self) -> Span {
+    self.span
+  }
+}
+
+impl<Name> IntoComponents for VariableValue<Name> {
+  type Components = (Span, Name);
+
+  #[inline]
+  fn into_components(self) -> Self::Components {
+    (self.span, self.name)
+  }
+}
+
+impl<Name> core::ops::Deref for VariableValue<Name> {
+  type Target = Name;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    self.name()
+  }
+}
+
+impl<Name> Display for VariableValue<Name>
+where
+  Name: DisplayHuman,
+{
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "${}", self.name.display())
+  }
+}
+
+impl<Name> VariableValue<Name> {
+  /// Creates a new variable from the given span and name.
+  #[inline(always)]
+  pub(crate) const fn new(span: Span, name: Name) -> Self {
+    Self { span, name }
+  }
+
+  /// Returns the span of the name.
+  #[inline]
+  pub const fn span(&self) -> &Span {
+    &self.span
+  }
+
+  /// Returns the name as a string slice.
+  #[inline]
+  pub const fn name(&self) -> &Name {
+    &self.name
+  }
+}
+
+impl<Name> DisplayCompact for VariableValue<Name>
+where
+  Name: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    core::fmt::Display::fmt(self, f)
+  }
+}
+
+impl<Name> DisplayPretty for VariableValue<Name>
+where
+  Name: DisplayHuman,
+{
+  type Options = ();
+
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>, _: &Self::Options) -> core::fmt::Result {
+    core::fmt::Display::fmt(self, f)
+  }
+}


### PR DESCRIPTION
Wave 0 lands the GraphQL dialect substrate for the Phase 2S assemblies: (1) the `GraphQL` marker, module wiring, and the atom-re-export prelude; (2) the full `#[repr(u16)] SyntaxKind` space — token/trivia images, every Wave 1–5 node kind, and `Root`/`Error`/`Gap` — with `raw()` and a declaration-index stability test; (3) the 16 typed keyword atoms via one `typed_keyword_atom!` invocation over the lexer's keyword nodes; (4) the AST node types copied type-only from the frozen crate (`Ident`/`Name`, the value carriers, `InputValue`/`ConstInputValue`, `Type`); (5) the dialect error (`GraphqlError`/`GraphqlErrors`) re-keyed to the source slice with the reduced `From` glue tokora 0.3.0's blankets allow, proven by a compile test instantiating `Fatal<GraphqlErrors>` as `ParseCtx` over both `str` and `[u8]` syntactic lexers; and (6) the matrix test harness plus an end-to-end smoke test (`ident` + `keyword_exact` through the dialect context over both sources).

Gates (package-scoped, isolated `CARGO_TARGET_DIR`): `cargo test -p smear-parser-next` = 101 passed (94 pre-existing + 7 new); `cargo +stable fmt --all -- --check` clean; `cargo clippy -p smear-parser-next --all-features --tests -- -D warnings` clean; `RUSTDOCFLAGS="-D warnings" cargo doc -p smear-parser-next --all-features --no-deps` clean.

Wave 0 of the Phase 2S assemblies plan; W1 (values) stacks on this.
