### PR TITLE
fix(docs): resolve the -D warnings intra-doc links, and gate them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,26 @@ on:
   push:
     branches:
       - main
+    # `**.md` used to sit in these lists. It cannot: `README.md`,
+    # `smear-lexer/README.md` and `smear-parser/README.md` are `include_str!`-ed
+    # into their crates' rustdoc, so editing one is a compile-time change to the
+    # documentation, and a broken reference-style link in a README fails the
+    # `docs` job below. Ignoring them meant the one job that can catch such a
+    # break never ran for the one change class that causes it. Only the markdown
+    # no crate compiles — `docs/` notes and the excluded `legacy/` tree — is
+    # ignored.
     paths-ignore:
-      - 'README'
       - 'COPYRIGHT'
       - 'LICENSE-*'
-      - '**.md'
+      - 'docs/**.md'
+      - 'legacy/**.md'
       - '**.txt'
   pull_request:
     paths-ignore:
-      - 'README'
       - 'COPYRIGHT'
       - 'LICENSE-*'
-      - '**.md'
+      - 'docs/**.md'
+      - 'legacy/**.md'
       - '**.txt'
   workflow_dispatch:
   schedule: [cron: "0 1 */7 * *"]
@@ -228,6 +236,81 @@ jobs:
 
     - name: Run test
       run: cargo test --all-features -- --quiet
+
+  # Build the documentation under `-D warnings`.
+  #
+  # An intra-doc link is a compile-time reference, not prose: it resolves against
+  # exactly the items the selected feature set compiles, and nothing else. That is
+  # why `--all-features` is the one configuration that *cannot* see a cross-dialect
+  # link — with both `graphql` and `graphqlx` present, every cross-dialect target
+  # resolves, and a link from one dialect's tree into the other's reads as valid.
+  # It is only a build that leaves a dialect out that has nothing to resolve to.
+  #
+  # So this job is a matrix, not a step. The `--all-features` leg catches the
+  # ordinary breakage (a private target, a renamed item, a broken README
+  # reference); the dialect-alone legs catch the isolation breach that reads like
+  # a comment. Both are needed, and neither subsumes the other: the two links this
+  # job was added for failed under `--all-features`, while the two in `smear`'s
+  # facade were invisible there and only the single-dialect legs saw them.
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - name: cargo doc --workspace --all-features
+      run: |
+        set -euo pipefail
+        TD="${CARGO_TARGET_DIR:-target}"
+        rm -rf "$TD/doc"
+        cargo doc --workspace --all-features --no-deps
+        for page in smear smear_lexer smear_parser; do
+          if [ ! -f "$TD/doc/$page/index.html" ]; then
+            echo "::error::cargo doc --workspace --all-features exited 0 but wrote no page for $page"
+            exit 1
+          fi
+        done
+    - name: cargo doc, one dialect at a time
+      run: |
+        set -euo pipefail
+        TD="${CARGO_TARGET_DIR:-target}"
+
+        # `package|features|rendered page`.
+        #
+        # Every leg is `--no-default-features` plus exactly one dialect, because a
+        # cross-dialect link is only unresolvable when the other dialect is absent.
+        # `rowan` rides along for `smear-parser` because the lossless tree — where
+        # Phase B found the first such link — is compiled out without it.
+        legs=(
+          "smear-parser|rowan,graphql|smear_parser"
+          "smear-parser|rowan,graphqlx|smear_parser"
+          "smear-lexer|graphql|smear_lexer"
+          "smear-lexer|graphqlx|smear_lexer"
+          "smear|graphql|smear"
+          "smear|graphqlx|smear"
+        )
+
+        for leg in "${legs[@]}"; do
+          IFS='|' read -r pkg features page <<< "$leg"
+          echo "::group::cargo doc -p $pkg --no-default-features --features $features"
+
+          # `required-features` makes cargo *skip* a target rather than fail it, so a
+          # feature set that selects nothing at all exits 0 having documented nothing,
+          # and a green step is not evidence the leg ran. Each leg therefore deletes
+          # its own page first and asserts it came back: the page can only exist
+          # because this leg wrote it, not because an earlier leg did.
+          rm -rf "$TD/doc/$page"
+          cargo doc -p "$pkg" --no-default-features --features "$features" --no-deps
+          if [ ! -f "$TD/doc/$page/index.html" ]; then
+            echo "::error::cargo doc -p $pkg --features $features exited 0 but documented nothing"
+            exit 1
+          fi
+
+          echo "::endgroup::"
+        done
 
   # Build with exactly the MSRV declared in Cargo.toml's `rust-version`, so
   # a floor that silently drifts above the declared value is caught here

