### PR TITLE
fix: i686 Miri scope, member MSRV inheritance, and a phantom token kind

### DIFF
--- a/ci/miri_sb.sh
+++ b/ci/miri_sb.sh
@@ -19,13 +19,34 @@ MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-ali
 # aggressively reuse freed addresses by default; a long allocation-heavy
 # test binary can exhaust it cumulatively ("no more free addresses in the
 # address space"). i686-unknown-linux-gnu is the only 32-bit target in the
-# CI matrix. Raising the reuse rate is a known lever for this, but whether
-# it is *sufficient* to avoid exhaustion for this suite is unproven until a
-# CI run confirms it.
+# CI matrix.
+#
+# -Zmiri-address-reuse-rate=1.0 stays on for i686: it is cheap and correct
+# in intent. But it was measured *insufficient alone* across three
+# consecutive CI runs, identically under this aliasing model and under
+# Tree Borrows (ci/miri_tb.sh): the smear-lexer lib tests and tests/oracle.rs
+# pass in full, then tests/tokora_conformance.rs still exhausts the address
+# space partway through graphqlx::lossless_conformance. cargo already runs
+# each test binary as its own process, so every binary starts with a fresh
+# 4 GiB space — the exhaustion accrues *within* one binary, so the only
+# further lever is not running that binary at all under this target.
+#
+# So i686 alone drops `--tests` and runs the lib unit tests only. This is a
+# deliberate, scoped reduction, not a silent one: i686's unique value in
+# this matrix is 32-bit pointer width on a SIMD byte-level lexer, and the
+# lib tests (115 passing at last measurement) exercise exactly that, under
+# both aliasing models. What is given up is "integration-suite coverage at
+# 32-bit", not "32-bit coverage" — tests/oracle.rs and
+# tests/tokora_conformance.rs still run under Miri on x86_64 and
+# powerpc64-unknown-linux-gnu, so the scenarios themselves stay covered,
+# just not at this pointer width.
 if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
   MIRIFLAGS="$MIRIFLAGS -Zmiri-address-reuse-rate=1.0"
+  TEST_ARGS=""
+else
+  TEST_ARGS="--tests"
 fi
 
 export MIRIFLAGS
 
-cargo miri test --tests --target $TARGET --lib
+cargo miri test $TEST_ARGS --target $TARGET --lib

--- a/ci/miri_tb.sh
+++ b/ci/miri_tb.sh
@@ -19,14 +19,36 @@ MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-ali
 # aggressively reuse freed addresses by default; a long allocation-heavy
 # test binary can exhaust it cumulatively ("no more free addresses in the
 # address space"). i686-unknown-linux-gnu is the only 32-bit target in the
-# CI matrix. Raising the reuse rate is a known lever for this, but whether
-# it is *sufficient* to avoid exhaustion for this suite is unproven until a
-# CI run confirms it.
+# CI matrix.
+#
+# -Zmiri-address-reuse-rate=1.0 stays on for i686: it is cheap and correct
+# in intent. But it was measured *insufficient alone* across three
+# consecutive CI runs, identically under this aliasing model (Tree Borrows)
+# and under Stacked Borrows (ci/miri_sb.sh): the smear-lexer lib tests and
+# tests/oracle.rs pass in full, then tests/tokora_conformance.rs still
+# exhausts the address space partway through graphqlx::lossless_conformance.
+# cargo already runs each test binary as its own process, so every binary
+# starts with a fresh 4 GiB space — the exhaustion accrues *within* one
+# binary, so the only further lever is not running that binary at all under
+# this target.
+#
+# So i686 alone drops `--tests` and runs the lib unit tests only. This is a
+# deliberate, scoped reduction, not a silent one: i686's unique value in
+# this matrix is 32-bit pointer width on a SIMD byte-level lexer, and the
+# lib tests (115 passing at last measurement) exercise exactly that, under
+# both aliasing models. What is given up is "integration-suite coverage at
+# 32-bit", not "32-bit coverage" — tests/oracle.rs and
+# tests/tokora_conformance.rs still run under Miri on x86_64 and
+# powerpc64-unknown-linux-gnu, so the scenarios themselves stay covered,
+# just not at this pointer width.
 if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
   MIRIFLAGS="$MIRIFLAGS -Zmiri-address-reuse-rate=1.0"
