### PR TITLE
fix(lossless): materialize through the partial door, so a nesting trip reports instead of panicking

### DIFF
--- a/smear-parser/src/graphql/lossless/runner.rs
+++ b/smear-parser/src/graphql/lossless/runner.rs
@@ -66,11 +66,52 @@ pub(crate) type LosslessCst<'inp> =
 ///
 /// Shared by [`parse_str`] and by the per-production drivers under `test_support`, so the
 /// root kind, the fallible-materialization contract and the diagnostic projection are stated
-/// once. `finish` names the root kind — it is NOT profile data — and hands back the inner
-/// emitter, which is where the diagnostics live.
+/// once. The materialization door names the root kind — it is NOT profile data — and hands back
+/// the inner emitter, which is where the diagnostics live.
+///
+/// # Why the partial door
+///
+/// The door is [`Cst::finish_partial`], not [`Cst::finish`], and the difference is exactly two
+/// refusals: `finish` rejects an event stream that leaves a node open (`UnclosedNodes`) or leaves
+/// a source byte covered by neither a committed token nor a recorded lexer-error diagnostic
+/// (`UncoveredGap`); `finish_partial` closes the one and tiles the other as a `gap_kind` run.
+/// **Both of those are reachable from ordinary input**, so under `finish` they were a panic on a
+/// public entry point:
+///
+/// - The nesting budget is the **lexer's**, not the parser's. Every `{`, `[` and `(` steps the
+///   [`Limiter`](tokora::state::tracker::Limiter) carried in the Logos `Extras`, and that
+///   tracker's inherited ceiling is tokora's *general-purpose* **500**
+///   ([`RecursionLimiter::new`](tokora::state::recursion_tracker::RecursionLimiter)), not the
+///   parser-facing 64 — nothing in this crate descends through
+///   [`InputRef::descend`](tokora::InputRef::descend), so the parser-side limiter is never
+///   consulted at all.
+/// - The **501st** simultaneously-open bracket therefore fails its lex, and a resource-limit trip
+///   *latches a poison boundary*: the scanner refuses to rebuild a lexer past that offset. No
+///   token and no diagnostic can ever cover the tail, and [`document_entry`]'s `skip_while` drain
+///   cannot reach it either — that drain is the mechanism which otherwise guarantees coverage.
+/// - So `finish` reported `UncoveredGap` and [`parse_str`] panicked, at 501 open brackets, for
+///   input an IDE produces by typing. That was smear issue #57.
+///
+/// Under this door the same parse hands back a tree over every byte (`tree.text() == source`
+/// still holds, the un-lexable tail tiled as gaps) plus the limit trip already on the diagnostic
+/// channel, which is where a consumer routes on it.
+///
+/// Nothing else is relaxed. Balance underflow, close identity, retro-wrap integrity, kind
+/// hygiene, span discipline and the token-channel wall are enforced identically through both
+/// doors, so the panic below still guards a genuine sink bug — and it now names the
+/// [`FinishError`](tokora::cst::FinishError) it refused, because a message that dropped it made
+/// #57 diagnosable only by patching this line.
+///
+/// The widening costs nothing for input that already worked: gap **placement** differs between
+/// the two doors only for a run that trails no committed token, and only when the stream is
+/// unbalanced — a shape `finish` refuses outright rather than places differently.
+///
+/// [`document_entry`]: super::document::document_entry
 pub(crate) fn finish_root(cst: LosslessCst<'_>) -> Parse {
-  let (green, emitter) = cst.finish(K::Root.raw());
-  let green = green.expect("the GraphQL lossless sink emitted a malformed event stream");
+  // `finish_partial`, NOT `finish`. See this function's `Why the partial door` note.
+  let (green, emitter) = cst.finish_partial(K::Root.raw());
+  let green = green
+    .unwrap_or_else(|e| panic!("the GraphQL lossless sink emitted a malformed event stream: {e}"));
 
   // `Verbose` exposes `diagnostics()` and nothing else — there is no `errors()` and no
   // `warnings()`. Each item carries `span()`, `labels()`, `kind()`, `severity()`, `payload()`.

--- a/smear-parser/tests/lossless_runner.rs
+++ b/smear-parser/tests/lossless_runner.rs
@@ -111,3 +111,107 @@ fn the_profile_validator_refuses_an_out_of_space_kind_at_the_emit_door() {
     "expected the sink's own kind-validator refusal message, got a different panic: {message:?}"
   );
 }