--- a/README.md
+++ b/README.md
@@ -206,5 +206,6 @@ shall be dual licensed as above, without any additional terms or conditions.
 
 [Github-url]: https://github.com/al8n/smear/
 [CI-url]: https://github.com/al8n/smear/actions/workflows/ci.yml
+[codecov-url]: https://app.codecov.io/gh/al8n/smear
 [doc-url]: https://docs.rs/smear
 [crates-url]: https://crates.io/smear

--- a/smear-parser/src/graphql/lossless/runner.rs
+++ b/smear-parser/src/graphql/lossless/runner.rs
@@ -153,10 +153,10 @@ pub mod test_support {
   /// (`tokora/src/parser/node.rs`'s own `wrap`) — with `kind` standing in for a production's.
   /// `'inp` is named and threaded from `src`, not elided, for the reason `trivia.rs`'s driver
   /// and `lossless_drivers!` both record: a closure's parameter type is spelled out explicitly
-  /// (see [`TestInput`]), and an elided lifetime there is free to be inferred shorter than the
-  /// source's, which the borrow checker then refuses. Nothing else in the crate calls this; it
-  /// exists for `tests/lossless_runner.rs`'s validator-discrimination test, which always passes
-  /// `""` — the node this probes wraps zero tokens either way.
+  /// (the private `TestInput` alias above), and an elided lifetime there is free to be inferred
+  /// shorter than the source's, which the borrow checker then refuses. Nothing else in the crate
+  /// calls this; it exists for `tests/lossless_runner.rs`'s validator-discrimination test, which
+  /// always passes `""` — the node this probes wraps zero tokens either way.
   ///
   /// # Panics
   ///

--- a/smear-parser/src/ty.rs
+++ b/smear-parser/src/ty.rs
@@ -16,8 +16,13 @@ use crate::path::Path;
 
 /// A named type reference with an optional non-null modifier.
 ///
-/// Vanilla GraphQL names its type references directly; GraphQLx uses
-/// [`DefinitionTypePath`] instead, since its type references are namespaced.
+/// Vanilla GraphQL names its type references directly; GraphQLx namespaces them and uses this
+/// module's `DefinitionTypePath` instead, surfaced publicly as `graphqlx::ast::DefinitionTypePath`.
+///
+/// Both are code spans and not intra-doc links, deliberately. This module is private, so the
+/// carrier has no public path to link to; and it is `graphqlx`-gated while this type is
+/// `graphql`-gated, so under `graphql` alone there is no item in scope to resolve against at all.
+/// A link here is a hard error under `RUSTDOCFLAGS="-D warnings"`, in both configurations.
 #[cfg(feature = "graphql")]
 #[derive(Debug, Clone, Copy)]
 pub struct NamedType<Name, Span = SimpleSpan> {

--- a/smear/src/lib.rs
+++ b/smear/src/lib.rs
@@ -15,8 +15,15 @@
 /// - `lossless` — preserves every byte of trivia. For formatters, linters, IDEs and
 ///   syntax highlighters, where the source must round-trip exactly.
 ///
-/// Available dialects are [`graphql`](lexer::graphql) and, under the `graphqlx`
-/// feature, [`graphqlx`](lexer::graphqlx).
+/// A dialect is a module only in a build that enables its feature, so each link below is gated
+/// to the build that has something to link to. Ungated, they are `unresolved link` errors under
+/// `RUSTDOCFLAGS="-D warnings"` in every single-dialect configuration — the failure the `docs`
+/// CI job's dialect-alone legs exist to catch.
+///
+/// Available dialects:
+///
+#[cfg_attr(feature = "graphql", doc = "- [`graphql`](lexer::graphql)")]
+#[cfg_attr(feature = "graphqlx", doc = "- [`graphqlx`](lexer::graphqlx)")]
 pub use smear_lexer as lexer;
 
 /// Parsers for GraphQL and GraphQL-like DSLs.
@@ -25,9 +32,14 @@ pub use smear_lexer as lexer;
 /// that build AST nodes from the token streams produced by [`lexer`], composed with
 /// the `tokora` combinator library.
 ///
-/// Available dialects are [`graphql`](parser::graphql) and, under the `graphqlx`
-/// feature, [`graphqlx`](parser::graphqlx) — the latter adding imports, generics,
-/// where-clauses, map and set types, and namespaced paths on top of GraphQL.
+/// Available dialects, each link gated on its feature for the reason recorded on [`lexer`]:
+///
+#[cfg_attr(feature = "graphql", doc = "- [`graphql`](parser::graphql)")]
+#[cfg_attr(
+  feature = "graphqlx",
+  doc = "- [`graphqlx`](parser::graphqlx) — adds imports, generics, where-clauses, map and set \
+         types, and namespaced paths on top of GraphQL."
+)]
 pub use smear_parser as parser;
 
 #[doc(hidden)]


