### PR TITLE
refactor(parser): gate test_support behind a feature, not doc(hidden)

### DIFF
--- a/smear-parser/Cargo.toml
+++ b/smear-parser/Cargo.toml
@@ -34,6 +34,22 @@ rowan = ["dep:rowan", "tokora/rowan", "std"]
 # compiled at all.
 lossless-coverage = ["rowan"]
 
+# Compiles the lossless suites' `test_support` scaffolding: the substrate's kind-space
+# conformance assertion, the two dialects' sink and trivia probes, and the 68 per-production
+# `fn(&str) -> Parse` drivers `lossless_drivers!` generates. Every one of them is reachable only
+# from an integration test in `tests/`, which is a separate crate and therefore sees `pub` and
+# nothing else — so `#[cfg(test)]` and `pub(crate)` are both out of reach and a feature is the
+# only door. Off, none of it is compiled and none of it is public API.
+#
+# Deliberately does NOT imply `rowan`. All of it lives inside the `rowan`-gated lossless tower,
+# so with `rowan` off there is nothing for this feature to expose; implying it would drag the
+# whole tower into `cargo test`'s default-feature row, which today compiles the lossless suites
+# to nothing on purpose.
+#
+# `smear-parser`'s own tests get it from the self dev-dependency below, not from a
+# `required-features` entry. See that block for why.
+test-support = []
+
 [dependencies]
 derive_more.workspace = true
 tokora.workspace = true
