### PR TITLE
refactor(parser): take tokora's callback view, and mint the lossless sink at the door

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize all text files to LF in the working tree, on every platform.
+#
+# Without this, Windows runners check out with core.autocrlf=true, which
+# rewrites LF -> CRLF for text files. That corrupts two things the lexer
+# oracle tests depend on byte-for-byte:
+#   - the committed golden `.txt` files under smear-lexer/tests/oracle/**,
+#     which are compared against an in-memory string built with `\n`;
+#   - the `.graphql`/`.graphqlx` fixtures under smear/tests/fixtures/**,
+#     which are pulled in via `include_str!` at compile time, so CRLF in the
+#     fixture shifts every span the lexer reports.
+#
+# `text=auto` still lets Git detect genuinely binary files and leave them
+# untouched; this repo currently has none.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,10 @@ jobs:
   miri-tb:
     name: miri-tb-${{ matrix.target }}-${{ matrix.cfg }}
     strategy:
+      # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
+      # a cross toolchain (installed below); don't let a failure there
+      # cancel the other, unrelated cells in this matrix.
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -272,6 +276,22 @@ jobs:
             ${{ runner.os }}-miri-
       - name: Install cargo-hack
         run: cargo install cargo-hack
+      - name: Install cross C toolchain for ${{ matrix.target }}
+        # x86_64-unknown-linux-gnu and the macOS targets build with the
+        # runner's native toolchain; only the two Linux cross targets need
+        # an extra package, so install exactly the one each needs.
+        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
+        run: |
+          case "${{ matrix.target }}" in
+            i686-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-multilib
+              ;;
+            powerpc64-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-powerpc64-linux-gnu
+              ;;
+          esac
       - name: Miri
         run: |
           bash ci/miri_tb.sh ${{ matrix.target }} ${{ matrix.cfg }}
@@ -279,6 +299,10 @@ jobs:
   miri-sb:
     name: miri-sb-${{ matrix.target }}-${{ matrix.cfg }}
     strategy:
+      # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
+      # a cross toolchain (installed below); don't let a failure there
+      # cancel the other, unrelated cells in this matrix.
+      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
@@ -318,6 +342,22 @@ jobs:
             ${{ runner.os }}-miri-
       - name: Install cargo-hack
         run: cargo install cargo-hack