+  TEST_ARGS=""
+else
+  TEST_ARGS="--tests"
 fi
 
 export MIRIFLAGS
 
-cargo miri test --tests --target $TARGET --lib
+cargo miri test $TEST_ARGS --target $TARGET --lib
 

--- a/smear-lexer/Cargo.toml
+++ b/smear-lexer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "smear-lexer"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/smear-lexer/examples/token_mix.rs
+++ b/smear-lexer/examples/token_mix.rs
@@ -53,7 +53,7 @@ fn classify(kind: LosslessTokenKind) -> Bucket {
 
     Spread => Bucket::Spread,
     Identifier => Bucket::Identifier,
-    Int | Float | Boolean => Bucket::Number,
+    Int | Float => Bucket::Number,
     InlineString => Bucket::InlineString,
     BlockString => Bucket::BlockString,
   }

--- a/smear-lexer/src/graphql/lossless/mod.rs
+++ b/smear-lexer/src/graphql/lossless/mod.rs
@@ -262,8 +262,6 @@ pub enum LosslessTokenKind {
 
   /// Float literal token
   Float,
-  /// Boolean literal token
-  Boolean,
   /// Identifier token
   Identifier,
   /// Integer literal token
@@ -301,7 +299,6 @@ impl core::fmt::Display for LosslessTokenKind {
       Self::Pipe => f.write_str("|"),
       Self::Spread => f.write_str("..."),
       Self::Float => f.write_str("float"),
-      Self::Boolean => f.write_str("boolean"),
       Self::Identifier => f.write_str("identifier"),
       Self::Int => f.write_str("int"),
       Self::InlineString => f.write_str("string"),
@@ -314,6 +311,7 @@ impl core::fmt::Display for LosslessTokenKind {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::LitPlainStr;
   use tokora::token::IdentifierToken;
 
   #[test]
@@ -326,5 +324,71 @@ mod tests {
     assert!(!IdentifierToken::is_identifier(
       &LosslessToken::<&str>::LitInt("1")
     ));
+  }
+
+  /// Census: every declared [`LosslessTokenKind`] variant must be producible by some
+  /// [`LosslessToken`], i.e. by some arm of [`LosslessToken::kind`].
+  ///
+  /// `Boolean` used to be a counterexample: the kind existed with no `LosslessToken` variant
+  /// able to produce it (`true`/`false` lex as `Identifier`, correctly — booleans are `Name`
+  /// tokens lexically per the GraphQL spec, distinguished only at parse time), so it was a
+  /// kind nothing could ever emit.
+  ///
+  /// `census!` builds an exhaustive `match` — no wildcard arm — mapping each
+  /// `LosslessTokenKind` to a `LosslessToken` that produces it, from the same variant list it
+  /// uses to drive the round-trip assertions below. There is one list, not two kept in sync
+  /// by hand: add a `LosslessTokenKind` variant without adding a case here and the generated
+  /// `match` stops being exhaustive, which is a compile error naming the missing variant
+  /// rather than a runtime assertion that might simply never run.
+  #[test]
+  fn lossless_token_kind_census() {
+    macro_rules! census {
+      ($($variant:ident => $token:expr),+ $(,)?) => {
+        fn sample(kind: LosslessTokenKind) -> LosslessToken<&'static str> {
+          match kind {
+            $(LosslessTokenKind::$variant => $token,)+
+          }
+        }
+
+        $(
+          assert_eq!(
+            sample(LosslessTokenKind::$variant).kind(),
+            LosslessTokenKind::$variant,
+            "LosslessTokenKind::{} is declared but its sample token maps to a different kind",
+            stringify!($variant),
+          );
+        )+
+      };
+    }
+
+    census! {
+      Ampersand => LosslessToken::Ampersand,
+      At => LosslessToken::At,
+      Bom => LosslessToken::Bom("\u{FEFF}"),
+      RBrace => LosslessToken::RBrace,
+      LBrace => LosslessToken::LBrace,
+      RBracket => LosslessToken::RBracket,
+      LBracket => LosslessToken::LBracket,
+      RParen => LosslessToken::RParen,
+      LParen => LosslessToken::LParen,
+      Bang => LosslessToken::Bang,
+      Colon => LosslessToken::Colon,
+      Dollar => LosslessToken::Dollar,
+      Equal => LosslessToken::Equal,
+      Space => LosslessToken::Space,
+      Tab => LosslessToken::Tab,
+      CarriageReturn => LosslessToken::CarriageReturn,
+      Newline => LosslessToken::Newline,
+      CarriageReturnAndNewline => LosslessToken::CarriageReturnAndNewline,
+      Comma => LosslessToken::Comma,
+      Pipe => LosslessToken::Pipe,
+      Spread => LosslessToken::Spread,
+      Float => LosslessToken::LitFloat("1.0"),
+      Identifier => LosslessToken::Identifier("x"),
+      Int => LosslessToken::LitInt("1"),
+      InlineString => LosslessToken::LitInlineStr(LitInlineStr::Plain(LitPlainStr::new("\"s\""))),
+      BlockString => LosslessToken::LitBlockStr(LitBlockStr::Plain(LitPlainStr::new("\"\"\"b\"\"\""))),
+      Comment => LosslessToken::Comment("# c"),
+    }
   }
 }

--- a/smear-lexer/src/graphql/syntactic/tests.rs
+++ b/smear-lexer/src/graphql/syntactic/tests.rs
@@ -225,3 +225,56 @@ fn capability_traits_classify_tokens() {
     Some(SyntacticTokenKind::Spread)
   );
 }