+
+/// `depth` nested selection sets, `{ a { a … } } `, four bytes per opening level.
+///
+/// The generator is spelled out rather than hard-coding a literal because the assertions below
+/// name the byte offset of one particular brace, and deriving it from the same `"{ a "` that
+/// built the string is the only way the two cannot drift.
+fn nested_selection_sets(depth: usize) -> String {
+  const OPEN: &str = "{ a ";
+  let mut src = String::with_capacity(depth * (OPEN.len() + 2));
+  for _ in 0..depth {
+    src.push_str(OPEN);
+  }
+  for _ in 0..depth {
+    src.push_str("} ");
+  }
+  src
+}
+
+/// Byte offset of the opening brace at `level` (1-based) in [`nested_selection_sets`].
+fn brace_offset(level: usize) -> usize {
+  (level - 1) * "{ a ".len()
+}
+
+/// The nesting budget is a **report**, not a panic — smear issue #57.
+///
+/// # The boundary, measured
+///
+/// **The 501st simultaneously-open bracket**, exactly. Bisected: 500 nested selection sets are
+/// accepted with no diagnostic at all and 501 trip, while `{ f(a: [[[…]]]) }` trips at 499 nested
+/// lists — its two enclosing brackets count toward the same tally, which is what identifies the
+/// budget as one global bracket-depth counter rather than anything per-production.
+///
+/// The issue reported "roughly 512" from two sampled points, and read the clean parse at 256 as
+/// the budget working at lower depths. Neither is what the code does: 256 is not a report, it is
+/// silence — nothing is consulted until the 501st bracket.
+///
+/// # Which of the two candidate defects it was
+///
+/// Neither, as the issue framed them. The budget is not the parser's: nothing in this crate
+/// descends through `InputRef::descend`, so tokora's parser-facing `RecursionLimiter` (64) is
+/// never consulted, and no amount of nesting trips it. It is the **lexer's** — every `{`, `[` and
+/// `(` steps the `Limiter` carried in the Logos `Extras`, whose inherited ceiling is tokora's
+/// general-purpose 500.
+///
+/// It does trip, and what follows the trip is what broke. A resource-limit trip **latches a
+/// poison boundary**: the scanner refuses to rebuild a lexer past that offset, so nothing — not
+/// the parse, not `document_entry`'s `skip_while` drain — can ever cover the remaining bytes.
+/// `Cst::finish` refuses that stream (`FinishError::UncoveredGap`, naming the exact byte range)
+/// and `finish_root` turned the refusal into a panic on a public entry point. So: the budget
+/// trips, and the trip was mishandled — but one layer below `finish_root`, which was only the
+/// place the mishandling surfaced.
+///
+/// # GraphQLx
+///
+/// The same three assertions hold for GraphQLx's `parse_str`, at the identical count, measured on
+/// the Phase B branch where that dialect exists. It shares this lexer's `Limiter` and this
+/// runner's materialization step, so it inherits the fix rather than needing its own; Phase B's
+/// own gates cover it.
+#[test]
+fn nesting_past_the_lexer_budget_reports_instead_of_panicking() {
+  // The last depth inside the budget: unchanged by the fix, and the control that proves the
+  // assertions below measure the boundary rather than "deep input reports".
+  let inside = nested_selection_sets(500);
+  let parse = parse_str(&inside);
+  assert!(
+    !parse.has_errors(),
+    "500 open brackets is inside the budget and must still parse clean"
+  );
+  assert!(
+    parse.diagnostics().is_empty(),
+    "500 open brackets must report nothing at all, not merely no error"
+  );
+  assert_eq!(parse.syntax().text().to_string(), inside);
+
+  // One past it. Every assertion here was unreachable before the fix: the call panicked.
+  let over = nested_selection_sets(501);
+  let parse = parse_str(&over);
+  assert!(
+    parse.has_errors(),
+    "501 open brackets must be reported, not accepted"
+  );
+  assert_eq!(
+    parse.syntax().text().to_string(),
+    over,
+    "the lossless guarantee survives the trip: the un-lexable tail tiles as gaps, so the tree \
+     still reproduces the source byte for byte"
+  );
+  let first = parse
+    .diagnostics()
+    .first()
+    .expect("the trip must be on the diagnostic channel");
+  assert_eq!(
+    first.span(),
+    brace_offset(501)..brace_offset(501) + 1,
+    "the diagnostic must sit on the brace that exceeded the budget"
+  );
+  assert_eq!(first.severity(), tokora::emitter::Severity::Error);
+
+  // Far past it, because a fix that merely moved the cliff would pass everything above.
+  let far = nested_selection_sets(2_000);
+  let parse = parse_str(&far);
+  assert!(parse.has_errors());
+  assert_eq!(parse.syntax().text().to_string(), far);
+}