@@ -45,6 +61,22 @@ smallvec = { version = "1", default-features = false, features = ["const_new"], 
 rowan = { version = "0.16", optional = true }
 
 [dev-dependencies]
+# The crate depending on itself, so `test-support` is on for every dev target — tests, benches,
+# examples, doctests — and off for every consumer.
+#
+# **Not `required-features`.** An unsatisfied `required-features` entry makes cargo *skip* the
+# target: it compiles nothing, prints nothing, and the run is green. Thirty-three test targets
+# gated that way would go silently empty the first time somebody ran `cargo test` without
+# remembering the feature, and no exit code would say so. A dev-dependency inverts that — the
+# feature is enabled by the manifest itself, so there is no invocation in which a test target
+# both exists and cannot see the scaffolding, and nothing to forget.
+#
+# A dev-dependency cycle is explicitly allowed by cargo (dev-dependencies are not used to build
+# the library itself), and resolver v2/v3 keeps dev-only features out of a plain `cargo build`.
+# Path-only and version-less on purpose: cargo drops such a dependency when packaging, so the
+# published manifest does not name a version of itself.
+smear-parser = { path = ".", features = ["test-support"] }
+
 criterion = "0.8"
 apollo-parser = "0.8.6"
 graphql-parser = "0.4.1"

--- a/smear-parser/src/graphql/lossless/document.rs
+++ b/smear-parser/src/graphql/lossless/document.rs
@@ -350,6 +350,9 @@ lossless_production! {
   ///
   /// [`definition`] without the three executable arms — which is the whole difference between a
   /// `TypeSystemDocument` and a `Document`.
+  // Reached only from `type_system_document`, itself reached only from a driver — see
+  // `lossless_drivers!` on why the allow is narrowed to the gate rather than written bare.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn type_system_definition_or_extension<'inp, Src, Ctx>(inp) {
     let head = peek_kind::<Src, Ctx>(inp)?;
     let mark = inp.cst_mark();
@@ -419,6 +422,9 @@ lossless_production! {
   ///
   /// Not reachable from [`parse_str`](super::parse_str), which parses the mixed form; the driver
   /// under `test_support` is its entry, and a schema-only consumer would call it directly.
+  // Which makes the driver its only caller, so the gate takes its last one — see
+  // `lossless_drivers!`.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn type_system_document<'inp, Src, Ctx>(inp) {
     node(
       K::TypeSystemDocument.raw(),

--- a/smear-parser/src/graphql/lossless/executable.rs
+++ b/smear-parser/src/graphql/lossless/executable.rs
@@ -208,6 +208,9 @@ lossless_production! {
   /// Dispatch on the definition head, reading an optional leading description first. Opens
   /// **no** node of its own; the chosen production spends the mark on its own — and this is one
   /// of the two places the contextual keywords are read.
+  // Reached only from `executable_document`, itself reached only from a driver — see
+  // `lossless_drivers!` on why the allow is narrowed to the gate rather than written bare.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn executable_definition<'inp, Src, Ctx>(inp) {
     // The head peek first — see `document::definition` for the ruling and for the measurement
     // that shows the ordering is currently redundant, every caller being a loop that peeks.
@@ -238,6 +241,9 @@ lossless_production! {
   /// The empty form is reported: `syntactic/` rejects an empty input ("one-or-more, so an empty
   /// input errors"), and gate 1 compares verdicts. The node is opened either way, so a caller
   /// always finds a document to walk.
+  // The executable-only root, off `parse_str`'s mixed-form path; its driver is its only caller
+  // and the gate takes it — see `lossless_drivers!`.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn executable_document<'inp, Src, Ctx>(inp) {
     node(
       K::ExecutableDocument.raw(),

--- a/smear-parser/src/graphql/lossless/recover.rs
+++ b/smear-parser/src/graphql/lossless/recover.rs
@@ -95,6 +95,9 @@ pub(crate) const VARIABLE_DEFINITION_HEADS: &[Kind] = &[Kind::Dollar];
 /// description, the `{` of a shorthand operation, or the
 /// `query`/`mutation`/`subscription`/`fragment` keyword — an `Identifier` to the lexer, which
 /// is why the set cannot be finer than this.
+// Named only by the executable-only root and its dispatcher, both of which are reached only from
+// a `test_support` driver — see `lossless_drivers!`.
+#[cfg_attr(not(feature = "test-support"), allow(dead_code))]
 pub(crate) const EXECUTABLE_DEFINITION_HEADS: &[Kind] = &[
   Kind::InlineString,
   Kind::BlockString,

--- a/smear-parser/src/graphql/lossless/runner.rs
+++ b/smear-parser/src/graphql/lossless/runner.rs
@@ -3,8 +3,11 @@
 
 use tokora::{
   Source,
-  cst::{Cst, CstProfile, KindValidator, Sink, parse_lossless},
+  cst::{Cst, CstProfile, KindValidator, parse_lossless},
 };
+// `Sink` is named only by `LosslessSink`, which the drivers alone use.
+#[cfg(feature = "test-support")]
+use tokora::cst::Sink;
 
 use super::{GraphqlLosslessLexer, GraphqlLosslessSlice, GraphqlLosslessToken};
 use crate::{graphql::kinds::SyntaxKind as K, lossless::KindSpace};
@@ -54,6 +57,10 @@ pub(crate) type LosslessEmitter<'inp> = tokora::emitter::Verbose<
 /// Named only as the emitter half of a driver's **context pair** — `Sink::new` is tokora-private,
 /// so the one way to mint one is [`parse_lossless`], which takes the source once and uses that
 /// same argument for the sink and the input.
+///
+/// Which is why it is gated with the drivers: the shipped [`parse_str`] path names
+/// [`LosslessCst`] and never this, so with `test-support` off it has no reference at all.
+#[cfg(feature = "test-support")]
 pub(crate) type LosslessSink<'inp> =
   Sink<'inp, GraphqlLosslessLexer<'inp, str>, LosslessEmitter<'inp>>;
 
@@ -129,6 +136,11 @@ pub fn parse_str(src: &str) -> Parse {
 /// sink a kind no production would ever construct. This module is that caller — a direct spend
 /// of the sink's own retro-wrap door, through the crate's real, shipped `profile()`, so the
 /// validator under test is the one every parse actually runs.
+///
+/// Behind `feature = "test-support"`, and hidden even then: both entry points exist to build a
+/// tree the grammar cannot produce, and one of them panics by design. `pub` is forced only
+/// because `tests/lossless_runner.rs` is a separate crate.
+#[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub mod test_support {
   use tokora::{InputRef, cache::DefaultCache};

--- a/smear-parser/src/graphql/lossless/trivia.rs
+++ b/smear-parser/src/graphql/lossless/trivia.rs
@@ -196,6 +196,11 @@ where
 /// **This module is where the atoms stop being generic.** The atoms above name only the
 /// projections; these drivers must choose a concrete source, emitter and context to build a
 /// `Sink` at all, exactly as [`super::runner::parse_str`] does.
+///
+/// Behind `feature = "test-support"`, and hidden even then. `pub` is forced only because
+/// `tests/lossless_trivia_atoms.rs` is a separate crate; the drivers themselves name this
+/// dialect's concrete lexer and are of no use to anyone outside it.
+#[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub mod test_support {
   use std::{

--- a/smear-parser/src/graphqlx/lossless/definition.rs
+++ b/smear-parser/src/graphqlx/lossless/definition.rs
@@ -693,6 +693,10 @@ lossless_production! {
 
   /// Dispatch on a type-system definition's keyword, reading an optional leading description
   /// first. Opens **no** node of its own; the chosen production spends the mark on its own.
+  // The document dispatchers all enter at `type_system_definition_at` with a mark they already
+  // minted; this description-reading wrapper is reached only from a driver — see
+  // `lossless_drivers!` on why the allow is narrowed to the gate rather than written bare.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn type_system_definition<'inp, Src, Ctx>(inp) {
     // The head peek first, so the leading trivia it crosses is committed before the mark is minted
     // and therefore lands outside whatever the mark eventually wraps.

--- a/smear-parser/src/graphqlx/lossless/document.rs
+++ b/smear-parser/src/graphqlx/lossless/document.rs
@@ -120,6 +120,9 @@ lossless_production! {
 
   /// One entry of an [`executable_document`](super::executable::executable_document): an import or
   /// a described executable definition.
+  // Reached only from `executable::executable_document`, itself reached only from a driver — see
+  // `lossless_drivers!` on why the allow is narrowed to the gate rather than written bare.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn import_or_executable_definition<'inp, Src, Ctx>(inp) {
     let head = peek_kind::<Src, Ctx>(inp)?;
     let mark = inp.cst_mark();
@@ -138,6 +141,9 @@ lossless_production! {
 
   /// One entry of a [`type_system_document`]: an import, an extension, or a described type-system
   /// definition.
+  // Reached only from `type_system_document`, itself reached only from a driver — see
+  // `lossless_drivers!`.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn import_or_type_system_definition_or_extension<'inp, Src, Ctx>(inp) {
     let head = peek_kind::<Src, Ctx>(inp)?;
     let mark = inp.cst_mark();
@@ -194,6 +200,9 @@ lossless_production! {
   /// [`document`]'s loop over the SDL-only dispatcher, written out rather than shared: a
   /// higher-ranked `fn` parameter would be the only way to abstract over the three dispatchers, and
   /// it buys eight lines at the cost of a signature no reader can check at a glance.
+  // The SDL-only root, off `parse_str`'s mixed-form path; its driver is its only caller and the
+  // gate takes it — see `lossless_drivers!`.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn type_system_document<'inp, Src, Ctx>(inp) {
     node(
       K::TypeSystemDocument.raw(),

--- a/smear-parser/src/graphqlx/lossless/executable.rs
+++ b/smear-parser/src/graphqlx/lossless/executable.rs
@@ -334,6 +334,9 @@ lossless_production! {
   /// walk. This loop's terminating peek is also what crosses the trailing trivia, which therefore
   /// lands inside the document — a document *is* the whole file, so that is the right answer
   /// rather than a tolerated one.
+  // The executable-only root, off `parse_str`'s mixed-form path; its driver is its only caller
+  // and the gate takes it — see `lossless_drivers!`.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn executable_document<'inp, Src, Ctx>(inp) {
     node(
       K::ExecutableDocument.raw(),

--- a/smear-parser/src/graphqlx/lossless/extension.rs
+++ b/smear-parser/src/graphqlx/lossless/extension.rs
@@ -253,6 +253,9 @@ lossless_production! {
   /// [`type_system_extension`] instead. Only the drivers and a direct consumer reach this door;
   /// `document.rs`'s dispatchers mint their own mark before the `extend`, because the same mark
   /// has to be able to cover a description on the *other* branch.
+  // "Only the drivers and a direct consumer" is one caller, the drivers being `pub(crate)`'s only
+  // reach — so the gate takes it. See `lossless_drivers!`.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn extension<'inp, Src, Ctx>(inp) {
     peek_kind::<Src, Ctx>(inp)?;
     let mark = inp.cst_mark();

--- a/smear-parser/src/graphqlx/lossless/recover.rs
+++ b/smear-parser/src/graphqlx/lossless/recover.rs
@@ -177,6 +177,9 @@ pub(crate) const DEFINITION_HEADS: &[Kind] = &[
 ];
 
 /// The token kinds an executable-document entry may begin with.
+// Named only by the executable-only root's dispatcher, reached only from a `test_support`
+// driver — see `lossless_drivers!`.
+#[cfg_attr(not(feature = "test-support"), allow(dead_code))]
 pub(crate) const EXECUTABLE_ENTRY_HEADS: &[Kind] = &[
   Kind::InlineString,
   Kind::BlockString,
@@ -186,6 +189,9 @@ pub(crate) const EXECUTABLE_ENTRY_HEADS: &[Kind] = &[
 
 /// The token kinds a type-system-document entry may begin with — no `{`, the shorthand operation
 /// not being a type-system definition.
+// Named only by the SDL-only root and its dispatcher, reached only from a `test_support`
+// driver — see `lossless_drivers!`.
+#[cfg_attr(not(feature = "test-support"), allow(dead_code))]
 pub(crate) const TYPE_SYSTEM_ENTRY_HEADS: &[Kind] =
   &[Kind::InlineString, Kind::BlockString, Kind::Identifier];
 

--- a/smear-parser/src/graphqlx/lossless/runner.rs
+++ b/smear-parser/src/graphqlx/lossless/runner.rs
@@ -3,8 +3,11 @@
 
 use tokora::{
   Source,
-  cst::{Cst, CstProfile, KindValidator, Sink, parse_lossless},
+  cst::{Cst, CstProfile, KindValidator, parse_lossless},
 };
+// `Sink` is named only by `LosslessSink`, which the drivers alone use.
+#[cfg(feature = "test-support")]
+use tokora::cst::Sink;
 
 use super::{GraphqlxLosslessLexer, GraphqlxLosslessSlice, GraphqlxLosslessToken};
 use crate::{graphqlx::kinds::SyntaxKind as K, lossless::KindSpace};
@@ -54,6 +57,10 @@ pub(crate) type LosslessEmitter<'inp> = tokora::emitter::Verbose<
 /// Named only as the emitter half of a driver's **context pair** — `Sink::new` is tokora-private,
 /// so the one way to mint one is [`parse_lossless`], which takes the source once and uses that
 /// same argument for the sink and the input.
+///
+/// Which is why it is gated with the drivers: the shipped [`parse_str`] path names
+/// [`LosslessCst`] and never this, so with `test-support` off it has no reference at all.
+#[cfg(feature = "test-support")]
 pub(crate) type LosslessSink<'inp> =
   Sink<'inp, GraphqlxLosslessLexer<'inp, str>, LosslessEmitter<'inp>>;
 
@@ -135,6 +142,11 @@ pub fn parse_str(src: &str) -> Parse {
 /// hands the sink a kind no production would ever construct. This module is that caller — a direct
 /// spend of the sink's own retro-wrap door, through the crate's real, shipped `profile()`, so the
 /// validator under test is the one every parse actually runs.
+///
+/// Behind `feature = "test-support"`, and hidden even then: both entry points exist to build a
+/// tree the grammar cannot produce, and one of them panics by design. `pub` is forced only
+/// because `tests/lossless_x_runner.rs` is a separate crate.
+#[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub mod test_support {
   use tokora::{InputRef, cache::DefaultCache};

--- a/smear-parser/src/graphqlx/lossless/trivia.rs
+++ b/smear-parser/src/graphqlx/lossless/trivia.rs
@@ -235,6 +235,11 @@ where
 /// `peek_keyword_of` and `try_eat_bang_of` — cover `peek_as` and `try_eat`, which GraphQL leaves
 /// to be exercised by its productions. GraphQLx has no productions yet, and an atom whose only
 /// witness is a production that does not exist is an atom with no witness.
+///
+/// Behind `feature = "test-support"`, and hidden even then. `pub` is forced only because
+/// `tests/lossless_x_trivia_atoms.rs` is a separate crate; the drivers themselves name this
+/// dialect's concrete lexer and are of no use to anyone outside it.
+#[cfg(feature = "test-support")]
 #[doc(hidden)]
 pub mod test_support {
   use std::{

--- a/smear-parser/src/graphqlx/lossless/ty.rs
+++ b/smear-parser/src/graphqlx/lossless/ty.rs
@@ -248,6 +248,9 @@ lossless_production! {
   /// [`path`]'s `expect` returns `Err` on a head that is neither a name nor a `::`, which aborts
   /// every enclosing production. This is the door a *list* of paths uses, where one bad member
   /// must cost one `Error` node and not the list.
+  // No list production names it yet, so its driver is its only caller and the gate takes it —
+  // see `lossless_drivers!` on why the allow is narrowed to the gate rather than written bare.
+  #[cfg_attr(not(feature = "test-support"), allow(dead_code))]
   fn path_or_recover<'inp, Src, Ctx>(inp) {
     match peek_kind::<Src, Ctx>(inp)? {
       Some(Kind::Identifier | Kind::PathSeparator) => path::<Src, Ctx>(inp),

--- a/smear-parser/src/lossless/macros.rs
+++ b/smear-parser/src/lossless/macros.rs
@@ -244,6 +244,31 @@ macro_rules! lossless_production {
 ///   fn parse_operation_definition => operation_definition (mark);
 /// }
 /// ```
+///
+/// # The generated module is behind `feature = "test-support"`
+///
+/// It was `#[doc(hidden)] pub` and nothing else, which hides a module from rustdoc and ships it
+/// anyway: sixteen modules and sixty-eight `fn(&str) -> Parse` entry points, public, callable and
+/// semver-relevant in every `rowan` build. The gate is written here, once, rather than at sixteen
+/// call sites.
+///
+/// **`pub` and not `pub(crate)`** because every consumer is a file under `tests/`, which cargo
+/// compiles as its own crate and which therefore sees exactly the shipped public surface.
+/// `#[cfg(test)]` cannot reach an integration test either. A feature is the only door that both
+/// lets `tests/` in and keeps a consumer out.
+///
+/// # Fourteen items the drivers were keeping alive
+///
+/// Gating the modules turned up productions whose **only** caller was a driver — the two SDL-only
+/// and executable-only document roots and their dispatchers, GraphQLx's `extension` and
+/// `path_or_recover`, and the three recovery head lists that only those productions name. They are
+/// real productions, deliberately not on `parse_str`'s path (each says so in its own docs), and
+/// they are `pub(crate)`, so with the drivers gone nothing in a shipped build can reach them.
+///
+/// Each carries `#[cfg_attr(not(feature = "test-support"), allow(dead_code))]` rather than a bare
+/// `allow`: the lint stays live in the configuration that has callers, so a driver that stops
+/// calling one is still reported. The alternative — one module-wide `allow` — would blanket four
+/// thousand lines and hide the next genuinely dead production.
 macro_rules! lossless_drivers {
   (
     dialect = $dm:ident::$dl:ident;
@@ -256,6 +281,13 @@ macro_rules! lossless_drivers {
     )*
   ) => {
     $(#[$modmeta])*
+    // The sixteen driver modules the two suites declare, gated at the one place that writes them
+    // all. `#[doc(hidden)]` alone left every one of them in the shipped `rowan` build — public,
+    // callable and semver-relevant — for the benefit of `tests/`, which is a separate crate and
+    // therefore cannot see anything less than `pub`. The feature removes them from the build
+    // instead of merely from the docs; `doc(hidden)` stays because they are not API even when a
+    // consumer opts in.
+    #[cfg(feature = "test-support")]
     #[doc(hidden)]
     pub mod $modname {
       #[allow(unused_imports)]

--- a/smear-parser/src/lossless/mod.rs
+++ b/smear-parser/src/lossless/mod.rs
@@ -60,8 +60,14 @@ pub(crate) use macros::{
 /// The three bookkeeping kinds and the raw round-trip are needed in four unrelated places — the
 /// sink profile, the kind validator, the coverage tally's width, and `rowan::Language` — and
 /// threading four values through four call chains is how they drift apart. Naming them once is
-/// also what lets [`test_support::assert_kind_space_is_well_formed`] be written once instead of
-/// three times per dialect.
+/// also what lets `test_support::assert_kind_space_is_well_formed` — behind
+/// `feature = "test-support"` — be written once instead of three times per dialect.
+///
+/// The reference is deliberately **not** an intra-doc link: the item it names is compiled only
+/// under that feature, and a link to a `cfg`-gated item is a `broken_intra_doc_links` warning in
+/// every build that does not enable it. `tests/lossless_isolation.rs` records the same failure
+/// mode from the other direction — a doc link is a compile-time reference, and gating the item
+/// without gating the link moves the breakage into `cargo doc`.
 ///
 /// # The invariants, and which one is load-bearing for what
 ///
@@ -103,8 +109,26 @@ pub trait KindSpace: Copy + Eq + core::fmt::Debug + 'static {
   fn from_raw(raw: u16) -> Option<Self>;
 }
 
-/// Test-only scaffolding. Nothing in the crate calls it.
-#[doc(hidden)]
+/// The conformance assertion for a [`KindSpace`] impl, behind `feature = "test-support"`.
+///
+/// # Why this one is documented where the dialects' scaffolding is hidden
+///
+/// [`KindSpace`] is a public, unsealed trait, and it is the substrate's extension point: the
+/// module header's whole claim is that these pieces are usable without naming a dialect, and a
+/// third dialect — in this crate or outside it — becomes one by implementing it. Its invariants
+/// are stated in prose four paragraphs up and enforced nowhere else, which is precisely the shape
+/// that a downstream implementor gets wrong and finds out about as a panic inside the sink's kind
+/// validator. So the check ships, as something a consumer may opt into, rather than being hidden
+/// from the docs of the trait it belongs to.
+///
+/// Everything under a *dialect's* `lossless` module named `test_support` is the opposite case —
+/// drivers over one concrete grammar, several of which build deliberately corrupt trees — and
+/// stays `#[doc(hidden)]` under the same feature.
+///
+/// The whole module is compiled only under the feature; nothing in a default build, and nothing
+/// in a plain `rowan` build, contains it.
+#[cfg(feature = "test-support")]
+#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]
 pub mod test_support {
   use super::KindSpace;
 


### PR DESCRIPTION
Closes #59.