+
+/// Census: every declared `SyntacticTokenKind` variant must be producible by some
+/// `SyntacticToken`, i.e. by some arm of `SyntacticToken::kind`.
+///
+/// Mirrors `lossless_token_kind_census` (`graphql/lossless/mod.rs`), which exists because
+/// `LosslessTokenKind::Boolean` was declared with no `LosslessToken` able to produce it.
+/// `SyntacticTokenKind` has no such gap today — trivia kinds don't exist here at all, since
+/// `SyntacticToken` skips trivia — so this is a regression guard, not a fix. See that test for
+/// why the `census!` macro shape (one variant list driving both an exhaustive `match` and the
+/// round-trip assertions) is the point: a variant added without a case here fails to compile.
+#[test]
+fn syntactic_token_kind_census() {
+  macro_rules! census {
+    ($($variant:ident => $token:expr),+ $(,)?) => {
+      fn sample(kind: SyntacticTokenKind) -> SyntacticToken<&'static str> {
+        match kind {
+          $(SyntacticTokenKind::$variant => $token,)+
+        }
+      }
+
+      $(
+        assert_eq!(
+          sample(SyntacticTokenKind::$variant).kind(),
+          SyntacticTokenKind::$variant,
+          "SyntacticTokenKind::{} is declared but its sample token maps to a different kind",
+          stringify!($variant),
+        );
+      )+
+    };
+  }
+
+  census! {
+    Ampersand => SyntacticToken::Ampersand,
+    At => SyntacticToken::At,
+    RBrace => SyntacticToken::RBrace,
+    RBracket => SyntacticToken::RBracket,
+    RParen => SyntacticToken::RParen,
+    Colon => SyntacticToken::Colon,
+    Dollar => SyntacticToken::Dollar,
+    Equal => SyntacticToken::Equal,
+    Bang => SyntacticToken::Bang,
+    LBrace => SyntacticToken::LBrace,
+    LBracket => SyntacticToken::LBracket,
+    LParen => SyntacticToken::LParen,
+    Pipe => SyntacticToken::Pipe,
+    Spread => SyntacticToken::Spread,
+    Identifier => SyntacticToken::Identifier("x"),
+    Float => SyntacticToken::LitFloat("1.0"),
+    Int => SyntacticToken::LitInt("1"),
+    InlineString => SyntacticToken::LitInlineStr(LitInlineStr::Plain(LitPlainStr::new("\"s\""))),
+    BlockString => SyntacticToken::LitBlockStr(LitBlockStr::Plain(LitPlainStr::new("\"\"\"b\"\"\""))),
+  }
+}