### PR DESCRIPTION
`RUSTDOCFLAGS="-D warnings" cargo doc` exited **101** on two intra-doc links. Fixing them is the smaller half. The reason they survived is that no CI job built the docs under `-D warnings`, so this adds the job that does — and the job then found **three more** that the two known ones were masking.

The issue records `graphql/lossless/runner.rs` as frozen and therefore not fixable. Phase B has merged, the freeze is over, and both original links are in scope.

## Why five sites and three different fixes

An intra-doc link is a compile-time reference, not prose: it resolves against exactly the items the selected feature set compiles, and nothing else. That is why the right fix is not the same twice.

### Private or absent target → code span

**`smear-parser/src/ty.rs`** — `NamedType` linked `` [`DefinitionTypePath`] ``.

`mod ty` is private, so under `--all-features` rustdoc reports *"public documentation for `NamedType` links to private item `DefinitionTypePath`"*. But it is worse than the issue recorded: the carrier is `graphqlx`-gated while `NamedType` is `graphql`-gated, so under `--features rowan,graphql` the error is *"unresolved link … no item named `DefinitionTypePath` in scope"* — the target is not merely private, it is absent.

No link can resolve in both configurations, so **making the target reachable is not available here**. The name is a code span, and the public specialisation (`graphqlx::ast::DefinitionTypePath`) is named in prose so a reader still knows where to look.

**`smear-parser/src/graphql/lossless/runner.rs`** — `open_raw_kind` linked the private `TestInput` alias.

The GraphQLx twin of this same file already carries the corrected form — *"a closure's parameter type is spelled out explicitly (the private `TestInput` alias above)"*. The GraphQL copy kept the un-corrected `` (see [`TestInput`]) ``. This makes the two match word for word; the convention was already in the repo, on the sibling file.

### Cross-dialect target → feature-gated link

**`smear/src/lib.rs`** (two sites) — the `lexer` and `parser` re-exports each linked *both* `graphql` and `graphqlx`. Both resolve under `--all-features`; **neither resolves in a single-dialect build**.

These are the crate's front door and worth keeping as links in the build that publishes, so instead of demoting them, each moved behind `#[cfg_attr(feature = "…", doc = "…")]` and now exists only in a build where its target does. This is the crate's own idiom — `smear-parser/src/lib.rs` already gates a whole doctest this way.

### Broken reference-style link → add the definition

**`README.md`** — the codecov badge used `][codecov-url]` with no `[codecov-url]:` definition, so rustdoc read it as an unresolved intra-doc link inside `smear`'s crate docs (`#![doc = include_str!("../../README.md")]`). Every other badge has one. Only visible once `smear-parser` stopped failing first.

## The gate

A new `docs` job, `RUSTDOCFLAGS: -D warnings`. It is a **matrix, not a step**, because `--all-features` is the one configuration that *cannot* see a cross-dialect link: with both dialects present, every cross-dialect target resolves and the breach reads as valid.

| leg | catches |
|---|---|
| `cargo doc --workspace --all-features --no-deps` | private targets, renamed items, broken README references |
| `-p smear-parser --no-default-features --features rowan,graphql` | cross-dialect links out of the GraphQL tree |
| `-p smear-parser … --features rowan,graphqlx` | cross-dialect links out of the GraphQLx tree |
| `-p smear-lexer … --features graphql` / `graphqlx` | same, in the lexer's dialect split |
| `-p smear … --features graphql` / `graphqlx` | same, in the facade |