+      - name: Install cross C toolchain for ${{ matrix.target }}
+        # x86_64-unknown-linux-gnu and the macOS targets build with the
+        # runner's native toolchain; only the two Linux cross targets need
+        # an extra package, so install exactly the one each needs.
+        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
+        run: |
+          case "${{ matrix.target }}" in
+            i686-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-multilib
+              ;;
+            powerpc64-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-powerpc64-linux-gnu
+              ;;
+          esac
       - name: Miri
         run: |
           bash ci/miri_sb.sh ${{ matrix.target }} ${{ matrix.cfg }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,33 @@ jobs:
 
     - name: Run test
       run: cargo test --all-features -- --quiet
-    
+
+  # Build with exactly the MSRV declared in Cargo.toml's `rust-version`, so
+  # a floor that silently drifts above the declared value is caught here
+  # instead of surfacing as a hard `cargo` failure for users pinned to it.
+  # Every other job runs `rustup update stable`, so without this job the
+  # declared MSRV is never actually exercised by anything.
+  msrv:
+    name: msrv
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Read declared MSRV from Cargo.toml
+      id: msrv
+      run: |
+        version=$(grep -m1 '^rust-version' Cargo.toml | sed -E 's/^rust-version *= *"([^"]+)".*/\1/')
+        if [ -z "$version" ]; then
+          echo "Error: could not read rust-version from Cargo.toml"
+          exit 1
+        fi
+        echo "Declared MSRV: $version"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+    - name: Install Rust ${{ steps.msrv.outputs.version }}
+      run: |
+        rustup toolchain install ${{ steps.msrv.outputs.version }} --profile minimal --no-self-update
+        rustup default ${{ steps.msrv.outputs.version }}
+    - name: cargo build --workspace --all-features
+      run: cargo build --workspace --all-features
 
   miri-tb:
     name: miri-tb-${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     
 
   miri-tb:
-    name: miri-tb-${{ matrix.target }}-${{ matrix.cfg }}
+    name: miri-tb-${{ matrix.target }}
     strategy:
       # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
       # a cross toolchain (installed below); don't let a failure there
@@ -247,8 +247,6 @@ jobs:
           - powerpc64-unknown-linux-gnu
           - x86_64-apple-darwin
           - aarch64-apple-darwin
-        cfg:
-          - all_tests
         # Exclude invalid combinations
         exclude:
           - os: ubuntu-latest
@@ -294,10 +292,10 @@ jobs:
           esac
       - name: Miri
         run: |
-          bash ci/miri_tb.sh ${{ matrix.target }} ${{ matrix.cfg }}
+          bash ci/miri_tb.sh ${{ matrix.target }}
 
   miri-sb:
-    name: miri-sb-${{ matrix.target }}-${{ matrix.cfg }}
+    name: miri-sb-${{ matrix.target }}
     strategy:
       # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
       # a cross toolchain (installed below); don't let a failure there
@@ -313,8 +311,6 @@ jobs:
           - powerpc64-unknown-linux-gnu
           - x86_64-apple-darwin
           - aarch64-apple-darwin
-        cfg:
-          - all_tests
         # Exclude invalid combinations
         exclude:
           - os: ubuntu-latest
@@ -360,7 +356,7 @@ jobs:
           esac
       - name: Miri
         run: |
-          bash ci/miri_sb.sh ${{ matrix.target }} ${{ matrix.cfg }}
+          bash ci/miri_sb.sh ${{ matrix.target }}
   coverage:
     name: coverage
     runs-on: ubuntu-latest
@@ -393,8 +389,6 @@ jobs:
           key: ${{ runner.os }}-coverage-cargo-build-target
       - name: Run tarpaulin
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "--cfg all_tests"
         with:
           command: tarpaulin
           args: --no-default-features --features graphql --run-types tests --run-types doctests --workspace --out xml -- --quiet

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 repository = "https://github.com/al8n/smear"
 homepage = "https://github.com/al8n/smear"
 license = "Apache-2.0 OR MIT"
-rust-version = "1.89"
+rust-version = "1.95"
 
 [workspace.dependencies]
 bstr = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ smear-parser = { path = "smear-parser", version = "0.0.0", default-features = fa
 rust_2018_idioms = "warn"
 single_use_lifetimes = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(all_tests)',
   'cfg(tarpaulin)',
   # Testing / coverage helpers. These are set via `RUSTFLAGS='--cfg ...'`
   # in CI to force the dispatcher down a specific path so lower‑tier

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,3 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(smear_lexer_disable_avx2)',
 ] }
 
-[patch.crates-io]
-tokora = { path = "../tokit/tokora" }

--- a/ci/miri_sb.sh
+++ b/ci/miri_sb.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
 set -e
 
-# Check if TARGET and CONFIG_FLAGS are provided, otherwise panic
+# Check if TARGET is provided, otherwise panic
 if [ -z "$1" ]; then
   echo "Error: TARGET is not provided"
   exit 1
 fi
 
-if [ -z "$2" ]; then
-  echo "Error: CONFIG_FLAGS are not provided"
-  exit 1
-fi
-
 TARGET=$1
-CONFIG_FLAGS=$2
 
 rustup toolchain install nightly --component miri
 rustup override set nightly
@@ -33,6 +27,5 @@ if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
 fi
 
 export MIRIFLAGS
-export RUSTFLAGS="--cfg test_$CONFIG_FLAGS"
 
 cargo miri test --tests --target $TARGET --lib

--- a/ci/miri_sb.sh
+++ b/ci/miri_sb.sh
@@ -19,7 +19,20 @@ rustup toolchain install nightly --component miri
 rustup override set nightly
 cargo miri setup
 
-export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-alignment-check"
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-alignment-check"
+
+# 32-bit targets simulate a 4 GiB address space, and Miri does not
+# aggressively reuse freed addresses by default; a long allocation-heavy
+# test binary can exhaust it cumulatively ("no more free addresses in the
+# address space"). i686-unknown-linux-gnu is the only 32-bit target in the
+# CI matrix. Raising the reuse rate is a known lever for this, but whether
+# it is *sufficient* to avoid exhaustion for this suite is unproven until a
+# CI run confirms it.
+if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
+  MIRIFLAGS="$MIRIFLAGS -Zmiri-address-reuse-rate=1.0"
+fi
+
+export MIRIFLAGS
 export RUSTFLAGS="--cfg test_$CONFIG_FLAGS"
 
 cargo miri test --tests --target $TARGET --lib

--- a/ci/miri_tb.sh
+++ b/ci/miri_tb.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
 set -e
 
-# Check if TARGET and CONFIG_FLAGS are provided, otherwise panic
+# Check if TARGET is provided, otherwise panic
 if [ -z "$1" ]; then
   echo "Error: TARGET is not provided"
   exit 1
 fi
 
-if [ -z "$2" ]; then
-  echo "Error: CONFIG_FLAGS are not provided"
-  exit 1
-fi
-
 TARGET=$1
-CONFIG_FLAGS=$2
 
 rustup toolchain install nightly --component miri
 rustup override set nightly
@@ -33,7 +27,6 @@ if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
 fi
 
 export MIRIFLAGS
-export RUSTFLAGS="--cfg test_$CONFIG_FLAGS"
 
 cargo miri test --tests --target $TARGET --lib
 

--- a/ci/miri_tb.sh
+++ b/ci/miri_tb.sh
@@ -19,7 +19,20 @@ rustup toolchain install nightly --component miri
 rustup override set nightly
 cargo miri setup
 
-export MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-alignment-check -Zmiri-tree-borrows"
+MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-alignment-check -Zmiri-tree-borrows"
+
+# 32-bit targets simulate a 4 GiB address space, and Miri does not
+# aggressively reuse freed addresses by default; a long allocation-heavy
+# test binary can exhaust it cumulatively ("no more free addresses in the
+# address space"). i686-unknown-linux-gnu is the only 32-bit target in the
+# CI matrix. Raising the reuse rate is a known lever for this, but whether
+# it is *sufficient* to avoid exhaustion for this suite is unproven until a
+# CI run confirms it.
+if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
+  MIRIFLAGS="$MIRIFLAGS -Zmiri-address-reuse-rate=1.0"
+fi
+
+export MIRIFLAGS
 export RUSTFLAGS="--cfg test_$CONFIG_FLAGS"
 
 cargo miri test --tests --target $TARGET --lib

--- a/smear-lexer/src/string_lexer/block/mod.rs
+++ b/smear-lexer/src/string_lexer/block/mod.rs
@@ -3,11 +3,11 @@ use std::{borrow::Cow, string::String};
 use derive_more::{From, IsVariant, TryUnwrap, Unwrap};
 use tokora::utils::human_display::DisplayHuman;
 
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
+pub(crate) use self::u8_slice::skip_block_str_from_bytes;
 pub(crate) use self::{
   str::{BlockStringToken, lex_block_str_from_str},
-  u8_slice::{
-    BlockStringToken as BytesBlockStringToken, lex_block_str_from_bytes, skip_block_str_from_bytes,
-  },
+  u8_slice::{BlockStringToken as BytesBlockStringToken, lex_block_str_from_bytes},
 };
 
 mod str;

--- a/smear-lexer/src/string_lexer/block/u8_slice.rs
+++ b/smear-lexer/src/string_lexer/block/u8_slice.rs
@@ -157,6 +157,7 @@ where
 /// An unterminated body returns the bytes scanned plus the error; the SIMD
 /// lexer discards both and delegates the whole token to Logos rather than
 /// constructing a source-typed error on the fast path.
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 #[inline]
 pub(crate) fn skip_block_str_from_bytes(
   src: &[u8],

--- a/smear-lexer/src/string_lexer/inline/mod.rs
+++ b/smear-lexer/src/string_lexer/inline/mod.rs
@@ -7,12 +7,14 @@ use tokora::utils::{
 use super::LitPlainStr;
 use std::{borrow::Cow, string::String};
 
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
+pub(crate) use self::simd::skip_inline_str_simd;
 pub(crate) use self::{
-  simd::skip_inline_str_simd,
   str::{StringToken, lex_inline_str_from_str},
   u8_slice::{StringToken as BytesStringToken, lex_inline_str_from_bytes},
 };
 
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 mod simd;
 mod str;
 mod u8_slice;

--- a/smear-lexer/src/string_lexer/mod.rs
+++ b/smear-lexer/src/string_lexer/mod.rs
@@ -9,8 +9,10 @@ use tokora::{
 
 use crate::error::{StringError, StringErrors};
 
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 pub(crate) use block::skip_block_str_from_bytes;
 pub use block::{LitBlockStr, LitComplexBlockStr};
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 pub(crate) use inline::skip_inline_str_simd;
 pub use inline::{LitComplexInlineStr, LitInlineStr};
 
@@ -361,6 +363,7 @@ impl<'de: 'a, 'a> TryFrom<&'de [u8]> for LitStr<&'a [u8]> {
 
 /// Panic message for the (statically unreachable) case where a string the SIMD
 /// fast path routed to error delegation turns out to lex cleanly.
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 const VALID_STRING_UNREACHABLE: &str =
   "SIMD string fast path emits every valid string literal; only errors reach delegation";
 
@@ -385,6 +388,7 @@ const VALID_STRING_UNREACHABLE: &str =
 /// Only ever invoked on the error path: the SIMD fast path emits every *valid*
 /// string itself, so the delegated `lex_*` here always returns `Err` (hence the
 /// [`VALID_STRING_UNREACHABLE`] `expect_err`).
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 pub(crate) trait DelegateStringError {
   /// The `StringErrors` character type this primitive lexes into: `char` for
   /// `str`, `u8` for `[u8]` — matching the SIMD lexer's own `Slice::Char`.
@@ -402,6 +406,7 @@ pub(crate) trait DelegateStringError {
   ) -> (StringErrors<Self::Char>, usize);
 }
 
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 impl DelegateStringError for str {
   type Char = char;
 
@@ -423,6 +428,7 @@ impl DelegateStringError for str {
   }
 }
 
+#[cfg(any(feature = "graphql", feature = "graphqlx"))]
 impl DelegateStringError for [u8] {
   type Char = u8;
 
@@ -444,7 +450,7 @@ impl DelegateStringError for [u8] {
   }
 }
 
-#[cfg(feature = "bytes")]
+#[cfg(all(feature = "bytes", any(feature = "graphql", feature = "graphqlx")))]
 const _: () = {
   use bytes::Bytes;
 
@@ -458,7 +464,7 @@ const _: () = {
   }
 };
 
-#[cfg(feature = "hipstr")]
+#[cfg(all(feature = "hipstr", any(feature = "graphql", feature = "graphqlx")))]
 const _: () = {
   use hipstr::{HipByt, HipStr};
 
@@ -486,7 +492,7 @@ const _: () = {
   }
 };
 
-#[cfg(feature = "bstr")]
+#[cfg(all(feature = "bstr", any(feature = "graphql", feature = "graphqlx")))]
 const _: () = {
   use bstr::BStr;
 

--- a/smear-parser/src/graphql/lossless/document.rs
+++ b/smear-parser/src/graphql/lossless/document.rs
@@ -61,7 +61,7 @@
 //!   nesting-aware region and reports it once.
 
 use smear_lexer::graphql::{ContextualKeyword, lossless::LosslessTokenKind as Kind};
-use tokora::{ParseInput as _, cst::event::EventMark, emitter::CstEmitter as _};
+use tokora::{ParseInput as _, cst::event::EventMark};
 
 use crate::graphql::kinds::SyntaxKind as K;
 
@@ -312,7 +312,7 @@ lossless_production! {
     // its answer — and because a production whose node placement depends on a caller's internals
     // is one refactor away from being wrong.
     let head = peek_kind::<Src, Ctx>(inp)?;
-    let mark = inp.emitter().cst_mark();
+    let mark = inp.cst_mark();
     let described = starts_description(head);
     if described {
       description::<Src, Ctx>(inp)?;
@@ -348,7 +348,7 @@ lossless_production! {
   /// `TypeSystemDocument` and a `Document`.
   fn type_system_definition_or_extension<'inp, Src, Ctx>(inp) {
     let head = peek_kind::<Src, Ctx>(inp)?;
-    let mark = inp.emitter().cst_mark();
+    let mark = inp.cst_mark();
     let described = starts_description(head);
     if described {
       description::<Src, Ctx>(inp)?;

--- a/smear-parser/src/graphql/lossless/executable.rs
+++ b/smear-parser/src/graphql/lossless/executable.rs
@@ -41,7 +41,7 @@
 //!   call site.
 
 use smear_lexer::graphql::{ContextualKeyword, lossless::LosslessTokenKind as Kind};
-use tokora::{ParseInput as _, cst::event::EventMark, emitter::CstEmitter as _};
+use tokora::{ParseInput as _, cst::event::EventMark};
 
 use crate::graphql::kinds::SyntaxKind as K;
 
@@ -208,7 +208,7 @@ lossless_production! {
     // The head peek first — see `document::definition` for the ruling and for the measurement
     // that shows the ordering is currently redundant, every caller being a loop that peeks.
     let head = peek_kind::<Src, Ctx>(inp)?;
-    let mark = inp.emitter().cst_mark();
+    let mark = inp.cst_mark();
     if starts_description(head) {
       description::<Src, Ctx>(inp)?;
     }

--- a/smear-parser/src/graphql/lossless/mod.rs
+++ b/smear-parser/src/graphql/lossless/mod.rs
@@ -396,7 +396,7 @@ macro_rules! lossless_drivers {
     $(#[$modmeta])*
     #[doc(hidden)]
     pub mod $modname {
-      use ::tokora::{InputRef, Parse as _, cache::DefaultCache, cst::Sink};
+      use ::tokora::{InputRef, cache::DefaultCache, cst::parse_lossless};
 
       #[allow(unused_imports)]
       use $crate::graphql::lossless::value::Constness;
@@ -410,12 +410,15 @@ macro_rules! lossless_drivers {
       };
 
       /// The context pair and the input each driver's closure receives.
-      type TestCtx<'inp, 'sink> = (
-        &'sink mut LosslessSink<'inp>,
+      ///
+      /// The sink is held **by value**: `parse_lossless` mints it from the source itself and
+      /// owns it for the parse, so there is no `&mut Sink` for a driver to hand around.
+      type TestCtx<'inp> = (
+        LosslessSink<'inp>,
         DefaultCache<'inp, GraphqlLosslessLexer<'inp, str>>,
       );
-      type TestInput<'inp, 'input, 'sink> =
-        InputRef<'inp, 'input, GraphqlLosslessLexer<'inp, str>, TestCtx<'inp, 'sink>, GraphQL>;
+      type TestInput<'inp, 'input> =
+        InputRef<'inp, 'input, GraphqlLosslessLexer<'inp, str>, TestCtx<'inp>, GraphQL>;
 
       $(
         $(#[$meta])*
@@ -424,29 +427,29 @@ macro_rules! lossless_drivers {
         pub fn $name<'inp>(src: &'inp str) -> Parse {
           // The `'inp` is **named**, threaded from `src`, for the reason `trivia`'s driver
           // records: elided, it varies independently of the error type and the closure `E0521`s.
-          let mut sink: LosslessSink<'inp> =
-            Sink::new(src, LosslessEmitter::default(), profile::<str>());
-
-          let _out = ::tokora::Parser::with_context::<GraphqlLosslessLexer<'_, str>, (), _>((
-            &mut sink,
+          //
+          // `Lang` is `parse_lossless`'s SECOND parameter and is used only in bounds, so it is
+          // turbofished alongside the lexer or inference settles it on `()`.
+          let (cst, _out) = parse_lossless::<GraphqlLosslessLexer<'inp, str>, GraphQL, _, _, _, _>(
+            src,
+            Default::default(),
+            LosslessEmitter::default(),
+            profile::<str>(),
             DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),
-          ))
-          .apply::<_, GraphQL>(|inp: &mut TestInput<'inp, '_, '_>| {
-            // Minted before the call, not inside the argument list: `inp` is already borrowed
-            // mutably as the first argument, so `inp.emitter()` in the second would be a second
-            // mutable borrow of the same value.
-            $(let $mark = ::tokora::emitter::CstEmitter::cst_mark(
-              ::tokora::InputRef::emitter(inp),
-            );)?
-            // `::<str, _>`: `Src` is not inferable from the input type, and `str` is the
-            // parameter that matches `L::Source`.
-            let out = super::$production::<str, _>(inp $(, $mark)? $($(, $extra)+)?);
-            inp.skip_while(|_| true)?;
-            out
-          })
-          .parse_str(src);
+            |inp: &mut TestInput<'inp, '_>| {
+              // Minted before the call, not inside the argument list: `inp` is already borrowed
+              // mutably as the first argument, so a second `inp` method call in the second would
+              // be a second mutable borrow of the same value.
+              $(let $mark = inp.cst_mark();)?
+              // `::<str, _>`: `Src` is not inferable from the input type, and `str` is the
+              // parameter that matches `L::Source`.
+              let out = super::$production::<str, _>(inp $(, $mark)? $($(, $extra)+)?);
+              inp.skip_while(|_| true)?;
+              out
+            },
+          );
 
-          finish_root(sink)
+          finish_root(cst)
         }
       )*
     }

--- a/smear-parser/src/graphql/lossless/recover.rs
+++ b/smear-parser/src/graphql/lossless/recover.rs
@@ -36,8 +36,8 @@
 
 use smear_lexer::graphql::{ContextualKeyword, lossless::LosslessTokenKind as Kind};
 use tokora::{
-  Emitter as _, SimpleSpan,
-  emitter::{CstEmitter as _, FromUnclosed},
+  SimpleSpan,
+  emitter::FromUnclosed,
   error::{UnclosedBrace, UnclosedBracket, UnclosedParen, UnexpectedEot, token::UnexpectedToken},
   input::Balance,
   span::Spanned,
@@ -340,7 +340,7 @@ lossless_production! {
       GraphqlLosslessLexer<'inp, Src>,
       GraphQL,
     >>::from_unclosed(UnclosedBracket::<SimpleSpan, GraphQL>::bracket_of(open));
-    inp.emitter().emit_error(Spanned::new(open, err))?;
+    inp.emit_error(Spanned::new(open, err))?;
     Ok(())
   }
 
@@ -352,7 +352,7 @@ lossless_production! {
       GraphqlLosslessLexer<'inp, Src>,
       GraphQL,
     >>::from_unclosed(UnclosedBrace::<SimpleSpan, GraphQL>::brace_of(open));
-    inp.emitter().emit_error(Spanned::new(open, err))?;
+    inp.emit_error(Spanned::new(open, err))?;
     Ok(())
   }
 
@@ -366,7 +366,7 @@ lossless_production! {
       GraphqlLosslessLexer<'inp, Src>,
       GraphQL,
     >>::from_unclosed(UnclosedParen::<SimpleSpan, GraphQL>::paren_of(open));
-    inp.emitter().emit_error(Spanned::new(open, err))?;
+    inp.emit_error(Spanned::new(open, err))?;
     Ok(())
   }
 
@@ -401,13 +401,13 @@ lossless_production! {
         let span = found.span;
         let err = UnexpectedToken::<_, _, _, GraphQL>::expected_one_of(span, expected)
           .with_found(found.data);
-        inp.emitter().emit_error(Spanned::new(span, err.into()))?;
+        inp.emit_error(Spanned::new(span, err.into()))?;
       }
       None => {
         let end = inp.span().end();
         let span = SimpleSpan::new(end, end);
         let err = UnexpectedEot::<usize, GraphQL>::eot_of(end);
-        inp.emitter().emit_error(Spanned::new(span, err.into()))?;
+        inp.emit_error(Spanned::new(span, err.into()))?;
       }
     }
     Ok(())
@@ -449,10 +449,10 @@ lossless_production! {
       return Ok(());
     }
 
-    let mark = inp.emitter().cst_mark();
+    let mark = inp.cst_mark();
     if inp.try_expect(|_| true)?.is_some() {
-      inp.emitter().cst_start_at(mark, K::Error.raw());
-      inp.emitter().cst_finish(K::Error.raw());
+      inp.cst_start_at(mark, K::Error.raw());
+      inp.cst_finish(K::Error.raw());
     }
     Ok(())
   }
@@ -511,10 +511,10 @@ lossless_production! {
       return Ok(());
     }
 
-    let mark = inp.emitter().cst_mark();
+    let mark = inp.cst_mark();
     if inp.try_expect(|_| true)?.is_some() {
-      inp.emitter().cst_start_at(mark, K::Error.raw());
-      inp.emitter().cst_finish(K::Error.raw());
+      inp.cst_start_at(mark, K::Error.raw());
+      inp.cst_finish(K::Error.raw());
     }
     Ok(())
   }

--- a/smear-parser/src/graphql/lossless/runner.rs
+++ b/smear-parser/src/graphql/lossless/runner.rs
@@ -3,12 +3,9 @@
 
 use tokora::{
   Source,
-  cst::{CstProfile, KindValidator, Sink},
+  cst::{Cst, CstProfile, KindValidator, Sink, parse_lossless},
   emitter::Severity,
 };
-// `parse_str` lives on tokora's `Parse` trait, whose name this module already uses for its own
-// result type — imported anonymously so the trait is in scope without shadowing it.
-use tokora::Parse as _;
 
 use super::{GraphqlLosslessLexer, GraphqlLosslessSlice, GraphqlLosslessToken, SyntaxNode};
 use crate::graphql::kinds::SyntaxKind as K;
@@ -54,17 +51,25 @@ pub(crate) type LosslessEmitter<'inp> = tokora::emitter::Verbose<
 >;
 
 /// The `Sink` every lossless driver records into.
+///
+/// Named only as the emitter half of a driver's **context pair** — `Sink::new` is tokora-private,
+/// so the one way to mint one is [`parse_lossless`], which takes the source once and uses that
+/// same argument for the sink and the input.
 pub(crate) type LosslessSink<'inp> =
   Sink<'inp, GraphqlLosslessLexer<'inp, str>, LosslessEmitter<'inp>>;
 
-/// Materialize `sink` at the root kind and collect its diagnostics.
+/// The spent sink [`parse_lossless`] hands back — the one door to materialization.
+pub(crate) type LosslessCst<'inp> =
+  Cst<'inp, GraphqlLosslessLexer<'inp, str>, LosslessEmitter<'inp>>;
+
+/// Materialize `cst` at the root kind and collect its diagnostics.
 ///
 /// Shared by [`parse_str`] and by the per-production drivers under `test_support`, so the
 /// root kind, the fallible-materialization contract and the diagnostic projection are stated
 /// once. `finish` names the root kind — it is NOT profile data — and hands back the inner
 /// emitter, which is where the diagnostics live.
-pub(crate) fn finish_root(sink: LosslessSink<'_>) -> Parse {
-  let (green, emitter) = sink.finish(K::Root.raw());
+pub(crate) fn finish_root(cst: LosslessCst<'_>) -> Parse {
+  let (green, emitter) = cst.finish(K::Root.raw());
   let green = green.expect("the GraphQL lossless sink emitted a malformed event stream");
 
   // `Verbose` exposes `diagnostics()` and nothing else — there is no `errors()` and no
@@ -155,34 +160,35 @@ impl Parse {
 
 /// Parse a `&str` as a GraphQL document, losslessly.
 pub fn parse_str(src: &str) -> Parse {
-  // Sink::new takes the source at construction rather than at finish, which removes the one
-  // way a caller could hand materialization a different buffer than the spans were measured
-  // against. Argument order is (source, inner emitter, profile) — the emitter is SECOND.
-  let mut sink: LosslessSink<'_> = Sink::new(src, LosslessEmitter::default(), profile::<str>());
-
-  // Productions take `&mut InputRef`, never `&mut Sink`. The sink reaches them as the emitter
-  // half of the parse context: `(&mut sink, cache)` is a `ParseContext`, and `Parser` drives it.
+  // `parse_lossless` is the only door that mints a `Sink`: it takes the source ONCE and uses
+  // that one argument for both the sink and the input, so the buffer the tree's text comes from
+  // and the buffer the parse reads cannot be two different buffers. Argument order is
+  // (source, lexer state, inner emitter, profile, cache, parser).
   //
-  // `Lang` needs the turbofish. `apply`'s signature uses it only in bounds — the returned
-  // `Parser<F, L, O, Ctx>` does not carry it, and `Ctx: ParseContext<'inp, L, Lang>` holds for
-  // every `Lang` — so nothing forces it to `GraphQL` and inference silently settles on `()`,
-  // which then fails to match this production's branded `InputRef`.
+  // `Lang` needs the turbofish. The driver's signature uses it only in bounds — nothing in the
+  // argument list carries it, and `Ctx: ParseContext<'inp, L, Lang>` holds for every `Lang` —
+  // so inference silently settles on `()`, which then fails to match this production's branded
+  // `InputRef`. The lexer is spelled alongside it because `Lang` is the SECOND parameter.
   //
   // `Src` needs its own turbofish for a second reason: `str` and `&str` both project
   // `Slice<'inp> = &'inp str`, so the lexer type alone leaves the production's source parameter
   // genuinely ambiguous. `str` is the one that matches `parse_str`'s `L::Source = str`.
-  let _out = tokora::Parser::with_context((
-    &mut sink,
-    tokora::cache::DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),
-  ))
+  //
   // `document_entry`, not `document`: the driver's result is discarded below, so an `Err` that
   // escaped the document production would leave the rest of the source uncommitted and
   // `finish` would refuse it as an `UncoveredGap`. The entry drains what an escape left behind,
   // which turns the one failure mode `parse_str` cannot report into a reportable parse.
-  .apply::<_, crate::graphql::GraphQL>(super::document::document_entry::<str, _>)
-  .parse_str(src);
+  let (cst, _out) =
+    parse_lossless::<GraphqlLosslessLexer<'_, str>, crate::graphql::GraphQL, _, _, _, _>(
+      src,
+      Default::default(),
+      LosslessEmitter::default(),
+      profile::<str>(),
+      tokora::cache::DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),
+      super::document::document_entry::<str, _>,
+    );
 
-  finish_root(sink)
+  finish_root(cst)
 }
 
 /// Test-only scaffolding for probing the sink's own kind-validator door.
@@ -197,19 +203,20 @@ pub fn parse_str(src: &str) -> Parse {
 /// validator under test is the one every parse actually runs.
 #[doc(hidden)]
 pub mod test_support {
-  use tokora::{InputRef, Parse as _, cache::DefaultCache, emitter::CstEmitter as _};
+  use tokora::{InputRef, cache::DefaultCache};
 
   use super::{
-    GraphqlLosslessLexer, LosslessEmitter, LosslessSink, Parse, Sink, finish_root, profile,
+    GraphqlLosslessLexer, LosslessEmitter, LosslessSink, Parse, finish_root, parse_lossless,
+    profile,
   };
   use crate::graphql::GraphQL;
 
-  type TestCtx<'inp, 'sink> = (
-    &'sink mut LosslessSink<'inp>,
+  type TestCtx<'inp> = (
+    LosslessSink<'inp>,
     DefaultCache<'inp, GraphqlLosslessLexer<'inp, str>>,
   );
-  type TestInput<'inp, 'input, 'sink> =
-    InputRef<'inp, 'input, GraphqlLosslessLexer<'inp, str>, TestCtx<'inp, 'sink>, GraphQL>;
+  type TestInput<'inp, 'input> =
+    InputRef<'inp, 'input, GraphqlLosslessLexer<'inp, str>, TestCtx<'inp>, GraphQL>;
 
   /// Opens a node at `kind` over `src` and materializes.
   ///
@@ -218,8 +225,8 @@ pub mod test_support {
   /// (`tokora/src/parser/node.rs`'s own `wrap`) — with `kind` standing in for a production's.
   /// `'inp` is named and threaded from `src`, not elided, for the reason `trivia.rs`'s driver
   /// and `lossless_drivers!` both record: a closure's parameter type is spelled out explicitly
-  /// (see [`TestInput`]), and an elided lifetime there is free to be inferred shorter than
-  /// `sink`'s, which the borrow checker then refuses. Nothing else in the crate calls this; it
+  /// (see [`TestInput`]), and an elided lifetime there is free to be inferred shorter than the
+  /// source's, which the borrow checker then refuses. Nothing else in the crate calls this; it
   /// exists for `tests/lossless_runner.rs`'s validator-discrimination test, which always passes
   /// `""` — the node this probes wraps zero tokens either way.
   ///
@@ -232,24 +239,24 @@ pub mod test_support {
   /// [`KindValidator::accept_all`](tokora::cst::KindValidator::accept_all), so it would not
   /// discriminate the real validator from a permissive one.
   ///
-  /// [`cst_mark`]: tokora::emitter::CstEmitter::cst_mark
-  /// [`cst_start_at`]: tokora::emitter::CstEmitter::cst_start_at
-  /// [`cst_finish`]: tokora::emitter::CstEmitter::cst_finish
+  /// [`cst_mark`]: tokora::InputRef::cst_mark
+  /// [`cst_start_at`]: tokora::InputRef::cst_start_at
+  /// [`cst_finish`]: tokora::InputRef::cst_finish
   pub fn open_raw_kind<'inp>(src: &'inp str, kind: u16) -> Parse {
-    let mut sink: LosslessSink<'inp> = Sink::new(src, LosslessEmitter::default(), profile::<str>());
-
-    let _out = tokora::Parser::with_context::<GraphqlLosslessLexer<'_, str>, (), _>((
-      &mut sink,
+    let (cst, _out) = parse_lossless::<GraphqlLosslessLexer<'inp, str>, GraphQL, _, _, _, _>(
+      src,
+      Default::default(),
+      LosslessEmitter::default(),
+      profile::<str>(),
       DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),
-    ))
-    .apply::<_, GraphQL>(|inp: &mut TestInput<'inp, '_, '_>| {
-      let mark = inp.emitter().cst_mark();
-      inp.emitter().cst_start_at(mark, kind);
-      inp.emitter().cst_finish(kind);
-      inp.skip_while(|_| true)
-    })
-    .parse_str(src);
+      |inp: &mut TestInput<'inp, '_>| {
+        let mark = inp.cst_mark();
+        inp.cst_start_at(mark, kind);
+        inp.cst_finish(kind);
+        inp.skip_while(|_| true)
+      },
+    );
 
-    finish_root(sink)
+    finish_root(cst)
   }
 }

--- a/smear-parser/src/graphql/lossless/selection.rs
+++ b/smear-parser/src/graphql/lossless/selection.rs
@@ -59,9 +59,7 @@
 //!   list value, for the same reasons.
 
 use smear_lexer::graphql::{ContextualKeyword, lossless::LosslessTokenKind as Kind};
-use tokora::{
-  ParseInput as _, TryParseInput as _, emitter::CstEmitter as _, try_parse_input::ParseAttempt,
-};
+use tokora::{ParseInput as _, TryParseInput as _, try_parse_input::ParseAttempt};
 
 use crate::graphql::kinds::SyntaxKind as K;
 
@@ -120,7 +118,7 @@ lossless_production! {
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {
         // An inert mark — one buffer slot, promising nothing. Unspent, it materializes into
         // nothing, which is precisely what a field with no alias needs.
-        let mark = inp.emitter().cst_mark();
+        let mark = inp.cst_mark();
         expect::<Src, Ctx>(inp, Kind::Identifier)?;
         // `node_at(mark, kind, parser)` takes THREE args: it wraps a parser rather than being
         // a bare wrap instruction, and `try_eat` is the declining probe that decides whether
@@ -166,7 +164,7 @@ lossless_production! {
   /// enclosing selection set rather than being wrapped in a node that claims a tail it does not
   /// have.
   fn spread_selection<'inp, Src, Ctx>(inp) {
-    let mark = inp.emitter().cst_mark();
+    let mark = inp.cst_mark();
     expect::<Src, Ctx>(inp, Kind::Spread)?;
     match peek_kind::<Src, Ctx>(inp)? {
       // A name — and only its spelling separates the two shapes.

--- a/smear-parser/src/graphql/lossless/trivia.rs
+++ b/smear-parser/src/graphql/lossless/trivia.rs
@@ -61,7 +61,7 @@
 //! discipline, for a placement this suite does not want.
 
 use tokora::{
-  Emitter as _, Lexer, SimpleSpan, Source, Token,
+  Lexer, SimpleSpan, Source, Token,
   error::{UnexpectedEot, token::UnexpectedToken},
   lexer::FromLogos,
   span::Spanned,
@@ -265,7 +265,7 @@ where
       // Emit first, then return the same diagnostic as the `Err`. Built twice rather than
       // cloned: see [`expectation_failure`].
       let reported = expectation_failure::<Src, Ctx>(inp, kind)?;
-      inp.emitter().emit_error(reported)?;
+      inp.emit_error(reported)?;
       Err(expectation_failure::<Src, Ctx>(inp, kind)?.data)
     }
   }
@@ -349,10 +349,10 @@ pub mod test_support {
   };
 
   use tokora::{
-    InputRef, Parse as _, SimpleSpan,
+    InputRef, SimpleSpan,
     cache::DefaultCache,
-    cst::Sink,
-    emitter::{CstEmitter as _, Verbose},
+    cst::{Sink, parse_lossless},
+    emitter::Verbose,
   };
 
   use crate::graphql::{GraphQL, kinds::SyntaxKind as K};
@@ -371,12 +371,12 @@ pub mod test_support {
   /// hits this: it applies a named function whose own signature pins both.
   type Emitter<'inp> = Verbose<GraphqlLosslessErrors<&'inp str>, SimpleSpan, GraphQL>;
   type TestSink<'inp> = Sink<'inp, GraphqlLosslessLexer<'inp, str>, Emitter<'inp>>;
-  type TestCtx<'inp, 'sink> = (
-    &'sink mut TestSink<'inp>,
+  type TestCtx<'inp> = (
+    TestSink<'inp>,
     DefaultCache<'inp, GraphqlLosslessLexer<'inp, str>>,
   );
-  type TestInput<'inp, 'input, 'sink> =
-    InputRef<'inp, 'input, GraphqlLosslessLexer<'inp, str>, TestCtx<'inp, 'sink>, GraphQL>;
+  type TestInput<'inp, 'input> =
+    InputRef<'inp, 'input, GraphqlLosslessLexer<'inp, str>, TestCtx<'inp>, GraphQL>;
 
   /// Runs one atom over `src` inside a `Document` node, drains whatever the atom left, and
   /// materializes.
@@ -396,27 +396,27 @@ pub mod test_support {
       let src: &$lt str = $src;
       let out = Cell::new($init);
 
-      let mut sink: TestSink<$lt> = Sink::new(src, Emitter::default(), profile::<str>());
-
-      let _ = tokora::Parser::with_context::<GraphqlLosslessLexer<'_, str>, (), _>((
-        &mut sink,
+      let (cst, _) = parse_lossless::<GraphqlLosslessLexer<$lt, str>, GraphQL, _, _, _, _>(
+        src,
+        Default::default(),
+        Emitter::default(),
+        profile::<str>(),
         DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),
-      ))
-      .apply::<_, GraphQL>(|$inp: &mut TestInput<$lt, '_, '_>| {
-        // The `node` combinator's own `mark` / `start_at` / `finish`, spelled out. The
-        // combinator wants an inner parser whose error type is pinned, and a closure whose
-        // body is `Ok(())` pins nothing — so the wrap is driven directly instead of teaching
-        // the test scaffold's inference about a type it never names.
-        let mark = $inp.emitter().cst_mark();
-        out.set($atom);
-        $inp.emitter().cst_start_at(mark, K::Document.raw());
-        $inp.emitter().cst_finish(K::Document.raw());
-        // Whatever the atom left behind, so `finish` has full coverage.
-        $inp.skip_while(|_| true)
-      })
-      .parse_str(src);
+        |$inp: &mut TestInput<$lt, '_>| {
+          // The `node` combinator's own `mark` / `start_at` / `finish`, spelled out. The
+          // combinator wants an inner parser whose error type is pinned, and a closure whose
+          // body is `Ok(())` pins nothing — so the wrap is driven directly instead of teaching
+          // the test scaffold's inference about a type it never names.
+          let mark = $inp.cst_mark();
+          out.set($atom);
+          $inp.cst_start_at(mark, K::Document.raw());
+          $inp.cst_finish(K::Document.raw());
+          // Whatever the atom left behind, so `finish` has full coverage.
+          $inp.skip_while(|_| true)
+        },
+      );
 
-      let (green, _emitter) = sink.finish(K::Root.raw());
+      let (green, _emitter) = cst.finish(K::Root.raw());
       let root = SyntaxNode::new_root(
         green.expect("the trivia-atom driver emitted a malformed event stream"),
       );

--- a/smear-parser/src/graphql/lossless/ty.rs
+++ b/smear-parser/src/graphql/lossless/ty.rs
@@ -38,7 +38,7 @@
 //!   malformed type should cost its own node, not the rest of the file.
 
 use smear_lexer::graphql::lossless::LosslessTokenKind as Kind;
-use tokora::{ParseInput as _, TryParseInput as _, emitter::CstEmitter as _};
+use tokora::{ParseInput as _, TryParseInput as _};
 
 use crate::graphql::kinds::SyntaxKind as K;
 
@@ -133,10 +133,10 @@ lossless_production! {
     // The head peek first, so the leading trivia it crosses is committed BEFORE the mark and
     // therefore lands outside any wrap this call makes.
     let head = peek_kind::<Src, Ctx>(inp)?;
-    // `cst_mark` is on the EMITTER, not on the input, and is reached through `InputRef::emitter`.
-    // An inert mark: one buffer slot, promising nothing; an unspent one materializes into
-    // nothing.
-    let mark = inp.emitter().cst_mark();
+    // `cst_mark` is the emitter's operation, reached through the handle's own forwarder — the
+    // emitter itself is not handed out. An inert mark: one buffer slot, promising nothing; an
+    // unspent one materializes into nothing.
+    let mark = inp.cst_mark();
     match head {
       Some(Kind::LBracket) => list_type::<Src, Ctx>(inp)?,
       Some(Kind::Identifier) => named_type::<Src, Ctx>(inp)?,

--- a/smear-parser/src/graphql/syntactic/argument/mod.rs
+++ b/smear-parser/src/graphql/syntactic/argument/mod.rs
@@ -9,7 +9,7 @@
 use std::vec::Vec;
 
 use tokora::{
-  Accumulator, Lexer, ParseInput, SimpleSpan, Slice, Source, TryParseInput,
+  Accumulator, EmitterView, Lexer, ParseInput, SimpleSpan, Slice, Source, TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
   span::Spanned,
@@ -159,7 +159,7 @@ argument_parser!(
 
 fn decide_argument_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -177,7 +177,7 @@ where
 
 fn decide_arguments_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/definition/arguments.rs
+++ b/smear-parser/src/graphql/syntactic/definition/arguments.rs
@@ -4,7 +4,7 @@ use super::*;
 
 fn decide_paren_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -22,7 +22,7 @@ where
 
 fn decide_lparen_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/definition/directive.rs
+++ b/smear-parser/src/graphql/syntactic/definition/directive.rs
@@ -74,7 +74,7 @@ fn is_location_keyword(keyword: ContextualKeyword) -> bool {
 
 fn decide_directive_location_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/definition/document.rs
+++ b/smear-parser/src/graphql/syntactic/definition/document.rs
@@ -274,7 +274,7 @@ definition_parser!(
 
 fn decide_type_system_definition_or_extension_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/definition/mod.rs
+++ b/smear-parser/src/graphql/syntactic/definition/mod.rs
@@ -9,7 +9,8 @@ use std::vec::Vec;
 
 use smear_lexer::graphql::{ContextualKeyword, syntactic::SyntacticTokenKind};
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, TryParseInput,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source,
+  TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
   punct::Pipe,

--- a/smear-parser/src/graphql/syntactic/definition/support.rs
+++ b/smear-parser/src/graphql/syntactic/definition/support.rs
@@ -165,7 +165,7 @@ where
 
 pub(super) fn decide_brace_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -183,7 +183,7 @@ where
 
 pub(super) fn decide_lbrace_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -201,7 +201,7 @@ where
 /// Continues a union-member tail only at an explicit `|` separator.
 pub(super) fn decide_pipe_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -219,7 +219,7 @@ where
 /// Continues an implemented-interface tail only at an explicit `&` separator.
 pub(super) fn decide_ampersand_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/document.rs
+++ b/smear-parser/src/graphql/syntactic/document.rs
@@ -14,7 +14,8 @@ use smear_lexer::{
   keywords::{Fragment, Mutation, Query, Subscription},
 };
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, TryParseInput,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source,
+  TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
   span::{AsSpan, Spanned},
@@ -371,7 +372,7 @@ document_parser!(
 /// owns committed head diagnostics, while end of input closes the document.
 fn decide_definition_or_extension_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/executable/mod.rs
+++ b/smear-parser/src/graphql/syntactic/executable/mod.rs
@@ -15,7 +15,7 @@ use smear_lexer::{
   keywords::{Fragment, Mutation, Query, Subscription},
 };
 use tokora::{
-  Accumulator, Branch, Lexer, ParseChoice, ParseInput, SimpleSpan, Slice, Source,
+  Accumulator, Branch, EmitterView, Lexer, ParseChoice, ParseInput, SimpleSpan, Slice, Source,
   cache::{Peeked, PeekedTokenExt},
   error::{UnexpectedEot, token::UnexpectedToken},
   parser::{Action, parens},
@@ -441,7 +441,7 @@ where
 
 fn decide_variable_definition_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -742,7 +742,7 @@ executable_parser!(
 
 fn decide_executable_definition_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/selection/mod.rs
+++ b/smear-parser/src/graphql/syntactic/selection/mod.rs
@@ -13,8 +13,8 @@ use smear_lexer::{
   keywords::On,
 };
 use tokora::{
-  Accumulator, Branch, Lexer, ParseChoice, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source,
-  TryParseInput,
+  Accumulator, Branch, EmitterView, Lexer, ParseChoice, ParseInput, ParseTokenChoice, SimpleSpan,
+  Slice, Source, TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
   span::Spanned,
@@ -515,7 +515,7 @@ selection_parser!(
 /// delimited repetition probes `}` before consulting this decision.
 fn decide_selection_set_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -534,7 +534,7 @@ where
 /// present, leaving every other token for the caller.
 fn decide_selection_set_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphql/syntactic/value/mod.rs
+++ b/smear-parser/src/graphql/syntactic/value/mod.rs
@@ -18,7 +18,8 @@
 
 use std::vec::Vec;
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, TryParseInput,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source,
+  TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   error::{UnexpectedEot, token::UnexpectedToken},
   parser::Action,
@@ -579,7 +580,7 @@ where
 
 pub(crate) fn decide_value_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -597,7 +598,7 @@ where
 
 pub(crate) fn decide_object_field_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>,
 ) -> Result<Action, GraphqlError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -1062,7 +1063,7 @@ value_parser!(
   {
     committed_default_value
       .peek_then_try::<_, U1>(
-        |mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>, _: &mut Ctx::Emitter| -> Result<
+        |mut peeked: Peeked<'_, 'inp, GraphqlLexer<'inp, Src>, U1>, _: EmitterView<'_, 'inp, GraphqlLexer<'inp, Src>, Ctx::Emitter, GraphQL>| -> Result<
           Action,
           GraphqlError<'inp, Src, Ctx>,
         > {

--- a/smear-parser/src/graphqlx/syntactic/argument/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/argument/mod.rs
@@ -11,7 +11,7 @@
 use std::vec::Vec;
 
 use tokora::{
-  Accumulator, Lexer, ParseInput, SimpleSpan, Slice, Source, Token,
+  Accumulator, EmitterView, Lexer, ParseInput, SimpleSpan, Slice, Source, Token,
   cache::{Peeked, PeekedTokenExt},
   parser::{Action, try_parens},
   span::Spanned,
@@ -139,7 +139,7 @@ argument_parser!(
 
 fn decide_argument_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/definition/arguments.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/arguments.rs
@@ -4,7 +4,7 @@ use super::*;
 
 fn decide_paren_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -22,7 +22,7 @@ where
 
 fn decide_lparen_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/definition/document.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/document.rs
@@ -314,7 +314,7 @@ where
 
 fn decide_document_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/definition/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/mod.rs
@@ -9,7 +9,7 @@ use std::vec::Vec;
 
 use smear_lexer::graphqlx::{ContextualKeyword, syntactic::SyntacticTokenKind};
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
   TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,

--- a/smear-parser/src/graphqlx/syntactic/definition/support.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/support.rs
@@ -132,7 +132,7 @@ where
 
 pub(super) fn decide_brace_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -150,7 +150,7 @@ where
 
 pub(super) fn decide_lbrace_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -168,7 +168,7 @@ where
 /// Continues a union-member or directive-location tail only at an explicit `|`.
 pub(super) fn decide_pipe_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -186,7 +186,7 @@ where
 /// Continues an implemented-interface tail only at an explicit `&`.
 pub(super) fn decide_ampersand_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/document.rs
+++ b/smear-parser/src/graphqlx/syntactic/document.rs
@@ -9,7 +9,8 @@ use std::vec::Vec;
 
 use smear_lexer::graphqlx::{ContextualKeyword, syntactic::SyntacticTokenKind};
 use tokora::{
-  Accumulator, Branch, Lexer, ParseChoice, ParseInput, SimpleSpan, Slice, Source, Token,
+  Accumulator, Branch, EmitterView, Lexer, ParseChoice, ParseInput, SimpleSpan, Slice, Source,
+  Token,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
   span::Spanned,
@@ -295,7 +296,7 @@ document_parser!(
 
 fn decide_document_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/executable/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/executable/mod.rs
@@ -9,8 +9,8 @@ use std::vec::Vec;
 
 use smear_lexer::graphqlx::{ContextualKeyword, syntactic::SyntacticTokenKind};
 use tokora::{
-  Accumulator, Branch, Lexer, ParseChoice, ParseInput, SimpleSpan, Slice, Source, Token,
-  TryParseInput,
+  Accumulator, Branch, EmitterView, Lexer, ParseChoice, ParseInput, SimpleSpan, Slice, Source,
+  Token, TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
   punct::{Colon, Dollar},
@@ -355,7 +355,7 @@ executable_parser!(
 
 fn decide_variable_definition_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -375,7 +375,7 @@ where
 /// is present, leaving every other token for the caller.
 fn decide_variables_definition_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -763,7 +763,7 @@ executable_parser!(
 
 fn decide_executable_document_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/generic/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/generic/mod.rs
@@ -9,7 +9,7 @@
 use std::vec::Vec;
 
 use tokora::{
-  Accumulator, Lexer, ParseInput, SimpleSpan, Slice, Source, Token, TryParseInput,
+  Accumulator, EmitterView, Lexer, ParseInput, SimpleSpan, Slice, Source, Token, TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
   span::Spanned,
@@ -121,7 +121,7 @@ where
 
 fn decide_angle_member<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -139,7 +139,7 @@ where
 
 fn decide_langle_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -156,7 +156,7 @@ where
 
 fn decide_ampersand_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -455,7 +455,7 @@ where
 
 fn decide_where_predicate_tail<'inp, Src, Ctx>(
   peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U2>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/import.rs
+++ b/smear-parser/src/graphqlx/syntactic/import.rs
@@ -6,7 +6,7 @@
 
 use std::vec::Vec;
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
   TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
@@ -215,7 +215,7 @@ import_parser!(
 
 fn decide_import_member<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -233,7 +233,7 @@ where
 
 fn decide_import_list_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/selection/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/selection/mod.rs
@@ -8,7 +8,7 @@ use std::vec::Vec;
 
 use smear_lexer::graphqlx::{ContextualKeyword, syntactic::SyntacticTokenKind};
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
   TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
@@ -585,7 +585,7 @@ selection_parser!(
 /// repetition probes `}` before consulting this decision.
 fn decide_selection_set_tail<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -604,7 +604,7 @@ where
 /// present, leaving every other token for the caller.
 fn decide_selection_set_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/ty.rs
+++ b/smear-parser/src/graphqlx/syntactic/ty.rs
@@ -8,7 +8,7 @@
 
 use std::{boxed::Box, vec::Vec};
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
   TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
@@ -51,7 +51,7 @@ fn type_head_kind(kind: SyntacticTokenKind) -> bool {
 
 fn decide_type_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -94,7 +94,7 @@ where
 
 fn decide_type_generics_opener<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/graphqlx/syntactic/value.rs
+++ b/smear-parser/src/graphqlx/syntactic/value.rs
@@ -11,7 +11,7 @@
 
 use std::vec::Vec;
 use tokora::{
-  Accumulator, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
+  Accumulator, EmitterView, Lexer, ParseInput, ParseTokenChoice, SimpleSpan, Slice, Source, Token,
   TryParseInput,
   cache::{Peeked, PeekedTokenExt},
   parser::Action,
@@ -422,7 +422,7 @@ fn const_value_head<S>(token: &smear_lexer::graphqlx::syntactic::SyntacticToken<
 
 fn decide_value_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -439,7 +439,7 @@ where
 
 fn decide_const_value_head<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,
@@ -456,7 +456,7 @@ where
 
 fn decide_brace_member<'inp, Src, Ctx>(
   mut peeked: Peeked<'_, 'inp, GraphqlxLexer<'inp, Src>, U1>,
-  _: &mut Ctx::Emitter,
+  _: EmitterView<'_, 'inp, GraphqlxLexer<'inp, Src>, Ctx::Emitter, GraphQLx>,
 ) -> Result<Action, GraphqlxError<'inp, Src, Ctx>>
 where
   Src: Source<usize> + ?Sized,

--- a/smear-parser/src/lib.rs
+++ b/smear-parser/src/lib.rs
@@ -20,8 +20,9 @@ pub mod combinator;
 #[cfg(any(feature = "graphql", feature = "graphqlx"))]
 mod name;
 
-/// Namespaced-path carrier shared by GraphQL-family dialect ASTs.
-#[cfg(any(feature = "graphql", feature = "graphqlx"))]
+/// Namespaced-path carrier used by the GraphQLx dialect AST; vanilla GraphQL
+/// has no namespaced paths.
+#[cfg(feature = "graphqlx")]
 mod path;
 
 /// Generic-definition carriers shared by extended GraphQL-family dialect ASTs.

--- a/smear-parser/src/name.rs
+++ b/smear-parser/src/name.rs
@@ -27,10 +27,15 @@ pub struct Name<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()>(Ident<S, Span, 
 /// GraphQL-family dialects use this nominal wrapper for the `Name but not on`
 /// grammar position. Its constructor is kept within this crate so syntactic
 /// productions are the single place that establish that exclusion.
+///
+/// Vanilla GraphQL fragments use this wrapper; GraphQLx has no fragment
+/// grammar.
+#[cfg(feature = "graphql")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct FragmentName<S: ?Sized, Span = SimpleSpan, Lang: ?Sized = ()>(Name<S, Span, Lang>);
 
+#[cfg(feature = "graphql")]
 impl<S, Span, Lang: ?Sized> FragmentName<S, Span, Lang> {
   #[inline]
   pub(crate) const fn new(span: Span, source: S) -> Self {
@@ -38,6 +43,7 @@ impl<S, Span, Lang: ?Sized> FragmentName<S, Span, Lang> {
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<S: ?Sized, Span, Lang: ?Sized> Deref for FragmentName<S, Span, Lang> {
   type Target = Name<S, Span, Lang>;
 
@@ -47,6 +53,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> Deref for FragmentName<S, Span, Lang> {
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<S: ?Sized, Span, Lang: ?Sized> DerefMut for FragmentName<S, Span, Lang> {
   #[inline]
   fn deref_mut(&mut self) -> &mut Self::Target {
@@ -54,6 +61,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> DerefMut for FragmentName<S, Span, Lang> {
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<S: ?Sized, Span, Lang: ?Sized> AsRef<Name<S, Span, Lang>> for FragmentName<S, Span, Lang> {
   #[inline]
   fn as_ref(&self) -> &Name<S, Span, Lang> {
@@ -61,6 +69,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> AsRef<Name<S, Span, Lang>> for FragmentName<
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<S, Span, Lang: ?Sized> PartialEq<S> for FragmentName<S, Span, Lang>
 where
   S: PartialEq,
@@ -71,6 +80,7 @@ where
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<S: ?Sized, Span, Lang: ?Sized> AsSpan<Span> for FragmentName<S, Span, Lang> {
   #[inline]
   fn as_span(&self) -> &Span {
@@ -78,6 +88,7 @@ impl<S: ?Sized, Span, Lang: ?Sized> AsSpan<Span> for FragmentName<S, Span, Lang>
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<S, Span, Lang: ?Sized> IntoSpan<Span> for FragmentName<S, Span, Lang> {
   #[inline]
   fn into_span(self) -> Span {
@@ -85,6 +96,7 @@ impl<S, Span, Lang: ?Sized> IntoSpan<Span> for FragmentName<S, Span, Lang> {
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<S, Span, Lang: ?Sized> IntoComponents for FragmentName<S, Span, Lang> {
   type Components = (Span, S);
 

--- a/smear-parser/src/ty.rs
+++ b/smear-parser/src/ty.rs
@@ -3,6 +3,7 @@
 //! These source-independent nodes retain the referenced name or element type,
 //! the complete source span, and whether the reference is non-null.
 
+#[cfg(feature = "graphqlx")]
 use std::vec::Vec;
 use tokora::{
   SimpleSpan,
@@ -10,9 +11,14 @@ use tokora::{
   utils::IntoComponents,
 };
 
+#[cfg(feature = "graphqlx")]
 use crate::path::Path;
 
 /// A named type reference with an optional non-null modifier.
+///
+/// Vanilla GraphQL names its type references directly; GraphQLx uses
+/// [`DefinitionTypePath`] instead, since its type references are namespaced.
+#[cfg(feature = "graphql")]
 #[derive(Debug, Clone, Copy)]
 pub struct NamedType<Name, Span = SimpleSpan> {
   span: Span,
@@ -20,6 +26,7 @@ pub struct NamedType<Name, Span = SimpleSpan> {
   required: bool,
 }
 
+#[cfg(feature = "graphql")]
 impl<Name, Span> AsSpan<Span> for NamedType<Name, Span> {
   #[inline]
   fn as_span(&self) -> &Span {
@@ -27,6 +34,7 @@ impl<Name, Span> AsSpan<Span> for NamedType<Name, Span> {
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<Name, Span> IntoSpan<Span> for NamedType<Name, Span> {
   #[inline]
   fn into_span(self) -> Span {
@@ -34,6 +42,7 @@ impl<Name, Span> IntoSpan<Span> for NamedType<Name, Span> {
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<Name, Span> IntoComponents for NamedType<Name, Span> {
   type Components = (Span, Name, bool);
 
@@ -43,6 +52,7 @@ impl<Name, Span> IntoComponents for NamedType<Name, Span> {
   }
 }
 
+#[cfg(feature = "graphql")]
 impl<Name, Span> NamedType<Name, Span> {
   /// Creates a named type reference.
   #[inline]
@@ -131,6 +141,7 @@ impl<Type, Span> ListType<Type, Span> {
 }
 
 /// A GraphQLx set type reference with an optional non-null modifier.
+#[cfg(feature = "graphqlx")]
 #[derive(Debug, Clone, Copy)]
 pub struct SetType<Type, Span = SimpleSpan> {
   span: Span,
@@ -138,6 +149,7 @@ pub struct SetType<Type, Span = SimpleSpan> {
   required: bool,
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span> SetType<Type, Span> {
   /// Creates a set type reference.
   #[inline]
@@ -164,6 +176,7 @@ impl<Type, Span> SetType<Type, Span> {
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span> AsSpan<Span> for SetType<Type, Span> {
   #[inline]
   fn as_span(&self) -> &Span {
@@ -171,6 +184,7 @@ impl<Type, Span> AsSpan<Span> for SetType<Type, Span> {
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span> IntoSpan<Span> for SetType<Type, Span> {
   #[inline]
   fn into_span(self) -> Span {
@@ -178,6 +192,7 @@ impl<Type, Span> IntoSpan<Span> for SetType<Type, Span> {
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span> IntoComponents for SetType<Type, Span> {
   type Components = (Span, Type, bool);
 
@@ -188,6 +203,7 @@ impl<Type, Span> IntoComponents for SetType<Type, Span> {
 }
 
 /// A GraphQLx map type reference with an optional non-null modifier.
+#[cfg(feature = "graphqlx")]
 #[derive(Debug, Clone, Copy)]
 pub struct MapType<Key, Value, Span = SimpleSpan> {
   span: Span,
@@ -196,6 +212,7 @@ pub struct MapType<Key, Value, Span = SimpleSpan> {
   required: bool,
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Key, Value, Span> MapType<Key, Value, Span> {
   /// Creates a map type reference.
   #[inline]
@@ -233,6 +250,7 @@ impl<Key, Value, Span> MapType<Key, Value, Span> {
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Key, Value, Span> AsSpan<Span> for MapType<Key, Value, Span> {
   #[inline]
   fn as_span(&self) -> &Span {
@@ -240,6 +258,7 @@ impl<Key, Value, Span> AsSpan<Span> for MapType<Key, Value, Span> {
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Key, Value, Span> IntoSpan<Span> for MapType<Key, Value, Span> {
   #[inline]
   fn into_span(self) -> Span {
@@ -247,6 +266,7 @@ impl<Key, Value, Span> IntoSpan<Span> for MapType<Key, Value, Span> {
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Key, Value, Span> IntoComponents for MapType<Key, Value, Span> {
   type Components = (Span, Key, Value, bool);
 
@@ -257,6 +277,7 @@ impl<Key, Value, Span> IntoComponents for MapType<Key, Value, Span> {
 }
 
 /// Generic type arguments carried by a GraphQLx type path.
+#[cfg(feature = "graphqlx")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeGenerics<Type, Span = SimpleSpan, Container = Vec<Type>> {
   span: Span,
@@ -264,6 +285,7 @@ pub struct TypeGenerics<Type, Span = SimpleSpan, Container = Vec<Type>> {
   _type: core::marker::PhantomData<Type>,
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span, Container> TypeGenerics<Type, Span, Container> {
   /// Creates a type-argument list from its enclosing span and parameters.
   #[inline]
@@ -297,6 +319,7 @@ impl<Type, Span, Container> TypeGenerics<Type, Span, Container> {
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span, Container> AsSpan<Span> for TypeGenerics<Type, Span, Container> {
   #[inline]
   fn as_span(&self) -> &Span {
@@ -304,6 +327,7 @@ impl<Type, Span, Container> AsSpan<Span> for TypeGenerics<Type, Span, Container>
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span, Container> IntoSpan<Span> for TypeGenerics<Type, Span, Container> {
   #[inline]
   fn into_span(self) -> Span {
@@ -311,6 +335,7 @@ impl<Type, Span, Container> IntoSpan<Span> for TypeGenerics<Type, Span, Containe
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Type, Span, Container> IntoComponents for TypeGenerics<Type, Span, Container> {
   type Components = (Span, Container);
 
@@ -321,6 +346,7 @@ impl<Type, Span, Container> IntoComponents for TypeGenerics<Type, Span, Containe
 }
 
 /// A namespaced GraphQLx type path, optional type arguments, and nullability.
+#[cfg(feature = "graphqlx")]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DefinitionTypePath<
   Name,
@@ -335,6 +361,7 @@ pub struct DefinitionTypePath<
   required: bool,
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Name, Type, Span, PathContainer, TypeContainer>
   DefinitionTypePath<Name, Type, Span, PathContainer, TypeContainer>
 {
@@ -380,6 +407,7 @@ impl<Name, Type, Span, PathContainer, TypeContainer>
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Name, Type, Span, PathContainer, TypeContainer> AsSpan<Span>
   for DefinitionTypePath<Name, Type, Span, PathContainer, TypeContainer>
 {
@@ -389,6 +417,7 @@ impl<Name, Type, Span, PathContainer, TypeContainer> AsSpan<Span>
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Name, Type, Span, PathContainer, TypeContainer> IntoSpan<Span>
   for DefinitionTypePath<Name, Type, Span, PathContainer, TypeContainer>
 {
@@ -398,6 +427,7 @@ impl<Name, Type, Span, PathContainer, TypeContainer> IntoSpan<Span>
   }
 }
 
+#[cfg(feature = "graphqlx")]
 impl<Name, Type, Span, PathContainer, TypeContainer> IntoComponents
   for DefinitionTypePath<Name, Type, Span, PathContainer, TypeContainer>
 {

--- a/smear-parser/src/ty/tests.rs
+++ b/smear-parser/src/ty/tests.rs
@@ -1,26 +1,17 @@
 use std::vec;
 
-use crate::path::Path;
 use tokora::{
   span::{AsSpan, IntoSpan},
   utils::IntoComponents,
 };
 
-use super::{DefinitionTypePath, ListType, MapType, NamedType, SetType, TypeGenerics};
+use super::ListType;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CustomSpan(u8);
 
 #[test]
 fn carriers_support_custom_spans() {
-  let named = NamedType::<_, CustomSpan>::new(CustomSpan(1), "Name", true);
-  assert_eq!(named.as_span(), &CustomSpan(1));
-  assert_eq!(
-    NamedType::<_, CustomSpan>::new(CustomSpan(1), "Name", true).into_span(),
-    CustomSpan(1)
-  );
-  assert_eq!(named.into_components(), (CustomSpan(1), "Name", true));
-
   let list = ListType::<_, CustomSpan>::new(CustomSpan(2), "Element", false);
   assert_eq!(list.as_span(), &CustomSpan(2));
   assert_eq!(
@@ -28,6 +19,28 @@ fn carriers_support_custom_spans() {
     CustomSpan(2)
   );
   assert_eq!(list.into_components(), (CustomSpan(2), "Element", false));
+}
+
+#[cfg(feature = "graphql")]
+#[test]
+fn named_type_carrier_supports_custom_spans() {
+  use super::NamedType;
+
+  let named = NamedType::<_, CustomSpan>::new(CustomSpan(1), "Name", true);
+  assert_eq!(named.as_span(), &CustomSpan(1));
+  assert_eq!(
+    NamedType::<_, CustomSpan>::new(CustomSpan(1), "Name", true).into_span(),
+    CustomSpan(1)
+  );
+  assert_eq!(named.into_components(), (CustomSpan(1), "Name", true));
+}
+
+#[cfg(feature = "graphqlx")]
+#[test]
+fn graphqlx_carriers_support_custom_spans() {
+  use crate::path::Path;
+
+  use super::{DefinitionTypePath, MapType, SetType, TypeGenerics};
 
   let set = SetType::<_, CustomSpan>::new(CustomSpan(3), "Element", true);
   assert_eq!(set.as_span(), &CustomSpan(3));

--- a/smear-parser/src/value/mod.rs
+++ b/smear-parser/src/value/mod.rs
@@ -21,9 +21,11 @@ pub use enum_value::*;
 pub use float::*;
 pub use int::*;
 pub use list::*;
+#[cfg(feature = "graphqlx")]
 pub use map::*;
 pub use null_value::*;
 pub use object::*;
+#[cfg(feature = "graphqlx")]
 pub use set::*;
 pub use string::*;
 pub use variable::*;
@@ -34,9 +36,11 @@ mod enum_value;
 mod float;
 mod int;
 mod list;
+#[cfg(feature = "graphqlx")]
 mod map;
 mod null_value;
 mod object;
+#[cfg(feature = "graphqlx")]
 mod set;
 mod string;
 mod variable;

--- a/smear-parser/src/value/tests.rs
+++ b/smear-parser/src/value/tests.rs
@@ -8,7 +8,7 @@ use tokora::{
 
 use super::{
   BlockStringValue, BooleanValue, DefaultInputValue, EnumValue, FloatValue, InlineStringValue,
-  IntValue, List, Map, MapEntry, NullValue, Object, ObjectField, Set, StringValue, VariableValue,
+  IntValue, List, NullValue, Object, ObjectField, StringValue, VariableValue,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -119,30 +119,6 @@ fn carriers_support_custom_spans_and_language_markers() {
   assert_eq!(list.values(), &[1, 2]);
   assert_eq!(list.into_components(), (CustomSpan(10), vec![1, 2]));
 
-  let set = Set::<i32, CustomSpan>::new(CustomSpan(11), vec![1, 2]);
-  assert_eq!(set.as_span(), &CustomSpan(11));
-  assert_eq!(set.values(), &[1, 2]);
-  assert_eq!(set.into_components(), (CustomSpan(11), vec![1, 2]));
-
-  let entry = MapEntry::<_, _, CustomSpan>::new(CustomSpan(12), "answer", 42);
-  assert_eq!(entry.as_span(), &CustomSpan(12));
-  assert_eq!(entry.key(), &"answer");
-  assert_eq!(entry.value(), &42);
-  assert_eq!(entry.into_components(), (CustomSpan(12), "answer", 42));
-
-  let map = Map::<_, _, CustomSpan>::new(
-    CustomSpan(13),
-    vec![MapEntry::<_, _, CustomSpan>::new(
-      CustomSpan(14),
-      "answer",
-      42,
-    )],
-  );
-  assert_eq!(map.as_span(), &CustomSpan(13));
-  assert_eq!(map.entries().len(), 1);
-  assert_eq!(map.entries()[0].key(), &"answer");
-  assert_eq!(map.into_entries()[0].value(), &42);
-
   let field = ObjectField::<_, _, CustomSpan>::new(CustomSpan(15), "answer", 42);
   assert_eq!(field.as_span(), &CustomSpan(15));
   assert_eq!(field.name(), &"answer");
@@ -168,6 +144,36 @@ fn carriers_support_custom_spans_and_language_markers() {
       BooleanValue::<str, CustomSpan, crate::graphql::GraphQL>::new(CustomSpan(15), false);
     let _: crate::value::BooleanValue<str, CustomSpan, crate::graphql::GraphQL> = branded;
   }
+}
+
+#[cfg(feature = "graphqlx")]
+#[test]
+fn graphqlx_collections_support_custom_spans() {
+  use super::{Map, MapEntry, Set};
+
+  let set = Set::<i32, CustomSpan>::new(CustomSpan(11), vec![1, 2]);
+  assert_eq!(set.as_span(), &CustomSpan(11));
+  assert_eq!(set.values(), &[1, 2]);
+  assert_eq!(set.into_components(), (CustomSpan(11), vec![1, 2]));
+
+  let entry = MapEntry::<_, _, CustomSpan>::new(CustomSpan(12), "answer", 42);
+  assert_eq!(entry.as_span(), &CustomSpan(12));
+  assert_eq!(entry.key(), &"answer");
+  assert_eq!(entry.value(), &42);
+  assert_eq!(entry.into_components(), (CustomSpan(12), "answer", 42));
+
+  let map = Map::<_, _, CustomSpan>::new(
+    CustomSpan(13),
+    vec![MapEntry::<_, _, CustomSpan>::new(
+      CustomSpan(14),
+      "answer",
+      42,
+    )],
+  );
+  assert_eq!(map.as_span(), &CustomSpan(13));
+  assert_eq!(map.entries().len(), 1);
+  assert_eq!(map.entries()[0].key(), &"answer");
+  assert_eq!(map.into_entries()[0].value(), &42);
 }
 
 #[test]

--- a/smear-parser/tests/lossless_wiring.rs
+++ b/smear-parser/tests/lossless_wiring.rs
@@ -6,7 +6,7 @@ use tokora::Token;
 /// The wiring guard, stated where it is actually decided.
 ///
 /// tokora's `cst::Sink` is compile-time restricted to trivia-surfacing lexers. This declaration
-/// is what admits the lossless door; without it `Sink::new` will not compile.
+/// is what admits the lossless door; without it `cst::parse_lossless` will not compile.
 ///
 /// **Why a `const` item and not a runtime `assert!`.** `SURFACES_TRIVIA` is an associated
 /// *constant*, so a runtime assertion over it re-checks a question the compiler already settled


### PR DESCRIPTION
## Why

tokora closed a door upstream (tokora #175, `feat(tokora): mint the CST sink from the source it reads, and never hand a callback the emitter`). A parser callback used to be handed `&mut Ctx::Emitter` — and `&mut E` **is** an emitter. A condition could wrap the one it was given and install the wrapper as the context of a *second* parse over a *different* buffer, so the recording sink would end up describing text it never read. Two things changed upstream to shut that:

- callbacks now receive an `EmitterView` rather than the emitter itself, and
- `Sink::new` and `InputRef::emitter()` became crate-private, with `cst::parse_lossless` as the one door that mints a sink — it takes the source **once** and uses that same argument for both the sink and the input, so the buffer the tree's text comes from and the buffer the parse reads cannot be two different buffers.

This PR moves smear onto that API.

## What changed

**Syntactic — the type, and nothing else.** `Decision::decide`, the `peek_then` family's handlers and the token-level pratt folds all take the new parameter. **43 parameters changed, with zero callback-body changes and zero call-site changes**: every one of the 43 decision callbacks names its parameter `_` and touches nothing, so only the spelling of the type moved. The replacement is derivable from the two adjacent lines — the lexer from the preceding `Peeked<…>`, the grammar brand from the `Ctx: ParseCtx<…>` bound. `EmitterView` is imported into the 13 files that carry their own tokora `use`, plus the two `definition/mod.rs` for the seven children that reach it through `use super::*` (43 parameters + 15 imports = 58 mentions in the tree).

**Lossless — reach the operations, mint the sink at the door.** The emitter's operations are inherent on the handle now, under the emitter's own names, so `inp.emitter().cst_mark()` becomes `inp.cst_mark()` and `inp.emitter().emit_error(..)` becomes `inp.emit_error(..)` — 21 sites across the productions, statement for statement, plus 3 more in the `lossless_drivers!` scaffold.

`parse_str`, the `lossless_drivers!` scaffold and `trivia`'s `drive!` all route through `cst::parse_lossless`, and materialization moves off the sink onto the `Cst` handle it hands back (`finish_root` now takes a `LosslessCst` instead of a `LosslessSink`). One consequence worth naming: the driver context pair holds the sink **by value** rather than by `&mut`, so the **`'sink` lifetime disappears from `TestCtx` / `TestInput` in all three test scaffolds** — the lifetime no longer occurs anywhere in the crate.

Active code no longer names `Sink::new`, `InputRef::emitter` or `&mut Ctx::Emitter`; the single surviving mention of `Sink::new` is a doc comment recording that it is tokora-private.

## Performance

**No syntactic regression.** Eight benchmark ids over three interleaved A/B rounds; the largest excursion was **−0.912%**, and every id landed inside its own noise floor (per-id floors ranged 0.66%–1.65%).

Caveat stated plainly: a regression below roughly **1%** would not have been visible on that machine, so this establishes "no regression at the resolution measured", not "performance is bit-identical".

## Gating

Gated locally against the **merged** tokora (`al8n/tokit@b78e854`, PR #175), not the pre-merge branch. Both feature configurations were run, because `rowan` is not a default feature and the plain legs never compile the lossless code where the `parse_lossless` / `Cst` migration lives:

| gate | plain | `--workspace --all-features` |
| --- | --- | --- |
| `cargo build` | pass (rc 0) | pass (rc 0) |
| `cargo test` | pass (rc 0) — 480 passed, 0 failed | pass (rc 0) — 695 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | pass (rc 0) | pass (rc 0) |
| `cargo fmt --check` | pass (rc 0) | pass (rc 0) |

Why both columns matter here, concretely: the 16 `lossless_*` integration binaries are `#![cfg(feature = "rowan")]`, so they compile to empty shells without it. They run **0 tests** in the plain column and **197** in the all-features one — the plain leg is green on this diff while compiling none of the code the lossless half of it touches.

The build output names the tokora under test directly: `Compiling tokora v0.8.0 (/Users/user/Develop/personal/tokit/tokora)`, that checkout at `b78e854`. Its tree is byte-identical to the reviewed PR head `798f4cd` (same tree hash `9073a795`), so the squash-merge changed nothing relative to what this migration was written against.

## Notes for review

- Base is `feat/tokora-0.8`, the 0.8 integration line this forked from at `68a9a40` — deliberately not `main`.
- **CI on this PR is red, and every red is inherited.** The integration line carries `[patch.crates-io] tokora = { path = "../tokit/tokora" }` (introduced by `6e341d2`, absent on `main`), which resolves only against a local side-by-side tokit checkout. A GitHub runner checks out `smear` alone, so cargo cannot resolve the manifest at all:

  ```
  error: failed to load source for dependency `tokora`
  Caused by: failed to read `/home/runner/work/smear/tokit/tokora/Cargo.toml`
  Caused by: No such file or directory (os error 2)
  ```

  (the miri jobs word it as `patch location ... does not contain packages matching tokora`.) All 7 failing checks fail this way, before compiling a line of smear; the other 27 are matrix fail-fast cancellations. The only checks that pass are the 3 `rustfmt` jobs and `loc` — precisely the ones that never resolve the dependency graph.

  This PR **does not touch any manifest**: the diff is 31 `.rs` files and nothing else, so the failure is identical to what the base branch would produce on its own. The local gating above is the real signal until the integration line moves to a published tokora.