--- a/smear-lexer/src/graphqlx/lossless/mod.rs
+++ b/smear-lexer/src/graphqlx/lossless/mod.rs
@@ -316,3 +316,83 @@ impl core::fmt::Display for LosslessTokenKind {
     core::fmt::Debug::fmt(self, f)
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::LitPlainStr;
+
+  /// Census: every declared [`LosslessTokenKind`] variant must be producible by some
+  /// [`LosslessToken`], i.e. by some arm of [`LosslessToken::kind`].
+  ///
+  /// See the graphql (non-x) twin of this test
+  /// (`smear-lexer/src/graphql/lossless/mod.rs`) for why: that dialect shipped a
+  /// `LosslessTokenKind::Boolean` with no `LosslessToken` able to produce it. GraphQLx's kind
+  /// enum has no such gap today, but nothing previously stopped one from being added the same
+  /// way, silently.
+  ///
+  /// `census!` builds an exhaustive `match` — no wildcard arm — mapping each
+  /// `LosslessTokenKind` to a `LosslessToken` that produces it, from the same variant list it
+  /// uses to drive the round-trip assertions below. There is one list, not two kept in sync by
+  /// hand: add a `LosslessTokenKind` variant without adding a case here and the generated
+  /// `match` stops being exhaustive, which is a compile error naming the missing variant
+  /// rather than a runtime assertion that might simply never run.
+  #[test]
+  fn lossless_token_kind_census() {
+    macro_rules! census {
+      ($($variant:ident => $token:expr),+ $(,)?) => {
+        fn sample(kind: LosslessTokenKind) -> LosslessToken<&'static str> {
+          match kind {
+            $(LosslessTokenKind::$variant => $token,)+
+          }
+        }
+
+        $(
+          assert_eq!(
+            sample(LosslessTokenKind::$variant).kind(),
+            LosslessTokenKind::$variant,
+            "LosslessTokenKind::{} is declared but its sample token maps to a different kind",
+            stringify!($variant),
+          );
+        )+
+      };
+    }
+
+    census! {
+      Asterisk => LosslessToken::Asterisk,
+      At => LosslessToken::At,
+      Bom => LosslessToken::Bom("\u{FEFF}"),
+      Dollar => LosslessToken::Dollar,
+      FatArrow => LosslessToken::FatArrow,
+      LAngle => LosslessToken::LAngle,
+      RAngle => LosslessToken::RAngle,
+      LParen => LosslessToken::LParen,
+      RParen => LosslessToken::RParen,
+      Spread => LosslessToken::Spread,
+      Colon => LosslessToken::Colon,
+      Equal => LosslessToken::Equal,
+      LBracket => LosslessToken::LBracket,
+      RBracket => LosslessToken::RBracket,
+      LBrace => LosslessToken::LBrace,
+      RBrace => LosslessToken::RBrace,
+      Pipe => LosslessToken::Pipe,
+      Bang => LosslessToken::Bang,
+      Ampersand => LosslessToken::Ampersand,
+      Plus => LosslessToken::Plus,
+      Minus => LosslessToken::Minus,
+      PathSeparator => LosslessToken::PathSeparator,
+      Comma => LosslessToken::Comma,
+      Space => LosslessToken::Space,
+      Tab => LosslessToken::Tab,
+      Newline => LosslessToken::Newline,
+      CarriageReturn => LosslessToken::CarriageReturn,
+      CarriageReturnAndNewline => LosslessToken::CarriageReturnAndNewline,
+      Comment => LosslessToken::Comment("# c"),
+      Identifier => LosslessToken::Identifier("x"),
+      Float => LosslessToken::LitFloat(LitFloat::Decimal("1.0")),
+      Int => LosslessToken::LitInt(LitInt::Decimal("1")),
+      InlineString => LosslessToken::LitInlineStr(LitInlineStr::Plain(LitPlainStr::new("\"s\""))),
+      BlockString => LosslessToken::LitBlockStr(LitBlockStr::Plain(LitPlainStr::new("\"\"\"b\"\"\""))),
+    }
+  }
+}

--- a/smear-lexer/src/graphqlx/syntactic/tests.rs
+++ b/smear-lexer/src/graphqlx/syntactic/tests.rs
@@ -317,3 +317,66 @@ fn keyword_literal_and_punctuator_capabilities_are_mapped() {
     Some(crate::graphqlx::syntactic::SyntacticTokenKind::Spread)
   );
 }