`rowan` rides along on the `smear-parser` legs because the lossless tree — where Phase B found the first such link — is compiled out without it.

**Two hazards this repo has earned, handled explicitly.**

`required-features` *skips* a target rather than failing it, so a leg whose features select nothing exits 0 having documented nothing and reports success. Each leg therefore deletes its own rendered page before building and asserts it came back — the page can only exist because that leg wrote it, not because an earlier leg did. Nothing is read into a variable that could come back empty.

`**.md` also had to leave `paths-ignore`. `README.md`, `smear-lexer/README.md` and `smear-parser/README.md` are `include_str!`-ed into their crates' rustdoc, so editing one is a compile-time change to the documentation. The README defect above is precisely the class the ignore rule was hiding from the only job that can catch it. Markdown no crate compiles — `docs/` notes, the excluded `legacy/` tree — stays ignored.

## Discrimination proof

A gate that has only ever been green proves nothing. The job's two `run:` blocks were **extracted verbatim from the YAML** and executed under `bash -e`, unmodified, against four planted defects. Each was reverted afterwards and the tree re-verified clean.

| probe | all-features leg | dialect-alone legs | evidence |
|---|---|---|---|
| **A** — reinstate the original `ty.rs` link | **101** | **101** | both name `smear-parser/src/ty.rs:20`; all-features says *private item*, `rowan,graphql` says *unresolved* |
| **B** — plant a fresh cross-dialect link (`graphqlx/lossless/ast/mod.rs` → `crate::graphql::lossless::ast`), the exact Phase B shape | **0**, and **zero errors** | **101** | fails at the `rowan,graphqlx` leg: *"no item named `graphql` in module `smear_parser`"*, with file, line and column |
| **C** — make a leg document nothing (`[lib] doc = false` on `smear`) | — | **1**, from the guard | rustdoc reported **0** errors and cargo exited 0; the guard fired: `::error::cargo doc -p smear --features graphql exited 0 but documented nothing` |
| **D** — remove the `[codecov-url]` definition again | **101** | — | names `smear/src/../../README.md:11` |

**Probe B is the one that justifies the matrix**: the `--all-features` leg was not merely green, it emitted zero diagnostics, while the dialect-alone leg named the file and column. **Probe C is the one that justifies the assertion**: the leg was green from cargo's point of view and the guard is what turned it red.

Green run, for contrast: all six dialect legs printed `Documenting <pkg>` and `Generated …/index.html`, so every leg genuinely invoked rustdoc rather than being skipped as fresh.

## Gates — all rc=0

| gate | rc |
|---|---|
| `cargo build` | 0 |
| `cargo test` | 0 |
| `cargo test --all-features` | 0 |
| `cargo clippy --all-targets -- -D warnings` | 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | 0 |
| `cargo fmt --check` | 0 |
| `cargo hack check -p smear-lexer --each-feature` | 0 (13/13) |
| `cargo hack check -p smear-parser --each-feature` | 0 (14/14) |
| `RUSTFLAGS="-Dwarnings" cargo check -p smear-parser --no-default-features --features rowan,graphqlx` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p smear-parser --no-default-features --features rowan,graphqlx --no-deps` | 0 |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p smear-parser --no-default-features --features rowan,graphql --no-deps` | 0 |

`cargo test --all-features` measured against trunk `69fd677` before any edit: **926 passed, 0 failed** both before and after, with an identical per-suite breakdown. `actionlint` reports exactly the same nine pre-existing findings on this workflow as it does on trunk's — the new job adds none.

## Not fixed here

- `[crates-url]: https://crates.io/smear` in `README.md` should be `https://crates.io/crates/smear`. It is a wrong destination, not a broken reference, so no doc gate can see it — out of scope for this PR rather than a drive-by.
- No crate declares `[package.metadata.docs.rs]`, so the `#[cfg_attr(docsrs, doc(cfg(…)))]` attributes in `smear-lexer/src/lib.rs` are inert on docs.rs as well as in CI. That is tokora #195's family, named in the issue as *related* rather than in scope, and it wants its own change.

Closes #62