### PR DESCRIPTION
Closes #57

## The boundary, measured

**The 501st simultaneously-open bracket**, exactly — bisected, not sampled.

| input shape | last depth accepted | first depth that panicked |
|---|---|---|
| `{ a { a … } }` nested selection sets | 500 | 501 |
| `{ f(a: [[[…]]]) }` nested list values | 498 | 499 |
| `{ f(a: {k: {k: …}}) }` nested object values | 498 | 499 |

The list and object shapes trip two levels earlier because their own `{` and `(`
count toward the same tally. That is what identifies the budget as **one global
bracket-depth counter**, not anything per-production.

## Two things the issue got wrong, and they matter

**"Roughly 512" is 501.** Both sampled points were misread.

**256 is not "the budget working" — it is silence.** The issue reasoned that
because 256 "reports cleanly", the limit exists and stops being honoured
somewhere before 512. It does not: at 256, and at every depth through 500,
`parse_str` returns `has_errors() == false` with **zero diagnostics**. Nothing is
consulted until the 501st bracket. There is no window in which the budget
degrades.

## Which of the two candidate defects it was

Neither, as framed. The issue asked whether the recursion budget fails to trip,
or trips and is mishandled in `finish_root`. The answer is that the budget it
named is not the one involved:

- **Not the parser's.** Nothing in this crate descends through
  `InputRef::descend`, so tokora's parser-facing `RecursionLimiter` — default
  **64** — is never consulted at all. No amount of nesting trips it.
- **It is the lexer's.** Every `{`, `[` and `(` steps the `Limiter` carried in
  the Logos `Extras` (`smear-lexer/src/handlers.rs`,
  `increase_recursion_depth_and_token`). That tracker's inherited ceiling is
  `RecursionLimiter::new()`'s *general-purpose* **500** — tokora documents these
  as two defaults for two subjects, and smear inherits the general one.

So the budget **does** trip, and what follows the trip is what broke. A
resource-limit trip **latches a poison boundary**: the scanner refuses to rebuild
a lexer past that offset. No token and no diagnostic can ever cover the remaining
bytes, and `document_entry`'s `skip_while(|_| true)` drain — the mechanism that
otherwise guarantees coverage — cannot reach them either. `Cst::finish` then
correctly refused the stream:

```
UncoveredGap { start: 2001, end: 3006 }
  source bytes 2001..3006 are covered by neither a committed token nor a
  recorded lexer-error diagnostic
```

and `finish_root` turned that refusal into a panic on a public entry point.
`finish_root` is where it surfaced, one layer above where it went wrong.

## The fix

Materialize through **`Cst::finish_partial`** instead of `Cst::finish`.

The two doors differ in exactly two refusals — an unclosed node, and an uncovered
gap. Both are *incompleteness* signals, and **both are reachable from input a
consumer did not author**, which is precisely why neither belongs behind a panic.
`finish_partial` closes the one and tiles the other as a `gap_kind` run. Every
*corruption* law — balance underflow, close identity, retro-wrap integrity, kind
hygiene, span discipline, the token-channel wall — is enforced identically
through both doors, so the panic still guards a genuine sink bug.

The panic message now names the `FinishError` it refused. Dropping it made #57
diagnosable only by patching that line locally, which is how the byte range above
was obtained.

**At 501 brackets the parse now:**
- returns a tree over every byte — `tree.text() == source` still holds, the
  un-lexable tail tiled as gaps;
- reports `has_errors() == true` with a `Severity::Error` diagnostic at
  `2000..2001`, the brace that exceeded the budget;
- does the same at depth 2 000, so the cliff was removed rather than moved.

**Input that already worked is unaffected.** Gap *placement* differs between the
two doors only for a run that trails no committed token in an *unbalanced*
stream — a shape `finish` refuses outright rather than places differently. The
487 / 703 existing tests below are the evidence.