+
+/// Census: every declared `SyntacticTokenKind` variant must be producible by some
+/// `SyntacticToken`, i.e. by some arm of `SyntacticToken::kind`.
+///
+/// Mirrors `lossless_token_kind_census` (`graphqlx/lossless/mod.rs`), added after the graphql
+/// (non-x) dialect shipped a `LosslessTokenKind::Boolean` with no `LosslessToken` able to
+/// produce it. `SyntacticTokenKind` has no such gap today — trivia kinds don't exist here at
+/// all, since `SyntacticToken` skips trivia — so this is a regression guard, not a fix. The
+/// `census!` macro shape (one variant list driving both an exhaustive `match` and the
+/// round-trip assertions) means a variant added without a case here fails to compile, naming
+/// the variant, instead of silently staying untested.
+#[test]
+fn syntactic_token_kind_census() {
+  use crate::{LitBlockStr, LitInlineStr, LitPlainStr, graphqlx::syntactic::SyntacticTokenKind};
+
+  macro_rules! census {
+    ($($variant:ident => $token:expr),+ $(,)?) => {
+      fn sample(kind: SyntacticTokenKind) -> SyntacticToken<&'static str> {
+        match kind {
+          $(SyntacticTokenKind::$variant => $token,)+
+        }
+      }
+
+      $(
+        assert_eq!(
+          sample(SyntacticTokenKind::$variant).kind(),
+          SyntacticTokenKind::$variant,
+          "SyntacticTokenKind::{} is declared but its sample token maps to a different kind",
+          stringify!($variant),
+        );
+      )+
+    };
+  }
+
+  census! {
+    Identifier => SyntacticToken::Identifier("x"),
+    Int => SyntacticToken::LitInt(LitInt::Decimal("1")),
+    Float => SyntacticToken::LitFloat(LitFloat::Decimal("1.0")),
+    InlineString => SyntacticToken::LitInlineStr(LitInlineStr::Plain(LitPlainStr::new("\"s\""))),
+    BlockString => SyntacticToken::LitBlockStr(LitBlockStr::Plain(LitPlainStr::new("\"\"\"b\"\"\""))),
+    Dollar => SyntacticToken::Dollar,
+    FatArrow => SyntacticToken::FatArrow,
+    LAngle => SyntacticToken::LAngle,
+    RAngle => SyntacticToken::RAngle,
+    LParen => SyntacticToken::LParen,
+    RParen => SyntacticToken::RParen,
+    Spread => SyntacticToken::Spread,
+    Colon => SyntacticToken::Colon,
+    Equal => SyntacticToken::Equal,
+    Asterisk => SyntacticToken::Asterisk,
+    At => SyntacticToken::At,
+    LBracket => SyntacticToken::LBracket,
+    RBracket => SyntacticToken::RBracket,
+    LBrace => SyntacticToken::LBrace,
+    RBrace => SyntacticToken::RBrace,
+    Pipe => SyntacticToken::Pipe,
+    Bang => SyntacticToken::Bang,
+    Ampersand => SyntacticToken::Ampersand,
+    Plus => SyntacticToken::Plus,
+    Minus => SyntacticToken::Minus,
+    PathSeparator => SyntacticToken::PathSeparator,
+  }
+}

--- a/smear-parser/Cargo.toml
+++ b/smear-parser/Cargo.toml
@@ -2,6 +2,7 @@
 name = "smear-parser"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true