## Discrimination proof

The test is `nesting_past_the_lexer_budget_reports_instead_of_panicking`.
Mutation: `cst.finish_partial(K::Root.raw())` → `cst.finish(K::Root.raw())`,
nothing else.

| state | result |
|---|---|
| fixed | `test … ok` — 6 passed, 0 failed |
| **panicking path restored** | **`test … FAILED`** — panicked at `runner.rs:114`, `malformed event stream: source bytes 2001..3006 are covered by neither a committed token nor a recorded lexer-error diagnostic` |
| reverted | `test … ok` — 6 passed, 0 failed |

Run independently on the Phase B branch as well (see below), where **both**
dialects' tests red under the same mutation and both go green on revert.

## GraphQLx

GraphQLx does not exist on this branch, so this PR carries a GraphQL test only.
It was nonetheless measured: on `feat/graphqlx-lossless`, where the runner has
been lifted to a shared `crate::lossless::runner`, GraphQLx's `parse_str` fails
at the **identical** count with the **identical** `UncoveredGap { 2001, 3006 }`,
and the same one-line door change fixes both. That is also what confirms the
defect is pre-existing rather than introduced by Phase B: the byte range is
byte-identical on a base that predates the lift.

GraphQLx shares this lexer's `Limiter` and this runner's materialization step, so
it inherits the fix when Phase B rebases, and Phase B's own gates exercise it.
Phase B additionally has a `test_support::open_and_never_close` probe that reaches
the panic by leaving a node open — a shape `finish_partial` now tolerates. That
probe needs repointing at a corruption shape when Phase B rebases;
`StructureWithoutTokens` (wrap a node over a nonempty source, commit no token) is
refused through both doors and works. Verified there.

## Worth flagging, not changed here

- **The trip latches for the rest of the file.** One over-deep construct near the
  top of a document voids everything after it — the tail becomes one tiled gap
  with no further diagnostics. Verified: 600 nested braces followed by an
  ordinary `query Later { ok }` yields one diagnostic and swallows the trailing
  definition. Round-trip still holds, and it is now a report rather than a crash,
  but for an IDE the remainder of the file goes dark. Latching is tokora's
  deliberate design for a poisoned lexer, so changing it is not a smear-side fix.
- **Smear sets no explicit limiter anywhere.** The 500 is inherited. It happens
  to bound parser recursion usefully — bracket nesting is GraphQL's only
  unbounded recursion source, and the lexer counts exactly `{`, `[`, `(` — so the
  parser is saved from a native stack overflow by a lexer default rather than by
  a decision. Tokora's own measurement puts a debug token driver at ~125 frames on
  a 2 MiB stack, which is why its parser-facing default is 64. That smear clears
  500 in debug says its frames are cheaper, not that 500 was chosen. An explicit,
  measured limiter is worth a separate issue.
- The token budget is `usize::MAX`, so large-but-shallow documents cannot trip
  this.

## Base

`main` is **not** a viable base for this fix: it contains no
`smear-parser/src/lossless/`, no `finish_root`, and no `graphql::lossless::parse_str`
— only the superseded `graphql/impls/lossless/` tree. `git grep finish_root`
across every remote branch hits only `feat/graphqlx-lossless` and
`feat/tokora-0.8`, and `main` is not an ancestor of either. This targets
`feat/tokora-0.8`, the branch PRs #55 and #56 merged into and the branch Phase B
is based on, so the fix rebases into Phase B rather than colliding with it.

## Gates

Isolated `CARGO_TARGET_DIR`, run on the exact committed tree.

| # | gate | rc |
|---|---|---|
| 1 | `cargo build` | 0 |
| 2 | `cargo test` | 0 — 487 passed, 0 failed, 16 ignored |
| 3 | `cargo test --all-features` | 0 — 703 passed, 0 failed, 16 ignored |
| 4 | `cargo clippy --all-targets -- -D warnings` | 0 |
| 5 | `cargo clippy --all-targets --all-features -- -D warnings` | 0 |
| 6 | `cargo fmt --check` | 0 |
| 7 | `cargo hack check -p smear-lexer --each-feature` | 0 |
| 8 | `cargo hack check -p smear-parser --each-feature` | 0 |
| 9 | `RUSTFLAGS="-Dwarnings" cargo check -p smear-parser --no-default-features --features rowan,graphqlx` | 0 |