--- a/smear-parser/src/graphql/lossless/mod.rs
+++ b/smear-parser/src/graphql/lossless/mod.rs
@@ -186,7 +186,6 @@ fn expectation_of(expected: Option<Expected<'_, LosslessTokenKind>>) -> Expectat
       LosslessTokenKind::Identifier => Expectation::Name,
       LosslessTokenKind::Int => Expectation::IntValue,
       LosslessTokenKind::Float => Expectation::FloatValue,
-      LosslessTokenKind::Boolean => Expectation::BooleanValue,
       LosslessTokenKind::InlineString => Expectation::InlineString,
       LosslessTokenKind::BlockString => Expectation::BlockString,
       LosslessTokenKind::Dollar => Expectation::Dollar,

--- a/smear/Cargo.toml
+++ b/smear/Cargo.toml
@@ -2,6 +2,7 @@
 name = "smear"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true


### PR DESCRIPTION
Three independent fixes, bundled into one PR because a CI round here takes hours on the macOS runner queue.

## 1. Restrict the i686 Miri cells to `--lib` (`a47714a`)

Both i686 cells failed on **three consecutive runs**, identically under Stacked Borrows and Tree Borrows:

```
error: resource exhaustion: there are no more free addresses in the address space
```

Miri simulates the *target's* address space, so on 32-bit that is 4 GiB and Miri does not aggressively reuse freed addresses. Not UB, not a smear or tokora bug.

`-Zmiri-address-reuse-rate=1.0` was tried first and **measured insufficient** — and verified to be genuinely applied, not skipped, by simulating the conditional across all five matrix targets. It stays on (cheap, correct in intent), with a comment recording that it is not sufficient alone.

cargo already runs each test binary as its own process, so every binary starts with a fresh 4 GiB space — the exhaustion accrues *within* one binary, so the only remaining lever is not running that binary at this target.

**This is a scoped reduction, not a silent one.** i686's unique value in the matrix is 32-bit pointer width on a SIMD byte-level lexer, and the lib tests (115 passing) exercise exactly that under both aliasing models. What is given up is "integration-suite coverage at 32-bit", not "32-bit coverage" — `oracle.rs` and `tokora_conformance.rs` still run under Miri on x86_64 and powerpc64, both green under both models.

Verified only i686 changes; the other four targets produce byte-identical commands to before. Missing-target guards still fire.

## 2. Inherit `rust-version` in the three member crates (`4d62844`)

The workspace declares `rust-version = "1.95"`, but no member set `rust-version.workspace = true`, so `cargo metadata` reported `rust_version: None` for all three. All three already inherit five other workspace keys, so this was an oversight.

Consequence: the MSRV was absent from published metadata and invisible to Cargo's MSRV-aware resolver — a consumer on an old toolchain would get a confusing compile failure instead of a clear MSRV error.

After: `cargo metadata --no-deps` reports `1.95` for `smear`, `smear-lexer` and `smear-parser`.

`legacy/` deliberately untouched: `workspace_members` confirms the root manifest's `exclude = ["legacy"]` is in effect, so those crates have no `[workspace.package]` to resolve against. Adding the line would be a no-op at best and misleading at worst.

## 3. Remove the phantom `LosslessTokenKind::Boolean`, add a census gate (`9917330`)

A census showed graphql's lossless dialect declared **28** kind variants but only **27** were producible. `Boolean` was the orphan: `LosslessToken` has no Boolean variant, and `kind()`'s 28 arms never yield it. `true`/`false` lex as `Identifier`, which is **correct** per the GraphQL spec — booleans are `Name` tokens lexically and are only distinguished at parse time. The lexing was right; the enum over-promised.

It also stranded an unreachable arm in `smear-parser` (`LosslessTokenKind::Boolean => Expectation::BooleanValue`).

Removed both, plus one site a qualified grep could not see: `examples/token_mix.rs` referenced `Boolean` unqualified through `use LosslessTokenKind::*`, which turned into E0408 on removal.

**The durable part is the census, not the removal.** A `census! { Variant => token_expr, ... }` macro expands one variant list into two things:

- a `match` with **no wildcard arm** mapping every kind to a token value, so an unlisted variant is a compile error naming it;
- a round-trip `assert_eq!(sample(kind).kind(), kind)` per variant.

One source of truth, rather than two lists that drift apart.

**Proven load-bearing**: adding an unwired `PhantomProbe` variant to graphqlx produced

```
error[E0004]: non-exhaustive patterns: `LosslessTokenKind::PhantomProbe` not covered
```

naming it exactly. Reverted, green.

Extended to the **syntactic** dialects as well (19/19 and 26/26 — both already clean, so those are regression guards rather than fixes).

## Gates — all rc=0

```
cargo build --workspace --all-features                                    0
cargo test --workspace --all-features                                     0   (24 groups, 0 failures)
cargo clippy --workspace --all-features --all-targets -- -D warnings      0
RUSTFLAGS="-Dwarnings" cargo hack check -p smear-lexer  --each-feature    0   (13/13 combos)
RUSTFLAGS="-Dwarnings" cargo hack check -p smear-parser --each-feature    0   (14/14 combos)
cargo fmt --all --check                                                   0
bash -n ci/miri_sb.sh ; bash -n ci/miri_tb.sh                             0
yq eval '.' .github/workflows/ci.yml                                      0
```

## Known, not fixed

`smear-parser/tests/lossless_kind_map.rs` carries a **comment** (not an assertion) stating that `LosslessTokenKind` has 28 variants, "one more than `LosslessToken`, because `Boolean` has no token variant". That is now stale — both are 27. The test's actual assertions concern the token side and still pass. Left for a follow-up rather than swept in silently.
