### PR TITLE
bench: port the apollo-comparison harness to tokora main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,52 @@ jobs:
     - name: cargo build --workspace --all-features
       run: cargo build --workspace --all-features
 
+  # ── THE BYTE-IDENTITY GATE ──────────────────────────────────────────────────────────────────
+  #
+  # Recomputes the four corpus tree hashes (`benchmarks/tests/byte_identity.rs`) and fails if any
+  # has moved. Before this job the four values lived in a GitHub issue and a commit message, so a
+  # change that re-shaped every tree in the corpus went green through every gate in the repository.
+  #
+  # WHY HERE, and not in `macos.yml` or `miri.yml`. Those two exist to hold legs that are
+  # queue-bound or slow, so that `CI` can reach a conclusion — see their headers. This gate is
+  # neither: it is ten seconds of pure computation whose verdict is a property of the parser's
+  # output, not of the host. Putting it behind the macOS queue would mean a moved hash surfaces
+  # hours after the pull request that moved it, and a second OS row would buy no extra information
+  # because the dump is byte-identical across platforms by construction (the escape is a fixed
+  # `char::is_control` test, deliberately not a drifting Unicode table). One Linux job, on `CI`,
+  # where a red is readable on the pull request that caused it.
+  #
+  # WHY `--release`. Not a preference. The `prefixes` corpus is ~9,300 documents and ~45 million
+  # lines of dump; in an unoptimised build it does not finish inside ten minutes, while in release
+  # all four corpora hash in about ten seconds. That is also why the test carries `#[ignore]` and
+  # why `--include-ignored` is spelled out here: `cargo test` defaults to debug, so the expensive
+  # corpus is opted into exactly once, in the one place that runs it in release. The three cheap
+  # corpora are additionally covered by the ordinary `test` job above, which needs no opt-in.
+  #
+  # WHY `--test byte_identity` RATHER THAN A FILTER. A cargo target filter that matches nothing
+  # warns and exits 0; a named `--test` target that has been renamed or deleted is a hard error.
+  # This job must fail loudly if the gate stops existing, which is the failure mode that would
+  # otherwise leave a green tick over no coverage at all.
+  byte-identity:
+    name: byte-identity
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - name: Cache cargo build and registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-byte-identity-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-byte-identity-
+    - name: cargo test --release --test byte_identity -- --include-ignored
+      run: cargo test -p smear-apollo-bench --release --test byte_identity -- --include-ignored
+
   # `needs:` is unchanged, but its effect is not. Every matrix named below used to contain a
   # `macos-latest` cell, so on a run where those cells never got a runner this job was never
   # created at all — it does not appear in the job list of #64's or #66's run. With the macOS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "benchmarks",
   "smear",
   "smear-lexer",
   "smear-parser",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -27,11 +27,16 @@ smear-parser = { path = "../smear-parser", version = "0.0.0", default-features =
 ] }
 tokora.workspace = true
 apollo-parser = "0.8.6"
-# Named directly only so `examples/treedump.rs` can spell `WalkEvent` and `NodeOrToken`, the two
-# types `SyntaxNode::preorder_with_tokens` yields. Both other members of this build graph already
+# Named directly only so `src/dump.rs` can spell `WalkEvent` and `NodeOrToken`, the two types
+# `SyntaxNode::preorder_with_tokens` yields. Both other members of this build graph already
 # depend on `rowan = "0.16"` — `apollo-parser` directly, smear through tokora — so this adds a name
 # to the namespace and nothing to the build.
 rowan = "0.16"
+# The byte-identity gate (`tests/byte_identity.rs`) recomputes the four corpus hashes in-process
+# and compares them against the constants in `src/dump.rs`. Hashing in Rust rather than piping to
+# `shasum` is what lets the gate run as an ordinary `cargo test` on any runner, and what lets the
+# 1.4 GB `prefixes` dump be hashed in bounded memory rather than materialised.
+sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "smear-apollo-bench"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Like-for-like benchmark: smear's GraphQL lossless CST parser vs apollo-parser"
+publish = false
+
+# A workspace member rather than a dev-dependency of `smear-parser`: a dev-dependency would
+# compile apollo into every `cargo test -p smear-parser`, and a workspace-*excluded* crate would
+# not inherit the root `[patch.crates-io]` that resolves the unpublished `tokora = "0.8.0"`.
+#
+# `apollo-parser` comes from the registry, not from the local `apollo-rs` checkout, so the
+# numbers describe what a real consumer gets and reproduce on any machine. 0.8.6 is both the
+# local checkout's version and crates.io's current max.
+
+[dependencies]
+# `graphqlx` is deliberately off: the benchmark only exercises the GraphQL dialect, and
+# `graphqlx` drags in `unstable`.
+smear-parser = { path = "../smear-parser", version = "0.0.0", default-features = false, features = [
+  "std",
+  "graphql",
+  "rowan",
+] }
+tokora.workspace = true
+apollo-parser = "0.8.6"
+
+[dev-dependencies]
+criterion = "0.8"
+
+[lints]
+workspace = true
+
+[[bench]]
+name = "apollo_comparison"
+path = "benches/apollo_comparison.rs"
+harness = false

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -27,6 +27,11 @@ smear-parser = { path = "../smear-parser", version = "0.0.0", default-features =
 ] }
 tokora.workspace = true
 apollo-parser = "0.8.6"
+# Named directly only so `examples/treedump.rs` can spell `WalkEvent` and `NodeOrToken`, the two
+# types `SyntaxNode::preorder_with_tokens` yields. Both other members of this build graph already
+# depend on `rowan = "0.16"` — `apollo-parser` directly, smear through tokora — so this adds a name
+# to the namespace and nothing to the build.
+rowan = "0.16"
 
 [dev-dependencies]
 criterion = "0.8"

--- a/benchmarks/benches/apollo_comparison.rs
+++ b/benchmarks/benches/apollo_comparison.rs
@@ -1,0 +1,100 @@
+//! smear's GraphQL lossless CST parser vs `apollo-parser`, both sides in one criterion process.
+//!
+//! Three tiers, measured separately because `apollo-parser`'s own published `parse_query` bench
+//! conflates parsing with a typed traversal and reports one number for both:
+//!
+//! * **tier0** — lex only, each lexer driven to exhaustion with every token black-boxed.
+//! * **tier1** — parse to CST, no traversal. The headline number.
+//! * **tier2** — parse plus `apollo-parser`'s own typed traversal, reproduced on both sides.
+//!   `tier2 - tier1` isolates the traversal.
+//!
+//! The [correctness gate](smear_apollo_bench::run_gate) runs first, in this same process, and any
+//! corpus entry that either side mishandles is excluded from timing and named on stdout. An
+//! entry both sides handle is timed with ids paired as `tierN/<entry>/smear` and
+//! `tierN/<entry>/apollo` so criterion reports them adjacently.
+//!
+//! Run with `cargo bench -p smear-apollo-bench --bench apollo_comparison`. A `harness = false`
+//! bench invoked any other way runs its body once with no timing.
+
+use core::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use smear_apollo_bench::{
+  CORPUS, Entry, apollo_lex, apollo_parse, apollo_parse_and_traverse, print_gate, run_gate,
+  smear_lex, smear_parse, smear_parse_and_traverse,
+};
+
+/// Everything that is timed, for one eligible corpus entry.
+fn bench_entry(c: &mut Criterion, entry: &Entry) {
+  let bytes = Throughput::Bytes(entry.len() as u64);
+  let src = entry.source;
+  let shape = entry.shape;
+
+  // Tier 0 — lex only.
+  {
+    let mut group = c.benchmark_group(format!("tier0_lex/{}", entry.name));
+    group.throughput(bytes.clone());
+    group.bench_function("smear", |b| b.iter(|| black_box(smear_lex(black_box(src)))));
+    group.bench_function("apollo", |b| {
+      b.iter(|| black_box(apollo_lex(black_box(src))))
+    });
+    group.finish();
+  }
+
+  // Tier 1 — parse to CST.
+  {
+    let mut group = c.benchmark_group(format!("tier1_parse/{}", entry.name));
+    group.throughput(bytes.clone());
+    group.bench_function("smear", |b| {
+      b.iter(|| black_box(smear_parse(black_box(src))))
+    });
+    group.bench_function("apollo", |b| {
+      b.iter(|| black_box(apollo_parse(black_box(src))))
+    });
+    group.finish();
+  }
+
+  // Tier 2 — parse plus typed traversal.
+  {
+    let mut group = c.benchmark_group(format!("tier2_parse_traverse/{}", entry.name));
+    group.throughput(bytes);
+    group.bench_function("smear", |b| {
+      b.iter(|| black_box(smear_parse_and_traverse(black_box(src), shape)))
+    });
+    group.bench_function("apollo", |b| {
+      b.iter(|| black_box(apollo_parse_and_traverse(black_box(src), shape)))
+    });
+    group.finish();
+  }
+}
+
+fn bench_all(c: &mut Criterion) {
+  // The gate runs before a single timing sample is taken, and it runs here rather than in a
+  // separate process so the tree that was checked is built by the same binary that is timed.
+  let rows = run_gate();
+  print_gate(&rows);
+
+  let mut timed = 0usize;
+  for entry in CORPUS {
+    let row = rows
+      .iter()
+      .find(|r| r.name == entry.name)
+      .expect("every corpus entry has a gate row");
+    if !row.eligible() {
+      // Named on stdout by `print_gate` already; skipping silently is the failure mode the
+      // design calls out by name, so say it again at the point of the skip.
+      eprintln!("skipping timing for excluded corpus entry: {}", entry.name);
+      continue;
+    }
+    bench_entry(c, entry);
+    timed += 1;
+  }
+
+  assert!(
+    timed > 0,
+    "the correctness gate excluded every corpus entry; there is nothing to compare"
+  );
+}
+
+criterion_group!(benches, bench_all);
+criterion_main!(benches);

--- a/benchmarks/corpus/0032_supergraph.graphql
+++ b/benchmarks/corpus/0032_supergraph.graphql
@@ -1,0 +1,266 @@
+schema
+@core(feature: "https://specs.apollo.dev/core/v0.1"),
+@core(feature: "https://specs.apollo.dev/join/v0.1")
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @core(feature: String!) repeatable on SCHEMA
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+directive @stream on FIELD
+directive @transform(from: String!) on FIELD
+
+union AccountType = PasswordAccount | SMSAccount
+
+type Amazon {
+  referrer: String
+}
+
+union Body = Image | Text
+
+type Book implements Product
+@join__owner(graph: BOOKS)
+@join__type(graph: BOOKS, key: "isbn")
+@join__type(graph: INVENTORY, key: "isbn")
+@join__type(graph: PRODUCT, key: "isbn")
+@join__type(graph: REVIEWS, key: "isbn")
+{
+  isbn: String! @join__field(graph: BOOKS)
+  title: String @join__field(graph: BOOKS)
+  year: Int @join__field(graph: BOOKS)
+  similarBooks: [Book]! @join__field(graph: BOOKS)
+  metadata: [MetadataOrError] @join__field(graph: BOOKS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  isCheckedOut: Boolean @join__field(graph: INVENTORY)
+  upc: String! @join__field(graph: PRODUCT)
+  sku: String! @join__field(graph: PRODUCT)
+  name(delimeter: String = " "): String @join__field(graph: PRODUCT, requires: "title year")
+  price: String @join__field(graph: PRODUCT)
+  details: ProductDetailsBook @join__field(graph: PRODUCT)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  relatedReviews: [Review!]! @join__field(graph: REVIEWS, requires: "similarBooks{isbn}")
+}
+
+union Brand = Ikea | Amazon
+
+type Car implements Vehicle
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: String! @join__field(graph: PRODUCT)
+  description: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  retailPrice: String @join__field(graph: REVIEWS, requires: "price")
+}
+
+type Error {
+  code: Int
+  message: String
+}
+
+type Furniture implements Product
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "upc")
+@join__type(graph: PRODUCT, key: "sku")
+@join__type(graph: INVENTORY, key: "sku")
+@join__type(graph: REVIEWS, key: "upc")
+{
+  upc: String! @join__field(graph: PRODUCT)
+  sku: String! @join__field(graph: PRODUCT)
+  name: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  brand: Brand @join__field(graph: PRODUCT)
+  metadata: [MetadataOrError] @join__field(graph: PRODUCT)
+  details: ProductDetailsFurniture @join__field(graph: PRODUCT)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  isHeavy: Boolean @join__field(graph: INVENTORY)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}
+
+type Ikea {
+  asile: Int
+}
+
+type Image implements NamedObject {
+  name: String!
+  attributes: ImageAttributes!
+}
+
+type ImageAttributes {
+  url: String!
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+ACCOUNTS @join__graph(name: "accounts" url: "")
+BOOKS @join__graph(name: "books" url: "")
+DOCUMENTS @join__graph(name: "documents" url: "")
+INVENTORY @join__graph(name: "inventory" url: "")
+PRODUCT @join__graph(name: "product" url: "")
+REVIEWS @join__graph(name: "reviews" url: "")
+}
+
+type KeyValue {
+  key: String!
+  value: String!
+}
+
+type Library
+@join__owner(graph: BOOKS)
+@join__type(graph: BOOKS, key: "id")
+@join__type(graph: ACCOUNTS, key: "id")
+{
+  id: ID! @join__field(graph: BOOKS)
+  name: String @join__field(graph: BOOKS)
+  userAccount(id: ID! = 1): User @join__field(graph: ACCOUNTS, requires: "name")
+}
+
+union MetadataOrError = KeyValue | Error
+
+type Mutation {
+  login(username: String!, password: String!): User @join__field(graph: ACCOUNTS)
+  reviewProduct(upc: String!, body: String!): Product @join__field(graph: REVIEWS)
+  updateReview(review: UpdateReviewInput!): Review @join__field(graph: REVIEWS)
+  deleteReview(id: ID!): Boolean @join__field(graph: REVIEWS)
+}
+
+type Name {
+  first: String
+  last: String
+}
+
+interface NamedObject {
+  name: String!
+}
+
+type PasswordAccount
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "email")
+{
+  email: String! @join__field(graph: ACCOUNTS)
+}
+
+interface Product {
+  upc: String!
+  sku: String!
+  name: String
+  price: String
+  details: ProductDetails
+  inStock: Boolean
+  reviews: [Review]
+}
+
+interface ProductDetails {
+  country: String
+}
+
+type ProductDetailsBook implements ProductDetails {
+  country: String
+  pages: Int
+}
+
+type ProductDetailsFurniture implements ProductDetails {
+  country: String
+  color: String
+}
+
+type Query {
+  user(id: ID!): User @join__field(graph: ACCOUNTS)
+  me: User @join__field(graph: ACCOUNTS)
+  book(isbn: String!): Book @join__field(graph: BOOKS)
+  books: [Book] @join__field(graph: BOOKS)
+  library(id: ID!): Library @join__field(graph: BOOKS)
+  body: Body! @join__field(graph: DOCUMENTS)
+  product(upc: String!): Product @join__field(graph: PRODUCT)
+  vehicle(id: String!): Vehicle @join__field(graph: PRODUCT)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCT)
+  topCars(first: Int = 5): [Car] @join__field(graph: PRODUCT)
+  topReviews(first: Int = 5): [Review] @join__field(graph: REVIEWS)
+}
+
+type Review
+@join__owner(graph: REVIEWS)
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: ID! @join__field(graph: REVIEWS)
+  body(format: Boolean = false): String @join__field(graph: REVIEWS)
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  product: Product @join__field(graph: REVIEWS)
+  metadata: [MetadataOrError] @join__field(graph: REVIEWS)
+}
+
+type SMSAccount
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "number")
+{
+  number: String @join__field(graph: ACCOUNTS)
+}
+
+type Text implements NamedObject {
+  name: String!
+  attributes: TextAttributes!
+}
+
+type TextAttributes {
+  bold: Boolean
+  text: String
+}
+
+union Thing = Car | Ikea
+
+input UpdateReviewInput {
+  id: ID!
+  body: String
+}
+
+type User
+@join__owner(graph: ACCOUNTS)
+@join__type(graph: ACCOUNTS, key: "id")
+@join__type(graph: ACCOUNTS, key: "username name{first last}")
+@join__type(graph: INVENTORY, key: "id")
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: ID! @join__field(graph: ACCOUNTS)
+  name: Name @join__field(graph: ACCOUNTS)
+  username: String @join__field(graph: ACCOUNTS)
+  birthDate(locale: String): String @join__field(graph: ACCOUNTS)
+  account: AccountType @join__field(graph: ACCOUNTS)
+  metadata: [UserMetadata] @join__field(graph: ACCOUNTS)
+  goodDescription: Boolean @join__field(graph: INVENTORY, requires: "metadata{description}")
+  vehicle: Vehicle @join__field(graph: PRODUCT)
+  thing: Thing @join__field(graph: PRODUCT)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  numberOfReviews: Int! @join__field(graph: REVIEWS)
+  goodAddress: Boolean @join__field(graph: REVIEWS, requires: "metadata{address}")
+}
+
+type UserMetadata {
+  name: String
+  address: String
+  description: String
+}
+
+type Van implements Vehicle
+@join__owner(graph: PRODUCT)
+@join__type(graph: PRODUCT, key: "id")
+@join__type(graph: REVIEWS, key: "id")
+{
+  id: String! @join__field(graph: PRODUCT)
+  description: String @join__field(graph: PRODUCT)
+  price: String @join__field(graph: PRODUCT)
+  retailPrice: String @join__field(graph: REVIEWS, requires: "price")
+}
+
+interface Vehicle {
+  id: String!
+  description: String
+  price: String
+  retailPrice: String
+}

--- a/benchmarks/corpus/alias.graphql
+++ b/benchmarks/corpus/alias.graphql
@@ -1,0 +1,3005 @@
+query($var0: String!, $var1: String!, $var2: String!, $var3: String!, $var4: String!, $var5: String!, $var6: String!, $var7: String!, $var8: String!, $var9: String!, $var10: String!, $var11: String!, $var12: String!, $var13: String!, $var14: String!, $var15: String!, $var16: String!, $var17: String!, $var18: String!, $var19: String!, $var20: String!, $var21: String!, $var22: String!, $var23: String!, $var24: String!, $var25: String!, $var26: String!, $var27: String!, $var28: String!, $var29: String!, $var30: String!, $var31: String!, $var32: String!, $var33: String!, $var34: String!, $var35: String!, $var36: String!, $var37: String!, $var38: String!, $var39: String!, $var40: String!, $var41: String!, $var42: String!, $var43: String!, $var44: String!, $var45: String!, $var46: String!, $var47: String!, $var48: String!, $var49: String!, $var50: String!, $var51: String!, $var52: String!, $var53: String!, $var54: String!, $var55: String!, $var56: String!, $var57: String!, $var58: String!, $var59: String!, $var60: String!, $var61: String!, $var62: String!, $var63: String!, $var64: String!, $var65: String!, $var66: String!, $var67: String!, $var68: String!, $var69: String!, $var70: String!, $var71: String!, $var72: String!, $var73: String!, $var74: String!, $var75: String!, $var76: String!, $var77: String!, $var78: String!, $var79: String!, $var80: String!, $var81: String!, $var82: String!, $var83: String!, $var84: String!, $var85: String!, $var86: String!, $var87: String!, $var88: String!, $var89: String!, $var90: String!, $var91: String!, $var92: String!, $var93: String!, $var94: String!, $var95: String!, $var96: String!, $var97: String!, $var98: String!, $var99: String!, $var100: String!, $var101: String!, $var102: String!, $var103: String!, $var104: String!, $var105: String!, $var106: String!, $var107: String!, $var108: String!, $var109: String!, $var110: String!, $var111: String!, $var112: String!, $var113: String!, $var114: String!, $var115: String!, $var116: String!, $var117: String!, $var118: String!, $var119: String!, $var120: String!, $var121: String!, $var122: String!, $var123: String!, $var124: String!, $var125: String!, $var126: String!, $var127: String!, $var128: String!, $var129: String!, $var130: String!, $var131: String!, $var132: String!, $var133: String!, $var134: String!, $var135: String!, $var136: String!, $var137: String!, $var138: String!, $var139: String!, $var140: String!, $var141: String!, $var142: String!, $var143: String!, $var144: String!, $var145: String!, $var146: String!, $var147: String!, $var148: String!, $var149: String!, $var150: String!, $var151: String!, $var152: String!, $var153: String!, $var154: String!, $var155: String!, $var156: String!, $var157: String!, $var158: String!, $var159: String!, $var160: String!, $var161: String!, $var162: String!, $var163: String!, $var164: String!, $var165: String!, $var166: String!, $var167: String!, $var168: String!, $var169: String!, $var170: String!, $var171: String!, $var172: String!, $var173: String!, $var174: String!, $var175: String!, $var176: String!, $var177: String!, $var178: String!, $var179: String!, $var180: String!, $var181: String!, $var182: String!, $var183: String!, $var184: String!, $var185: String!, $var186: String!, $var187: String!, $var188: String!, $var189: String!, $var190: String!, $var191: String!, $var192: String!, $var193: String!, $var194: String!, $var195: String!, $var196: String!, $var197: String!, $var198: String!, $var199: String!, $var200: String!, $var201: String!, $var202: String!, $var203: String!, $var204: String!, $var205: String!, $var206: String!, $var207: String!, $var208: String!, $var209: String!, $var210: String!, $var211: String!, $var212: String!, $var213: String!, $var214: String!, $var215: String!, $var216: String!, $var217: String!, $var218: String!, $var219: String!, $var220: String!, $var221: String!, $var222: String!, $var223: String!, $var224: String!, $var225: String!, $var226: String!, $var227: String!, $var228: String!, $var229: String!, $var230: String!, $var231: String!, $var232: String!, $var233: String!, $var234: String!, $var235: String!, $var236: String!, $var237: String!, $var238: String!, $var239: String!, $var240: String!, $var241: String!, $var242: String!, $var243: String!, $var244: String!, $var245: String!, $var246: String!, $var247: String!, $var248: String!, $var249: String!, $var250: String!, $var251: String!, $var252: String!, $var253: String!, $var254: String!, $var255: String!, $var256: String!, $var257: String!, $var258: String!, $var259: String!, $var260: String!, $var261: String!, $var262: String!, $var263: String!, $var264: String!, $var265: String!, $var266: String!, $var267: String!, $var268: String!, $var269: String!, $var270: String!, $var271: String!, $var272: String!, $var273: String!, $var274: String!, $var275: String!, $var276: String!, $var277: String!, $var278: String!, $var279: String!, $var280: String!, $var281: String!, $var282: String!, $var283: String!, $var284: String!, $var285: String!, $var286: String!, $var287: String!, $var288: String!, $var289: String!, $var290: String!, $var291: String!, $var292: String!, $var293: String!, $var294: String!, $var295: String!, $var296: String!, $var297: String!, $var298: String!, $var299: String!, $var300: String!, $var301: String!, $var302: String!, $var303: String!, $var304: String!, $var305: String!, $var306: String!, $var307: String!, $var308: String!, $var309: String!, $var310: String!, $var311: String!, $var312: String!, $var313: String!, $var314: String!, $var315: String!, $var316: String!, $var317: String!, $var318: String!, $var319: String!, $var320: String!, $var321: String!, $var322: String!, $var323: String!, $var324: String!, $var325: String!, $var326: String!, $var327: String!, $var328: String!, $var329: String!, $var330: String!, $var331: String!, $var332: String!, $var333: String!, $var334: String!, $var335: String!, $var336: String!, $var337: String!, $var338: String!, $var339: String!, $var340: String!, $var341: String!, $var342: String!, $var343: String!, $var344: String!, $var345: String!, $var346: String!, $var347: String!, $var348: String!, $var349: String!, $var350: String!, $var351: String!, $var352: String!, $var353: String!, $var354: String!, $var355: String!, $var356: String!, $var357: String!, $var358: String!, $var359: String!, $var360: String!, $var361: String!, $var362: String!, $var363: String!, $var364: String!, $var365: String!, $var366: String!, $var367: String!, $var368: String!, $var369: String!, $var370: String!, $var371: String!, $var372: String!, $var373: String!, $var374: String!, $var375: String!, $var376: String!, $var377: String!, $var378: String!, $var379: String!, $var380: String!, $var381: String!, $var382: String!, $var383: String!, $var384: String!, $var385: String!, $var386: String!, $var387: String!, $var388: String!, $var389: String!, $var390: String!, $var391: String!, $var392: String!, $var393: String!, $var394: String!, $var395: String!, $var396: String!, $var397: String!, $var398: String!, $var399: String!, $var400: String!, $var401: String!, $var402: String!, $var403: String!, $var404: String!, $var405: String!, $var406: String!, $var407: String!, $var408: String!, $var409: String!, $var410: String!, $var411: String!, $var412: String!, $var413: String!, $var414: String!, $var415: String!, $var416: String!, $var417: String!, $var418: String!, $var419: String!, $var420: String!, $var421: String!, $var422: String!, $var423: String!, $var424: String!, $var425: String!, $var426: String!, $var427: String!, $var428: String!, $var429: String!, $var430: String!, $var431: String!, $var432: String!, $var433: String!, $var434: String!, $var435: String!, $var436: String!, $var437: String!, $var438: String!, $var439: String!, $var440: String!, $var441: String!, $var442: String!, $var443: String!, $var444: String!, $var445: String!, $var446: String!, $var447: String!, $var448: String!, $var449: String!, $var450: String!, $var451: String!, $var452: String!, $var453: String!, $var454: String!, $var455: String!, $var456: String!, $var457: String!, $var458: String!, $var459: String!, $var460: String!, $var461: String!, $var462: String!, $var463: String!, $var464: String!, $var465: String!, $var466: String!, $var467: String!, $var468: String!, $var469: String!, $var470: String!, $var471: String!, $var472: String!, $var473: String!, $var474: String!, $var475: String!, $var476: String!, $var477: String!, $var478: String!, $var479: String!, $var480: String!, $var481: String!, $var482: String!, $var483: String!, $var484: String!, $var485: String!, $var486: String!, $var487: String!, $var488: String!, $var489: String!, $var490: String!, $var491: String!, $var492: String!, $var493: String!, $var494: String!, $var495: String!, $var496: String!, $var497: String!, $var498: String!, $var499: String!, $var500: String!, $var501: String!, $var502: String!, $var503: String!, $var504: String!, $var505: String!, $var506: String!, $var507: String!, $var508: String!, $var509: String!, $var510: String!, $var511: String!, $var512: String!, $var513: String!, $var514: String!, $var515: String!, $var516: String!, $var517: String!, $var518: String!, $var519: String!, $var520: String!, $var521: String!, $var522: String!, $var523: String!, $var524: String!, $var525: String!, $var526: String!, $var527: String!, $var528: String!, $var529: String!, $var530: String!, $var531: String!, $var532: String!, $var533: String!, $var534: String!, $var535: String!, $var536: String!, $var537: String!, $var538: String!, $var539: String!, $var540: String!, $var541: String!, $var542: String!, $var543: String!, $var544: String!, $var545: String!, $var546: String!, $var547: String!, $var548: String!, $var549: String!, $var550: String!, $var551: String!, $var552: String!, $var553: String!, $var554: String!, $var555: String!, $var556: String!, $var557: String!, $var558: String!, $var559: String!, $var560: String!, $var561: String!, $var562: String!, $var563: String!, $var564: String!, $var565: String!, $var566: String!, $var567: String!, $var568: String!, $var569: String!, $var570: String!, $var571: String!, $var572: String!, $var573: String!, $var574: String!, $var575: String!, $var576: String!, $var577: String!, $var578: String!, $var579: String!, $var580: String!, $var581: String!, $var582: String!, $var583: String!, $var584: String!, $var585: String!, $var586: String!, $var587: String!, $var588: String!, $var589: String!, $var590: String!, $var591: String!, $var592: String!, $var593: String!, $var594: String!, $var595: String!, $var596: String!, $var597: String!, $var598: String!, $var599: String!, $var600: String!, $var601: String!, $var602: String!, $var603: String!, $var604: String!, $var605: String!, $var606: String!, $var607: String!, $var608: String!, $var609: String!, $var610: String!, $var611: String!, $var612: String!, $var613: String!, $var614: String!, $var615: String!, $var616: String!, $var617: String!, $var618: String!, $var619: String!, $var620: String!, $var621: String!, $var622: String!, $var623: String!, $var624: String!, $var625: String!, $var626: String!, $var627: String!, $var628: String!, $var629: String!, $var630: String!, $var631: String!, $var632: String!, $var633: String!, $var634: String!, $var635: String!, $var636: String!, $var637: String!, $var638: String!, $var639: String!, $var640: String!, $var641: String!, $var642: String!, $var643: String!, $var644: String!, $var645: String!, $var646: String!, $var647: String!, $var648: String!, $var649: String!, $var650: String!, $var651: String!, $var652: String!, $var653: String!, $var654: String!, $var655: String!, $var656: String!, $var657: String!, $var658: String!, $var659: String!, $var660: String!, $var661: String!, $var662: String!, $var663: String!, $var664: String!, $var665: String!, $var666: String!, $var667: String!, $var668: String!, $var669: String!, $var670: String!, $var671: String!, $var672: String!, $var673: String!, $var674: String!, $var675: String!, $var676: String!, $var677: String!, $var678: String!, $var679: String!, $var680: String!, $var681: String!, $var682: String!, $var683: String!, $var684: String!, $var685: String!, $var686: String!, $var687: String!, $var688: String!, $var689: String!, $var690: String!, $var691: String!, $var692: String!, $var693: String!, $var694: String!, $var695: String!, $var696: String!, $var697: String!, $var698: String!, $var699: String!, $var700: String!, $var701: String!, $var702: String!, $var703: String!, $var704: String!, $var705: String!, $var706: String!, $var707: String!, $var708: String!, $var709: String!, $var710: String!, $var711: String!, $var712: String!, $var713: String!, $var714: String!, $var715: String!, $var716: String!, $var717: String!, $var718: String!, $var719: String!, $var720: String!, $var721: String!, $var722: String!, $var723: String!, $var724: String!, $var725: String!, $var726: String!, $var727: String!, $var728: String!, $var729: String!, $var730: String!, $var731: String!, $var732: String!, $var733: String!, $var734: String!, $var735: String!, $var736: String!, $var737: String!, $var738: String!, $var739: String!, $var740: String!, $var741: String!, $var742: String!, $var743: String!, $var744: String!, $var745: String!, $var746: String!, $var747: String!, $var748: String!, $var749: String!, $var750: String!, $var751: String!, $var752: String!, $var753: String!, $var754: String!, $var755: String!, $var756: String!, $var757: String!, $var758: String!, $var759: String!, $var760: String!, $var761: String!, $var762: String!, $var763: String!, $var764: String!, $var765: String!, $var766: String!, $var767: String!, $var768: String!, $var769: String!, $var770: String!, $var771: String!, $var772: String!, $var773: String!, $var774: String!, $var775: String!, $var776: String!, $var777: String!, $var778: String!, $var779: String!, $var780: String!, $var781: String!, $var782: String!, $var783: String!, $var784: String!, $var785: String!, $var786: String!, $var787: String!, $var788: String!, $var789: String!, $var790: String!, $var791: String!, $var792: String!, $var793: String!, $var794: String!, $var795: String!, $var796: String!, $var797: String!, $var798: String!, $var799: String!, $var800: String!, $var801: String!, $var802: String!, $var803: String!, $var804: String!, $var805: String!, $var806: String!, $var807: String!, $var808: String!, $var809: String!, $var810: String!, $var811: String!, $var812: String!, $var813: String!, $var814: String!, $var815: String!, $var816: String!, $var817: String!, $var818: String!, $var819: String!, $var820: String!, $var821: String!, $var822: String!, $var823: String!, $var824: String!, $var825: String!, $var826: String!, $var827: String!, $var828: String!, $var829: String!, $var830: String!, $var831: String!, $var832: String!, $var833: String!, $var834: String!, $var835: String!, $var836: String!, $var837: String!, $var838: String!, $var839: String!, $var840: String!, $var841: String!, $var842: String!, $var843: String!, $var844: String!, $var845: String!, $var846: String!, $var847: String!, $var848: String!, $var849: String!, $var850: String!, $var851: String!, $var852: String!, $var853: String!, $var854: String!, $var855: String!, $var856: String!, $var857: String!, $var858: String!, $var859: String!, $var860: String!, $var861: String!, $var862: String!, $var863: String!, $var864: String!, $var865: String!, $var866: String!, $var867: String!, $var868: String!, $var869: String!, $var870: String!, $var871: String!, $var872: String!, $var873: String!, $var874: String!, $var875: String!, $var876: String!, $var877: String!, $var878: String!, $var879: String!, $var880: String!, $var881: String!, $var882: String!, $var883: String!, $var884: String!, $var885: String!, $var886: String!, $var887: String!, $var888: String!, $var889: String!, $var890: String!, $var891: String!, $var892: String!, $var893: String!, $var894: String!, $var895: String!, $var896: String!, $var897: String!, $var898: String!, $var899: String!, $var900: String!, $var901: String!, $var902: String!, $var903: String!, $var904: String!, $var905: String!, $var906: String!, $var907: String!, $var908: String!, $var909: String!, $var910: String!, $var911: String!, $var912: String!, $var913: String!, $var914: String!, $var915: String!, $var916: String!, $var917: String!, $var918: String!, $var919: String!, $var920: String!, $var921: String!, $var922: String!, $var923: String!, $var924: String!, $var925: String!, $var926: String!, $var927: String!, $var928: String!, $var929: String!, $var930: String!, $var931: String!, $var932: String!, $var933: String!, $var934: String!, $var935: String!, $var936: String!, $var937: String!, $var938: String!, $var939: String!, $var940: String!, $var941: String!, $var942: String!, $var943: String!, $var944: String!, $var945: String!, $var946: String!, $var947: String!, $var948: String!, $var949: String!, $var950: String!, $var951: String!, $var952: String!, $var953: String!, $var954: String!, $var955: String!, $var956: String!, $var957: String!, $var958: String!, $var959: String!, $var960: String!, $var961: String!, $var962: String!, $var963: String!, $var964: String!, $var965: String!, $var966: String!, $var967: String!, $var968: String!, $var969: String!, $var970: String!, $var971: String!, $var972: String!, $var973: String!, $var974: String!, $var975: String!, $var976: String!, $var977: String!, $var978: String!, $var979: String!, $var980: String!, $var981: String!, $var982: String!, $var983: String!, $var984: String!, $var985: String!, $var986: String!, $var987: String!, $var988: String!, $var989: String!, $var990: String!, $var991: String!, $var992: String!, $var993: String!, $var994: String!, $var995: String!, $var996: String!, $var997: String!, $var998: String!, $var999: String!, $var1000: String!) {
+	hum0: human(id: $var0) {
+		name
+	}
+	hum1: human(id: $var1) {
+		name
+	}
+	hum2: human(id: $var2) {
+		name
+	}
+	hum3: human(id: $var3) {
+		name
+	}
+	hum4: human(id: $var4) {
+		name
+	}
+	hum5: human(id: $var5) {
+		name
+	}
+	hum6: human(id: $var6) {
+		name
+	}
+	hum7: human(id: $var7) {
+		name
+	}
+	hum8: human(id: $var8) {
+		name
+	}
+	hum9: human(id: $var9) {
+		name
+	}
+	hum10: human(id: $var10) {
+		name
+	}
+	hum11: human(id: $var11) {
+		name
+	}
+	hum12: human(id: $var12) {
+		name
+	}
+	hum13: human(id: $var13) {
+		name
+	}
+	hum14: human(id: $var14) {
+		name
+	}
+	hum15: human(id: $var15) {
+		name
+	}
+	hum16: human(id: $var16) {
+		name
+	}
+	hum17: human(id: $var17) {
+		name
+	}
+	hum18: human(id: $var18) {
+		name
+	}
+	hum19: human(id: $var19) {
+		name
+	}
+	hum20: human(id: $var20) {
+		name
+	}
+	hum21: human(id: $var21) {
+		name
+	}
+	hum22: human(id: $var22) {
+		name
+	}
+	hum23: human(id: $var23) {
+		name
+	}
+	hum24: human(id: $var24) {
+		name
+	}
+	hum25: human(id: $var25) {
+		name
+	}
+	hum26: human(id: $var26) {
+		name
+	}
+	hum27: human(id: $var27) {
+		name
+	}
+	hum28: human(id: $var28) {
+		name
+	}
+	hum29: human(id: $var29) {
+		name
+	}
+	hum30: human(id: $var30) {
+		name
+	}
+	hum31: human(id: $var31) {
+		name
+	}
+	hum32: human(id: $var32) {
+		name
+	}
+	hum33: human(id: $var33) {
+		name
+	}
+	hum34: human(id: $var34) {
+		name
+	}
+	hum35: human(id: $var35) {
+		name
+	}
+	hum36: human(id: $var36) {
+		name
+	}
+	hum37: human(id: $var37) {
+		name
+	}
+	hum38: human(id: $var38) {
+		name
+	}
+	hum39: human(id: $var39) {
+		name
+	}
+	hum40: human(id: $var40) {
+		name
+	}
+	hum41: human(id: $var41) {
+		name
+	}
+	hum42: human(id: $var42) {
+		name
+	}
+	hum43: human(id: $var43) {
+		name
+	}
+	hum44: human(id: $var44) {
+		name
+	}
+	hum45: human(id: $var45) {
+		name
+	}
+	hum46: human(id: $var46) {
+		name
+	}
+	hum47: human(id: $var47) {
+		name
+	}
+	hum48: human(id: $var48) {
+		name
+	}
+	hum49: human(id: $var49) {
+		name
+	}
+	hum50: human(id: $var50) {
+		name
+	}
+	hum51: human(id: $var51) {
+		name
+	}
+	hum52: human(id: $var52) {
+		name
+	}
+	hum53: human(id: $var53) {
+		name
+	}
+	hum54: human(id: $var54) {
+		name
+	}
+	hum55: human(id: $var55) {
+		name
+	}
+	hum56: human(id: $var56) {
+		name
+	}
+	hum57: human(id: $var57) {
+		name
+	}
+	hum58: human(id: $var58) {
+		name
+	}
+	hum59: human(id: $var59) {
+		name
+	}
+	hum60: human(id: $var60) {
+		name
+	}
+	hum61: human(id: $var61) {
+		name
+	}
+	hum62: human(id: $var62) {
+		name
+	}
+	hum63: human(id: $var63) {
+		name
+	}
+	hum64: human(id: $var64) {
+		name
+	}
+	hum65: human(id: $var65) {
+		name
+	}
+	hum66: human(id: $var66) {
+		name
+	}
+	hum67: human(id: $var67) {
+		name
+	}
+	hum68: human(id: $var68) {
+		name
+	}
+	hum69: human(id: $var69) {
+		name
+	}
+	hum70: human(id: $var70) {
+		name
+	}
+	hum71: human(id: $var71) {
+		name
+	}
+	hum72: human(id: $var72) {
+		name
+	}
+	hum73: human(id: $var73) {
+		name
+	}
+	hum74: human(id: $var74) {
+		name
+	}
+	hum75: human(id: $var75) {
+		name
+	}
+	hum76: human(id: $var76) {
+		name
+	}
+	hum77: human(id: $var77) {
+		name
+	}
+	hum78: human(id: $var78) {
+		name
+	}
+	hum79: human(id: $var79) {
+		name
+	}
+	hum80: human(id: $var80) {
+		name
+	}
+	hum81: human(id: $var81) {
+		name
+	}
+	hum82: human(id: $var82) {
+		name
+	}
+	hum83: human(id: $var83) {
+		name
+	}
+	hum84: human(id: $var84) {
+		name
+	}
+	hum85: human(id: $var85) {
+		name
+	}
+	hum86: human(id: $var86) {
+		name
+	}
+	hum87: human(id: $var87) {
+		name
+	}
+	hum88: human(id: $var88) {
+		name
+	}
+	hum89: human(id: $var89) {
+		name
+	}
+	hum90: human(id: $var90) {
+		name
+	}
+	hum91: human(id: $var91) {
+		name
+	}
+	hum92: human(id: $var92) {
+		name
+	}
+	hum93: human(id: $var93) {
+		name
+	}
+	hum94: human(id: $var94) {
+		name
+	}
+	hum95: human(id: $var95) {
+		name
+	}
+	hum96: human(id: $var96) {
+		name
+	}
+	hum97: human(id: $var97) {
+		name
+	}
+	hum98: human(id: $var98) {
+		name
+	}
+	hum99: human(id: $var99) {
+		name
+	}
+	hum100: human(id: $var100) {
+		name
+	}
+	hum101: human(id: $var101) {
+		name
+	}
+	hum102: human(id: $var102) {
+		name
+	}
+	hum103: human(id: $var103) {
+		name
+	}
+	hum104: human(id: $var104) {
+		name
+	}
+	hum105: human(id: $var105) {
+		name
+	}
+	hum106: human(id: $var106) {
+		name
+	}
+	hum107: human(id: $var107) {
+		name
+	}
+	hum108: human(id: $var108) {
+		name
+	}
+	hum109: human(id: $var109) {
+		name
+	}
+	hum110: human(id: $var110) {
+		name
+	}
+	hum111: human(id: $var111) {
+		name
+	}
+	hum112: human(id: $var112) {
+		name
+	}
+	hum113: human(id: $var113) {
+		name
+	}
+	hum114: human(id: $var114) {
+		name
+	}
+	hum115: human(id: $var115) {
+		name
+	}
+	hum116: human(id: $var116) {
+		name
+	}
+	hum117: human(id: $var117) {
+		name
+	}
+	hum118: human(id: $var118) {
+		name
+	}
+	hum119: human(id: $var119) {
+		name
+	}
+	hum120: human(id: $var120) {
+		name
+	}
+	hum121: human(id: $var121) {
+		name
+	}
+	hum122: human(id: $var122) {
+		name
+	}
+	hum123: human(id: $var123) {
+		name
+	}
+	hum124: human(id: $var124) {
+		name
+	}
+	hum125: human(id: $var125) {
+		name
+	}
+	hum126: human(id: $var126) {
+		name
+	}
+	hum127: human(id: $var127) {
+		name
+	}
+	hum128: human(id: $var128) {
+		name
+	}
+	hum129: human(id: $var129) {
+		name
+	}
+	hum130: human(id: $var130) {
+		name
+	}
+	hum131: human(id: $var131) {
+		name
+	}
+	hum132: human(id: $var132) {
+		name
+	}
+	hum133: human(id: $var133) {
+		name
+	}
+	hum134: human(id: $var134) {
+		name
+	}
+	hum135: human(id: $var135) {
+		name
+	}
+	hum136: human(id: $var136) {
+		name
+	}
+	hum137: human(id: $var137) {
+		name
+	}
+	hum138: human(id: $var138) {
+		name
+	}
+	hum139: human(id: $var139) {
+		name
+	}
+	hum140: human(id: $var140) {
+		name
+	}
+	hum141: human(id: $var141) {
+		name
+	}
+	hum142: human(id: $var142) {
+		name
+	}
+	hum143: human(id: $var143) {
+		name
+	}
+	hum144: human(id: $var144) {
+		name
+	}
+	hum145: human(id: $var145) {
+		name
+	}
+	hum146: human(id: $var146) {
+		name
+	}
+	hum147: human(id: $var147) {
+		name
+	}
+	hum148: human(id: $var148) {
+		name
+	}
+	hum149: human(id: $var149) {
+		name
+	}
+	hum150: human(id: $var150) {
+		name
+	}
+	hum151: human(id: $var151) {
+		name
+	}
+	hum152: human(id: $var152) {
+		name
+	}
+	hum153: human(id: $var153) {
+		name
+	}
+	hum154: human(id: $var154) {
+		name
+	}
+	hum155: human(id: $var155) {
+		name
+	}
+	hum156: human(id: $var156) {
+		name
+	}
+	hum157: human(id: $var157) {
+		name
+	}
+	hum158: human(id: $var158) {
+		name
+	}
+	hum159: human(id: $var159) {
+		name
+	}
+	hum160: human(id: $var160) {
+		name
+	}
+	hum161: human(id: $var161) {
+		name
+	}
+	hum162: human(id: $var162) {
+		name
+	}
+	hum163: human(id: $var163) {
+		name
+	}
+	hum164: human(id: $var164) {
+		name
+	}
+	hum165: human(id: $var165) {
+		name
+	}
+	hum166: human(id: $var166) {
+		name
+	}
+	hum167: human(id: $var167) {
+		name
+	}
+	hum168: human(id: $var168) {
+		name
+	}
+	hum169: human(id: $var169) {
+		name
+	}
+	hum170: human(id: $var170) {
+		name
+	}
+	hum171: human(id: $var171) {
+		name
+	}
+	hum172: human(id: $var172) {
+		name
+	}
+	hum173: human(id: $var173) {
+		name
+	}
+	hum174: human(id: $var174) {
+		name
+	}
+	hum175: human(id: $var175) {
+		name
+	}
+	hum176: human(id: $var176) {
+		name
+	}
+	hum177: human(id: $var177) {
+		name
+	}
+	hum178: human(id: $var178) {
+		name
+	}
+	hum179: human(id: $var179) {
+		name
+	}
+	hum180: human(id: $var180) {
+		name
+	}
+	hum181: human(id: $var181) {
+		name
+	}
+	hum182: human(id: $var182) {
+		name
+	}
+	hum183: human(id: $var183) {
+		name
+	}
+	hum184: human(id: $var184) {
+		name
+	}
+	hum185: human(id: $var185) {
+		name
+	}
+	hum186: human(id: $var186) {
+		name
+	}
+	hum187: human(id: $var187) {
+		name
+	}
+	hum188: human(id: $var188) {
+		name
+	}
+	hum189: human(id: $var189) {
+		name
+	}
+	hum190: human(id: $var190) {
+		name
+	}
+	hum191: human(id: $var191) {
+		name
+	}
+	hum192: human(id: $var192) {
+		name
+	}
+	hum193: human(id: $var193) {
+		name
+	}
+	hum194: human(id: $var194) {
+		name
+	}
+	hum195: human(id: $var195) {
+		name
+	}
+	hum196: human(id: $var196) {
+		name
+	}
+	hum197: human(id: $var197) {
+		name
+	}
+	hum198: human(id: $var198) {
+		name
+	}
+	hum199: human(id: $var199) {
+		name
+	}
+	hum200: human(id: $var200) {
+		name
+	}
+	hum201: human(id: $var201) {
+		name
+	}
+	hum202: human(id: $var202) {
+		name
+	}
+	hum203: human(id: $var203) {
+		name
+	}
+	hum204: human(id: $var204) {
+		name
+	}
+	hum205: human(id: $var205) {
+		name
+	}
+	hum206: human(id: $var206) {
+		name
+	}
+	hum207: human(id: $var207) {
+		name
+	}
+	hum208: human(id: $var208) {
+		name
+	}
+	hum209: human(id: $var209) {
+		name
+	}
+	hum210: human(id: $var210) {
+		name
+	}
+	hum211: human(id: $var211) {
+		name
+	}
+	hum212: human(id: $var212) {
+		name
+	}
+	hum213: human(id: $var213) {
+		name
+	}
+	hum214: human(id: $var214) {
+		name
+	}
+	hum215: human(id: $var215) {
+		name
+	}
+	hum216: human(id: $var216) {
+		name
+	}
+	hum217: human(id: $var217) {
+		name
+	}
+	hum218: human(id: $var218) {
+		name
+	}
+	hum219: human(id: $var219) {
+		name
+	}
+	hum220: human(id: $var220) {
+		name
+	}
+	hum221: human(id: $var221) {
+		name
+	}
+	hum222: human(id: $var222) {
+		name
+	}
+	hum223: human(id: $var223) {
+		name
+	}
+	hum224: human(id: $var224) {
+		name
+	}
+	hum225: human(id: $var225) {
+		name
+	}
+	hum226: human(id: $var226) {
+		name
+	}
+	hum227: human(id: $var227) {
+		name
+	}
+	hum228: human(id: $var228) {
+		name
+	}
+	hum229: human(id: $var229) {
+		name
+	}
+	hum230: human(id: $var230) {
+		name
+	}
+	hum231: human(id: $var231) {
+		name
+	}
+	hum232: human(id: $var232) {
+		name
+	}
+	hum233: human(id: $var233) {
+		name
+	}
+	hum234: human(id: $var234) {
+		name
+	}
+	hum235: human(id: $var235) {
+		name
+	}
+	hum236: human(id: $var236) {
+		name
+	}
+	hum237: human(id: $var237) {
+		name
+	}
+	hum238: human(id: $var238) {
+		name
+	}
+	hum239: human(id: $var239) {
+		name
+	}
+	hum240: human(id: $var240) {
+		name
+	}
+	hum241: human(id: $var241) {
+		name
+	}
+	hum242: human(id: $var242) {
+		name
+	}
+	hum243: human(id: $var243) {
+		name
+	}
+	hum244: human(id: $var244) {
+		name
+	}
+	hum245: human(id: $var245) {
+		name
+	}
+	hum246: human(id: $var246) {
+		name
+	}
+	hum247: human(id: $var247) {
+		name
+	}
+	hum248: human(id: $var248) {
+		name
+	}
+	hum249: human(id: $var249) {
+		name
+	}
+	hum250: human(id: $var250) {
+		name
+	}
+	hum251: human(id: $var251) {
+		name
+	}
+	hum252: human(id: $var252) {
+		name
+	}
+	hum253: human(id: $var253) {
+		name
+	}
+	hum254: human(id: $var254) {
+		name
+	}
+	hum255: human(id: $var255) {
+		name
+	}
+	hum256: human(id: $var256) {
+		name
+	}
+	hum257: human(id: $var257) {
+		name
+	}
+	hum258: human(id: $var258) {
+		name
+	}
+	hum259: human(id: $var259) {
+		name
+	}
+	hum260: human(id: $var260) {
+		name
+	}
+	hum261: human(id: $var261) {
+		name
+	}
+	hum262: human(id: $var262) {
+		name
+	}
+	hum263: human(id: $var263) {
+		name
+	}
+	hum264: human(id: $var264) {
+		name
+	}
+	hum265: human(id: $var265) {
+		name
+	}
+	hum266: human(id: $var266) {
+		name
+	}
+	hum267: human(id: $var267) {
+		name
+	}
+	hum268: human(id: $var268) {
+		name
+	}
+	hum269: human(id: $var269) {
+		name
+	}
+	hum270: human(id: $var270) {
+		name
+	}
+	hum271: human(id: $var271) {
+		name
+	}
+	hum272: human(id: $var272) {
+		name
+	}
+	hum273: human(id: $var273) {
+		name
+	}
+	hum274: human(id: $var274) {
+		name
+	}
+	hum275: human(id: $var275) {
+		name
+	}
+	hum276: human(id: $var276) {
+		name
+	}
+	hum277: human(id: $var277) {
+		name
+	}
+	hum278: human(id: $var278) {
+		name
+	}
+	hum279: human(id: $var279) {
+		name
+	}
+	hum280: human(id: $var280) {
+		name
+	}
+	hum281: human(id: $var281) {
+		name
+	}
+	hum282: human(id: $var282) {
+		name
+	}
+	hum283: human(id: $var283) {
+		name
+	}
+	hum284: human(id: $var284) {
+		name
+	}
+	hum285: human(id: $var285) {
+		name
+	}
+	hum286: human(id: $var286) {
+		name
+	}
+	hum287: human(id: $var287) {
+		name
+	}
+	hum288: human(id: $var288) {
+		name
+	}
+	hum289: human(id: $var289) {
+		name
+	}
+	hum290: human(id: $var290) {
+		name
+	}
+	hum291: human(id: $var291) {
+		name
+	}
+	hum292: human(id: $var292) {
+		name
+	}
+	hum293: human(id: $var293) {
+		name
+	}
+	hum294: human(id: $var294) {
+		name
+	}
+	hum295: human(id: $var295) {
+		name
+	}
+	hum296: human(id: $var296) {
+		name
+	}
+	hum297: human(id: $var297) {
+		name
+	}
+	hum298: human(id: $var298) {
+		name
+	}
+	hum299: human(id: $var299) {
+		name
+	}
+	hum300: human(id: $var300) {
+		name
+	}
+	hum301: human(id: $var301) {
+		name
+	}
+	hum302: human(id: $var302) {
+		name
+	}
+	hum303: human(id: $var303) {
+		name
+	}
+	hum304: human(id: $var304) {
+		name
+	}
+	hum305: human(id: $var305) {
+		name
+	}
+	hum306: human(id: $var306) {
+		name
+	}
+	hum307: human(id: $var307) {
+		name
+	}
+	hum308: human(id: $var308) {
+		name
+	}
+	hum309: human(id: $var309) {
+		name
+	}
+	hum310: human(id: $var310) {
+		name
+	}
+	hum311: human(id: $var311) {
+		name
+	}
+	hum312: human(id: $var312) {
+		name
+	}
+	hum313: human(id: $var313) {
+		name
+	}
+	hum314: human(id: $var314) {
+		name
+	}
+	hum315: human(id: $var315) {
+		name
+	}
+	hum316: human(id: $var316) {
+		name
+	}
+	hum317: human(id: $var317) {
+		name
+	}
+	hum318: human(id: $var318) {
+		name
+	}
+	hum319: human(id: $var319) {
+		name
+	}
+	hum320: human(id: $var320) {
+		name
+	}
+	hum321: human(id: $var321) {
+		name
+	}
+	hum322: human(id: $var322) {
+		name
+	}
+	hum323: human(id: $var323) {
+		name
+	}
+	hum324: human(id: $var324) {
+		name
+	}
+	hum325: human(id: $var325) {
+		name
+	}
+	hum326: human(id: $var326) {
+		name
+	}
+	hum327: human(id: $var327) {
+		name
+	}
+	hum328: human(id: $var328) {
+		name
+	}
+	hum329: human(id: $var329) {
+		name
+	}
+	hum330: human(id: $var330) {
+		name
+	}
+	hum331: human(id: $var331) {
+		name
+	}
+	hum332: human(id: $var332) {
+		name
+	}
+	hum333: human(id: $var333) {
+		name
+	}
+	hum334: human(id: $var334) {
+		name
+	}
+	hum335: human(id: $var335) {
+		name
+	}
+	hum336: human(id: $var336) {
+		name
+	}
+	hum337: human(id: $var337) {
+		name
+	}
+	hum338: human(id: $var338) {
+		name
+	}
+	hum339: human(id: $var339) {
+		name
+	}
+	hum340: human(id: $var340) {
+		name
+	}
+	hum341: human(id: $var341) {
+		name
+	}
+	hum342: human(id: $var342) {
+		name
+	}
+	hum343: human(id: $var343) {
+		name
+	}
+	hum344: human(id: $var344) {
+		name
+	}
+	hum345: human(id: $var345) {
+		name
+	}
+	hum346: human(id: $var346) {
+		name
+	}
+	hum347: human(id: $var347) {
+		name
+	}
+	hum348: human(id: $var348) {
+		name
+	}
+	hum349: human(id: $var349) {
+		name
+	}
+	hum350: human(id: $var350) {
+		name
+	}
+	hum351: human(id: $var351) {
+		name
+	}
+	hum352: human(id: $var352) {
+		name
+	}
+	hum353: human(id: $var353) {
+		name
+	}
+	hum354: human(id: $var354) {
+		name
+	}
+	hum355: human(id: $var355) {
+		name
+	}
+	hum356: human(id: $var356) {
+		name
+	}
+	hum357: human(id: $var357) {
+		name
+	}
+	hum358: human(id: $var358) {
+		name
+	}
+	hum359: human(id: $var359) {
+		name
+	}
+	hum360: human(id: $var360) {
+		name
+	}
+	hum361: human(id: $var361) {
+		name
+	}
+	hum362: human(id: $var362) {
+		name
+	}
+	hum363: human(id: $var363) {
+		name
+	}
+	hum364: human(id: $var364) {
+		name
+	}
+	hum365: human(id: $var365) {
+		name
+	}
+	hum366: human(id: $var366) {
+		name
+	}
+	hum367: human(id: $var367) {
+		name
+	}
+	hum368: human(id: $var368) {
+		name
+	}
+	hum369: human(id: $var369) {
+		name
+	}
+	hum370: human(id: $var370) {
+		name
+	}
+	hum371: human(id: $var371) {
+		name
+	}
+	hum372: human(id: $var372) {
+		name
+	}
+	hum373: human(id: $var373) {
+		name
+	}
+	hum374: human(id: $var374) {
+		name
+	}
+	hum375: human(id: $var375) {
+		name
+	}
+	hum376: human(id: $var376) {
+		name
+	}
+	hum377: human(id: $var377) {
+		name
+	}
+	hum378: human(id: $var378) {
+		name
+	}
+	hum379: human(id: $var379) {
+		name
+	}
+	hum380: human(id: $var380) {
+		name
+	}
+	hum381: human(id: $var381) {
+		name
+	}
+	hum382: human(id: $var382) {
+		name
+	}
+	hum383: human(id: $var383) {
+		name
+	}
+	hum384: human(id: $var384) {
+		name
+	}
+	hum385: human(id: $var385) {
+		name
+	}
+	hum386: human(id: $var386) {
+		name
+	}
+	hum387: human(id: $var387) {
+		name
+	}
+	hum388: human(id: $var388) {
+		name
+	}
+	hum389: human(id: $var389) {
+		name
+	}
+	hum390: human(id: $var390) {
+		name
+	}
+	hum391: human(id: $var391) {
+		name
+	}
+	hum392: human(id: $var392) {
+		name
+	}
+	hum393: human(id: $var393) {
+		name
+	}
+	hum394: human(id: $var394) {
+		name
+	}
+	hum395: human(id: $var395) {
+		name
+	}
+	hum396: human(id: $var396) {
+		name
+	}
+	hum397: human(id: $var397) {
+		name
+	}
+	hum398: human(id: $var398) {
+		name
+	}
+	hum399: human(id: $var399) {
+		name
+	}
+	hum400: human(id: $var400) {
+		name
+	}
+	hum401: human(id: $var401) {
+		name
+	}
+	hum402: human(id: $var402) {
+		name
+	}
+	hum403: human(id: $var403) {
+		name
+	}
+	hum404: human(id: $var404) {
+		name
+	}
+	hum405: human(id: $var405) {
+		name
+	}
+	hum406: human(id: $var406) {
+		name
+	}
+	hum407: human(id: $var407) {
+		name
+	}
+	hum408: human(id: $var408) {
+		name
+	}
+	hum409: human(id: $var409) {
+		name
+	}
+	hum410: human(id: $var410) {
+		name
+	}
+	hum411: human(id: $var411) {
+		name
+	}
+	hum412: human(id: $var412) {
+		name
+	}
+	hum413: human(id: $var413) {
+		name
+	}
+	hum414: human(id: $var414) {
+		name
+	}
+	hum415: human(id: $var415) {
+		name
+	}
+	hum416: human(id: $var416) {
+		name
+	}
+	hum417: human(id: $var417) {
+		name
+	}
+	hum418: human(id: $var418) {
+		name
+	}
+	hum419: human(id: $var419) {
+		name
+	}
+	hum420: human(id: $var420) {
+		name
+	}
+	hum421: human(id: $var421) {
+		name
+	}
+	hum422: human(id: $var422) {
+		name
+	}
+	hum423: human(id: $var423) {
+		name
+	}
+	hum424: human(id: $var424) {
+		name
+	}
+	hum425: human(id: $var425) {
+		name
+	}
+	hum426: human(id: $var426) {
+		name
+	}
+	hum427: human(id: $var427) {
+		name
+	}
+	hum428: human(id: $var428) {
+		name
+	}
+	hum429: human(id: $var429) {
+		name
+	}
+	hum430: human(id: $var430) {
+		name
+	}
+	hum431: human(id: $var431) {
+		name
+	}
+	hum432: human(id: $var432) {
+		name
+	}
+	hum433: human(id: $var433) {
+		name
+	}
+	hum434: human(id: $var434) {
+		name
+	}
+	hum435: human(id: $var435) {
+		name
+	}
+	hum436: human(id: $var436) {
+		name
+	}
+	hum437: human(id: $var437) {
+		name
+	}
+	hum438: human(id: $var438) {
+		name
+	}
+	hum439: human(id: $var439) {
+		name
+	}
+	hum440: human(id: $var440) {
+		name
+	}
+	hum441: human(id: $var441) {
+		name
+	}
+	hum442: human(id: $var442) {
+		name
+	}
+	hum443: human(id: $var443) {
+		name
+	}
+	hum444: human(id: $var444) {
+		name
+	}
+	hum445: human(id: $var445) {
+		name
+	}
+	hum446: human(id: $var446) {
+		name
+	}
+	hum447: human(id: $var447) {
+		name
+	}
+	hum448: human(id: $var448) {
+		name
+	}
+	hum449: human(id: $var449) {
+		name
+	}
+	hum450: human(id: $var450) {
+		name
+	}
+	hum451: human(id: $var451) {
+		name
+	}
+	hum452: human(id: $var452) {
+		name
+	}
+	hum453: human(id: $var453) {
+		name
+	}
+	hum454: human(id: $var454) {
+		name
+	}
+	hum455: human(id: $var455) {
+		name
+	}
+	hum456: human(id: $var456) {
+		name
+	}
+	hum457: human(id: $var457) {
+		name
+	}
+	hum458: human(id: $var458) {
+		name
+	}
+	hum459: human(id: $var459) {
+		name
+	}
+	hum460: human(id: $var460) {
+		name
+	}
+	hum461: human(id: $var461) {
+		name
+	}
+	hum462: human(id: $var462) {
+		name
+	}
+	hum463: human(id: $var463) {
+		name
+	}
+	hum464: human(id: $var464) {
+		name
+	}
+	hum465: human(id: $var465) {
+		name
+	}
+	hum466: human(id: $var466) {
+		name
+	}
+	hum467: human(id: $var467) {
+		name
+	}
+	hum468: human(id: $var468) {
+		name
+	}
+	hum469: human(id: $var469) {
+		name
+	}
+	hum470: human(id: $var470) {
+		name
+	}
+	hum471: human(id: $var471) {
+		name
+	}
+	hum472: human(id: $var472) {
+		name
+	}
+	hum473: human(id: $var473) {
+		name
+	}
+	hum474: human(id: $var474) {
+		name
+	}
+	hum475: human(id: $var475) {
+		name
+	}
+	hum476: human(id: $var476) {
+		name
+	}
+	hum477: human(id: $var477) {
+		name
+	}
+	hum478: human(id: $var478) {
+		name
+	}
+	hum479: human(id: $var479) {
+		name
+	}
+	hum480: human(id: $var480) {
+		name
+	}
+	hum481: human(id: $var481) {
+		name
+	}
+	hum482: human(id: $var482) {
+		name
+	}
+	hum483: human(id: $var483) {
+		name
+	}
+	hum484: human(id: $var484) {
+		name
+	}
+	hum485: human(id: $var485) {
+		name
+	}
+	hum486: human(id: $var486) {
+		name
+	}
+	hum487: human(id: $var487) {
+		name
+	}
+	hum488: human(id: $var488) {
+		name
+	}
+	hum489: human(id: $var489) {
+		name
+	}
+	hum490: human(id: $var490) {
+		name
+	}
+	hum491: human(id: $var491) {
+		name
+	}
+	hum492: human(id: $var492) {
+		name
+	}
+	hum493: human(id: $var493) {
+		name
+	}
+	hum494: human(id: $var494) {
+		name
+	}
+	hum495: human(id: $var495) {
+		name
+	}
+	hum496: human(id: $var496) {
+		name
+	}
+	hum497: human(id: $var497) {
+		name
+	}
+	hum498: human(id: $var498) {
+		name
+	}
+	hum499: human(id: $var499) {
+		name
+	}
+	hum500: human(id: $var500) {
+		name
+	}
+	hum501: human(id: $var501) {
+		name
+	}
+	hum502: human(id: $var502) {
+		name
+	}
+	hum503: human(id: $var503) {
+		name
+	}
+	hum504: human(id: $var504) {
+		name
+	}
+	hum505: human(id: $var505) {
+		name
+	}
+	hum506: human(id: $var506) {
+		name
+	}
+	hum507: human(id: $var507) {
+		name
+	}
+	hum508: human(id: $var508) {
+		name
+	}
+	hum509: human(id: $var509) {
+		name
+	}
+	hum510: human(id: $var510) {
+		name
+	}
+	hum511: human(id: $var511) {
+		name
+	}
+	hum512: human(id: $var512) {
+		name
+	}
+	hum513: human(id: $var513) {
+		name
+	}
+	hum514: human(id: $var514) {
+		name
+	}
+	hum515: human(id: $var515) {
+		name
+	}
+	hum516: human(id: $var516) {
+		name
+	}
+	hum517: human(id: $var517) {
+		name
+	}
+	hum518: human(id: $var518) {
+		name
+	}
+	hum519: human(id: $var519) {
+		name
+	}
+	hum520: human(id: $var520) {
+		name
+	}
+	hum521: human(id: $var521) {
+		name
+	}
+	hum522: human(id: $var522) {
+		name
+	}
+	hum523: human(id: $var523) {
+		name
+	}
+	hum524: human(id: $var524) {
+		name
+	}
+	hum525: human(id: $var525) {
+		name
+	}
+	hum526: human(id: $var526) {
+		name
+	}
+	hum527: human(id: $var527) {
+		name
+	}
+	hum528: human(id: $var528) {
+		name
+	}
+	hum529: human(id: $var529) {
+		name
+	}
+	hum530: human(id: $var530) {
+		name
+	}
+	hum531: human(id: $var531) {
+		name
+	}
+	hum532: human(id: $var532) {
+		name
+	}
+	hum533: human(id: $var533) {
+		name
+	}
+	hum534: human(id: $var534) {
+		name
+	}
+	hum535: human(id: $var535) {
+		name
+	}
+	hum536: human(id: $var536) {
+		name
+	}
+	hum537: human(id: $var537) {
+		name
+	}
+	hum538: human(id: $var538) {
+		name
+	}
+	hum539: human(id: $var539) {
+		name
+	}
+	hum540: human(id: $var540) {
+		name
+	}
+	hum541: human(id: $var541) {
+		name
+	}
+	hum542: human(id: $var542) {
+		name
+	}
+	hum543: human(id: $var543) {
+		name
+	}
+	hum544: human(id: $var544) {
+		name
+	}
+	hum545: human(id: $var545) {
+		name
+	}
+	hum546: human(id: $var546) {
+		name
+	}
+	hum547: human(id: $var547) {
+		name
+	}
+	hum548: human(id: $var548) {
+		name
+	}
+	hum549: human(id: $var549) {
+		name
+	}
+	hum550: human(id: $var550) {
+		name
+	}
+	hum551: human(id: $var551) {
+		name
+	}
+	hum552: human(id: $var552) {
+		name
+	}
+	hum553: human(id: $var553) {
+		name
+	}
+	hum554: human(id: $var554) {
+		name
+	}
+	hum555: human(id: $var555) {
+		name
+	}
+	hum556: human(id: $var556) {
+		name
+	}
+	hum557: human(id: $var557) {
+		name
+	}
+	hum558: human(id: $var558) {
+		name
+	}
+	hum559: human(id: $var559) {
+		name
+	}
+	hum560: human(id: $var560) {
+		name
+	}
+	hum561: human(id: $var561) {
+		name
+	}
+	hum562: human(id: $var562) {
+		name
+	}
+	hum563: human(id: $var563) {
+		name
+	}
+	hum564: human(id: $var564) {
+		name
+	}
+	hum565: human(id: $var565) {
+		name
+	}
+	hum566: human(id: $var566) {
+		name
+	}
+	hum567: human(id: $var567) {
+		name
+	}
+	hum568: human(id: $var568) {
+		name
+	}
+	hum569: human(id: $var569) {
+		name
+	}
+	hum570: human(id: $var570) {
+		name
+	}
+	hum571: human(id: $var571) {
+		name
+	}
+	hum572: human(id: $var572) {
+		name
+	}
+	hum573: human(id: $var573) {
+		name
+	}
+	hum574: human(id: $var574) {
+		name
+	}
+	hum575: human(id: $var575) {
+		name
+	}
+	hum576: human(id: $var576) {
+		name
+	}
+	hum577: human(id: $var577) {
+		name
+	}
+	hum578: human(id: $var578) {
+		name
+	}
+	hum579: human(id: $var579) {
+		name
+	}
+	hum580: human(id: $var580) {
+		name
+	}
+	hum581: human(id: $var581) {
+		name
+	}
+	hum582: human(id: $var582) {
+		name
+	}
+	hum583: human(id: $var583) {
+		name
+	}
+	hum584: human(id: $var584) {
+		name
+	}
+	hum585: human(id: $var585) {
+		name
+	}
+	hum586: human(id: $var586) {
+		name
+	}
+	hum587: human(id: $var587) {
+		name
+	}
+	hum588: human(id: $var588) {
+		name
+	}
+	hum589: human(id: $var589) {
+		name
+	}
+	hum590: human(id: $var590) {
+		name
+	}
+	hum591: human(id: $var591) {
+		name
+	}
+	hum592: human(id: $var592) {
+		name
+	}
+	hum593: human(id: $var593) {
+		name
+	}
+	hum594: human(id: $var594) {
+		name
+	}
+	hum595: human(id: $var595) {
+		name
+	}
+	hum596: human(id: $var596) {
+		name
+	}
+	hum597: human(id: $var597) {
+		name
+	}
+	hum598: human(id: $var598) {
+		name
+	}
+	hum599: human(id: $var599) {
+		name
+	}
+	hum600: human(id: $var600) {
+		name
+	}
+	hum601: human(id: $var601) {
+		name
+	}
+	hum602: human(id: $var602) {
+		name
+	}
+	hum603: human(id: $var603) {
+		name
+	}
+	hum604: human(id: $var604) {
+		name
+	}
+	hum605: human(id: $var605) {
+		name
+	}
+	hum606: human(id: $var606) {
+		name
+	}
+	hum607: human(id: $var607) {
+		name
+	}
+	hum608: human(id: $var608) {
+		name
+	}
+	hum609: human(id: $var609) {
+		name
+	}
+	hum610: human(id: $var610) {
+		name
+	}
+	hum611: human(id: $var611) {
+		name
+	}
+	hum612: human(id: $var612) {
+		name
+	}
+	hum613: human(id: $var613) {
+		name
+	}
+	hum614: human(id: $var614) {
+		name
+	}
+	hum615: human(id: $var615) {
+		name
+	}
+	hum616: human(id: $var616) {
+		name
+	}
+	hum617: human(id: $var617) {
+		name
+	}
+	hum618: human(id: $var618) {
+		name
+	}
+	hum619: human(id: $var619) {
+		name
+	}
+	hum620: human(id: $var620) {
+		name
+	}
+	hum621: human(id: $var621) {
+		name
+	}
+	hum622: human(id: $var622) {
+		name
+	}
+	hum623: human(id: $var623) {
+		name
+	}
+	hum624: human(id: $var624) {
+		name
+	}
+	hum625: human(id: $var625) {
+		name
+	}
+	hum626: human(id: $var626) {
+		name
+	}
+	hum627: human(id: $var627) {
+		name
+	}
+	hum628: human(id: $var628) {
+		name
+	}
+	hum629: human(id: $var629) {
+		name
+	}
+	hum630: human(id: $var630) {
+		name
+	}
+	hum631: human(id: $var631) {
+		name
+	}
+	hum632: human(id: $var632) {
+		name
+	}
+	hum633: human(id: $var633) {
+		name
+	}
+	hum634: human(id: $var634) {
+		name
+	}
+	hum635: human(id: $var635) {
+		name
+	}
+	hum636: human(id: $var636) {
+		name
+	}
+	hum637: human(id: $var637) {
+		name
+	}
+	hum638: human(id: $var638) {
+		name
+	}
+	hum639: human(id: $var639) {
+		name
+	}
+	hum640: human(id: $var640) {
+		name
+	}
+	hum641: human(id: $var641) {
+		name
+	}
+	hum642: human(id: $var642) {
+		name
+	}
+	hum643: human(id: $var643) {
+		name
+	}
+	hum644: human(id: $var644) {
+		name
+	}
+	hum645: human(id: $var645) {
+		name
+	}
+	hum646: human(id: $var646) {
+		name
+	}
+	hum647: human(id: $var647) {
+		name
+	}
+	hum648: human(id: $var648) {
+		name
+	}
+	hum649: human(id: $var649) {
+		name
+	}
+	hum650: human(id: $var650) {
+		name
+	}
+	hum651: human(id: $var651) {
+		name
+	}
+	hum652: human(id: $var652) {
+		name
+	}
+	hum653: human(id: $var653) {
+		name
+	}
+	hum654: human(id: $var654) {
+		name
+	}
+	hum655: human(id: $var655) {
+		name
+	}
+	hum656: human(id: $var656) {
+		name
+	}
+	hum657: human(id: $var657) {
+		name
+	}
+	hum658: human(id: $var658) {
+		name
+	}
+	hum659: human(id: $var659) {
+		name
+	}
+	hum660: human(id: $var660) {
+		name
+	}
+	hum661: human(id: $var661) {
+		name
+	}
+	hum662: human(id: $var662) {
+		name
+	}
+	hum663: human(id: $var663) {
+		name
+	}
+	hum664: human(id: $var664) {
+		name
+	}
+	hum665: human(id: $var665) {
+		name
+	}
+	hum666: human(id: $var666) {
+		name
+	}
+	hum667: human(id: $var667) {
+		name
+	}
+	hum668: human(id: $var668) {
+		name
+	}
+	hum669: human(id: $var669) {
+		name
+	}
+	hum670: human(id: $var670) {
+		name
+	}
+	hum671: human(id: $var671) {
+		name
+	}
+	hum672: human(id: $var672) {
+		name
+	}
+	hum673: human(id: $var673) {
+		name
+	}
+	hum674: human(id: $var674) {
+		name
+	}
+	hum675: human(id: $var675) {
+		name
+	}
+	hum676: human(id: $var676) {
+		name
+	}
+	hum677: human(id: $var677) {
+		name
+	}
+	hum678: human(id: $var678) {
+		name
+	}
+	hum679: human(id: $var679) {
+		name
+	}
+	hum680: human(id: $var680) {
+		name
+	}
+	hum681: human(id: $var681) {
+		name
+	}
+	hum682: human(id: $var682) {
+		name
+	}
+	hum683: human(id: $var683) {
+		name
+	}
+	hum684: human(id: $var684) {
+		name
+	}
+	hum685: human(id: $var685) {
+		name
+	}
+	hum686: human(id: $var686) {
+		name
+	}
+	hum687: human(id: $var687) {
+		name
+	}
+	hum688: human(id: $var688) {
+		name
+	}
+	hum689: human(id: $var689) {
+		name
+	}
+	hum690: human(id: $var690) {
+		name
+	}
+	hum691: human(id: $var691) {
+		name
+	}
+	hum692: human(id: $var692) {
+		name
+	}
+	hum693: human(id: $var693) {
+		name
+	}
+	hum694: human(id: $var694) {
+		name
+	}
+	hum695: human(id: $var695) {
+		name
+	}
+	hum696: human(id: $var696) {
+		name
+	}
+	hum697: human(id: $var697) {
+		name
+	}
+	hum698: human(id: $var698) {
+		name
+	}
+	hum699: human(id: $var699) {
+		name
+	}
+	hum700: human(id: $var700) {
+		name
+	}
+	hum701: human(id: $var701) {
+		name
+	}
+	hum702: human(id: $var702) {
+		name
+	}
+	hum703: human(id: $var703) {
+		name
+	}
+	hum704: human(id: $var704) {
+		name
+	}
+	hum705: human(id: $var705) {
+		name
+	}
+	hum706: human(id: $var706) {
+		name
+	}
+	hum707: human(id: $var707) {
+		name
+	}
+	hum708: human(id: $var708) {
+		name
+	}
+	hum709: human(id: $var709) {
+		name
+	}
+	hum710: human(id: $var710) {
+		name
+	}
+	hum711: human(id: $var711) {
+		name
+	}
+	hum712: human(id: $var712) {
+		name
+	}
+	hum713: human(id: $var713) {
+		name
+	}
+	hum714: human(id: $var714) {
+		name
+	}
+	hum715: human(id: $var715) {
+		name
+	}
+	hum716: human(id: $var716) {
+		name
+	}
+	hum717: human(id: $var717) {
+		name
+	}
+	hum718: human(id: $var718) {
+		name
+	}
+	hum719: human(id: $var719) {
+		name
+	}
+	hum720: human(id: $var720) {
+		name
+	}
+	hum721: human(id: $var721) {
+		name
+	}
+	hum722: human(id: $var722) {
+		name
+	}
+	hum723: human(id: $var723) {
+		name
+	}
+	hum724: human(id: $var724) {
+		name
+	}
+	hum725: human(id: $var725) {
+		name
+	}
+	hum726: human(id: $var726) {
+		name
+	}
+	hum727: human(id: $var727) {
+		name
+	}
+	hum728: human(id: $var728) {
+		name
+	}
+	hum729: human(id: $var729) {
+		name
+	}
+	hum730: human(id: $var730) {
+		name
+	}
+	hum731: human(id: $var731) {
+		name
+	}
+	hum732: human(id: $var732) {
+		name
+	}
+	hum733: human(id: $var733) {
+		name
+	}
+	hum734: human(id: $var734) {
+		name
+	}
+	hum735: human(id: $var735) {
+		name
+	}
+	hum736: human(id: $var736) {
+		name
+	}
+	hum737: human(id: $var737) {
+		name
+	}
+	hum738: human(id: $var738) {
+		name
+	}
+	hum739: human(id: $var739) {
+		name
+	}
+	hum740: human(id: $var740) {
+		name
+	}
+	hum741: human(id: $var741) {
+		name
+	}
+	hum742: human(id: $var742) {
+		name
+	}
+	hum743: human(id: $var743) {
+		name
+	}
+	hum744: human(id: $var744) {
+		name
+	}
+	hum745: human(id: $var745) {
+		name
+	}
+	hum746: human(id: $var746) {
+		name
+	}
+	hum747: human(id: $var747) {
+		name
+	}
+	hum748: human(id: $var748) {
+		name
+	}
+	hum749: human(id: $var749) {
+		name
+	}
+	hum750: human(id: $var750) {
+		name
+	}
+	hum751: human(id: $var751) {
+		name
+	}
+	hum752: human(id: $var752) {
+		name
+	}
+	hum753: human(id: $var753) {
+		name
+	}
+	hum754: human(id: $var754) {
+		name
+	}
+	hum755: human(id: $var755) {
+		name
+	}
+	hum756: human(id: $var756) {
+		name
+	}
+	hum757: human(id: $var757) {
+		name
+	}
+	hum758: human(id: $var758) {
+		name
+	}
+	hum759: human(id: $var759) {
+		name
+	}
+	hum760: human(id: $var760) {
+		name
+	}
+	hum761: human(id: $var761) {
+		name
+	}
+	hum762: human(id: $var762) {
+		name
+	}
+	hum763: human(id: $var763) {
+		name
+	}
+	hum764: human(id: $var764) {
+		name
+	}
+	hum765: human(id: $var765) {
+		name
+	}
+	hum766: human(id: $var766) {
+		name
+	}
+	hum767: human(id: $var767) {
+		name
+	}
+	hum768: human(id: $var768) {
+		name
+	}
+	hum769: human(id: $var769) {
+		name
+	}
+	hum770: human(id: $var770) {
+		name
+	}
+	hum771: human(id: $var771) {
+		name
+	}
+	hum772: human(id: $var772) {
+		name
+	}
+	hum773: human(id: $var773) {
+		name
+	}
+	hum774: human(id: $var774) {
+		name
+	}
+	hum775: human(id: $var775) {
+		name
+	}
+	hum776: human(id: $var776) {
+		name
+	}
+	hum777: human(id: $var777) {
+		name
+	}
+	hum778: human(id: $var778) {
+		name
+	}
+	hum779: human(id: $var779) {
+		name
+	}
+	hum780: human(id: $var780) {
+		name
+	}
+	hum781: human(id: $var781) {
+		name
+	}
+	hum782: human(id: $var782) {
+		name
+	}
+	hum783: human(id: $var783) {
+		name
+	}
+	hum784: human(id: $var784) {
+		name
+	}
+	hum785: human(id: $var785) {
+		name
+	}
+	hum786: human(id: $var786) {
+		name
+	}
+	hum787: human(id: $var787) {
+		name
+	}
+	hum788: human(id: $var788) {
+		name
+	}
+	hum789: human(id: $var789) {
+		name
+	}
+	hum790: human(id: $var790) {
+		name
+	}
+	hum791: human(id: $var791) {
+		name
+	}
+	hum792: human(id: $var792) {
+		name
+	}
+	hum793: human(id: $var793) {
+		name
+	}
+	hum794: human(id: $var794) {
+		name
+	}
+	hum795: human(id: $var795) {
+		name
+	}
+	hum796: human(id: $var796) {
+		name
+	}
+	hum797: human(id: $var797) {
+		name
+	}
+	hum798: human(id: $var798) {
+		name
+	}
+	hum799: human(id: $var799) {
+		name
+	}
+	hum800: human(id: $var800) {
+		name
+	}
+	hum801: human(id: $var801) {
+		name
+	}
+	hum802: human(id: $var802) {
+		name
+	}
+	hum803: human(id: $var803) {
+		name
+	}
+	hum804: human(id: $var804) {
+		name
+	}
+	hum805: human(id: $var805) {
+		name
+	}
+	hum806: human(id: $var806) {
+		name
+	}
+	hum807: human(id: $var807) {
+		name
+	}
+	hum808: human(id: $var808) {
+		name
+	}
+	hum809: human(id: $var809) {
+		name
+	}
+	hum810: human(id: $var810) {
+		name
+	}
+	hum811: human(id: $var811) {
+		name
+	}
+	hum812: human(id: $var812) {
+		name
+	}
+	hum813: human(id: $var813) {
+		name
+	}
+	hum814: human(id: $var814) {
+		name
+	}
+	hum815: human(id: $var815) {
+		name
+	}
+	hum816: human(id: $var816) {
+		name
+	}
+	hum817: human(id: $var817) {
+		name
+	}
+	hum818: human(id: $var818) {
+		name
+	}
+	hum819: human(id: $var819) {
+		name
+	}
+	hum820: human(id: $var820) {
+		name
+	}
+	hum821: human(id: $var821) {
+		name
+	}
+	hum822: human(id: $var822) {
+		name
+	}
+	hum823: human(id: $var823) {
+		name
+	}
+	hum824: human(id: $var824) {
+		name
+	}
+	hum825: human(id: $var825) {
+		name
+	}
+	hum826: human(id: $var826) {
+		name
+	}
+	hum827: human(id: $var827) {
+		name
+	}
+	hum828: human(id: $var828) {
+		name
+	}
+	hum829: human(id: $var829) {
+		name
+	}
+	hum830: human(id: $var830) {
+		name
+	}
+	hum831: human(id: $var831) {
+		name
+	}
+	hum832: human(id: $var832) {
+		name
+	}
+	hum833: human(id: $var833) {
+		name
+	}
+	hum834: human(id: $var834) {
+		name
+	}
+	hum835: human(id: $var835) {
+		name
+	}
+	hum836: human(id: $var836) {
+		name
+	}
+	hum837: human(id: $var837) {
+		name
+	}
+	hum838: human(id: $var838) {
+		name
+	}
+	hum839: human(id: $var839) {
+		name
+	}
+	hum840: human(id: $var840) {
+		name
+	}
+	hum841: human(id: $var841) {
+		name
+	}
+	hum842: human(id: $var842) {
+		name
+	}
+	hum843: human(id: $var843) {
+		name
+	}
+	hum844: human(id: $var844) {
+		name
+	}
+	hum845: human(id: $var845) {
+		name
+	}
+	hum846: human(id: $var846) {
+		name
+	}
+	hum847: human(id: $var847) {
+		name
+	}
+	hum848: human(id: $var848) {
+		name
+	}
+	hum849: human(id: $var849) {
+		name
+	}
+	hum850: human(id: $var850) {
+		name
+	}
+	hum851: human(id: $var851) {
+		name
+	}
+	hum852: human(id: $var852) {
+		name
+	}
+	hum853: human(id: $var853) {
+		name
+	}
+	hum854: human(id: $var854) {
+		name
+	}
+	hum855: human(id: $var855) {
+		name
+	}
+	hum856: human(id: $var856) {
+		name
+	}
+	hum857: human(id: $var857) {
+		name
+	}
+	hum858: human(id: $var858) {
+		name
+	}
+	hum859: human(id: $var859) {
+		name
+	}
+	hum860: human(id: $var860) {
+		name
+	}
+	hum861: human(id: $var861) {
+		name
+	}
+	hum862: human(id: $var862) {
+		name
+	}
+	hum863: human(id: $var863) {
+		name
+	}
+	hum864: human(id: $var864) {
+		name
+	}
+	hum865: human(id: $var865) {
+		name
+	}
+	hum866: human(id: $var866) {
+		name
+	}
+	hum867: human(id: $var867) {
+		name
+	}
+	hum868: human(id: $var868) {
+		name
+	}
+	hum869: human(id: $var869) {
+		name
+	}
+	hum870: human(id: $var870) {
+		name
+	}
+	hum871: human(id: $var871) {
+		name
+	}
+	hum872: human(id: $var872) {
+		name
+	}
+	hum873: human(id: $var873) {
+		name
+	}
+	hum874: human(id: $var874) {
+		name
+	}
+	hum875: human(id: $var875) {
+		name
+	}
+	hum876: human(id: $var876) {
+		name
+	}
+	hum877: human(id: $var877) {
+		name
+	}
+	hum878: human(id: $var878) {
+		name
+	}
+	hum879: human(id: $var879) {
+		name
+	}
+	hum880: human(id: $var880) {
+		name
+	}
+	hum881: human(id: $var881) {
+		name
+	}
+	hum882: human(id: $var882) {
+		name
+	}
+	hum883: human(id: $var883) {
+		name
+	}
+	hum884: human(id: $var884) {
+		name
+	}
+	hum885: human(id: $var885) {
+		name
+	}
+	hum886: human(id: $var886) {
+		name
+	}
+	hum887: human(id: $var887) {
+		name
+	}
+	hum888: human(id: $var888) {
+		name
+	}
+	hum889: human(id: $var889) {
+		name
+	}
+	hum890: human(id: $var890) {
+		name
+	}
+	hum891: human(id: $var891) {
+		name
+	}
+	hum892: human(id: $var892) {
+		name
+	}
+	hum893: human(id: $var893) {
+		name
+	}
+	hum894: human(id: $var894) {
+		name
+	}
+	hum895: human(id: $var895) {
+		name
+	}
+	hum896: human(id: $var896) {
+		name
+	}
+	hum897: human(id: $var897) {
+		name
+	}
+	hum898: human(id: $var898) {
+		name
+	}
+	hum899: human(id: $var899) {
+		name
+	}
+	hum900: human(id: $var900) {
+		name
+	}
+	hum901: human(id: $var901) {
+		name
+	}
+	hum902: human(id: $var902) {
+		name
+	}
+	hum903: human(id: $var903) {
+		name
+	}
+	hum904: human(id: $var904) {
+		name
+	}
+	hum905: human(id: $var905) {
+		name
+	}
+	hum906: human(id: $var906) {
+		name
+	}
+	hum907: human(id: $var907) {
+		name
+	}
+	hum908: human(id: $var908) {
+		name
+	}
+	hum909: human(id: $var909) {
+		name
+	}
+	hum910: human(id: $var910) {
+		name
+	}
+	hum911: human(id: $var911) {
+		name
+	}
+	hum912: human(id: $var912) {
+		name
+	}
+	hum913: human(id: $var913) {
+		name
+	}
+	hum914: human(id: $var914) {
+		name
+	}
+	hum915: human(id: $var915) {
+		name
+	}
+	hum916: human(id: $var916) {
+		name
+	}
+	hum917: human(id: $var917) {
+		name
+	}
+	hum918: human(id: $var918) {
+		name
+	}
+	hum919: human(id: $var919) {
+		name
+	}
+	hum920: human(id: $var920) {
+		name
+	}
+	hum921: human(id: $var921) {
+		name
+	}
+	hum922: human(id: $var922) {
+		name
+	}
+	hum923: human(id: $var923) {
+		name
+	}
+	hum924: human(id: $var924) {
+		name
+	}
+	hum925: human(id: $var925) {
+		name
+	}
+	hum926: human(id: $var926) {
+		name
+	}
+	hum927: human(id: $var927) {
+		name
+	}
+	hum928: human(id: $var928) {
+		name
+	}
+	hum929: human(id: $var929) {
+		name
+	}
+	hum930: human(id: $var930) {
+		name
+	}
+	hum931: human(id: $var931) {
+		name
+	}
+	hum932: human(id: $var932) {
+		name
+	}
+	hum933: human(id: $var933) {
+		name
+	}
+	hum934: human(id: $var934) {
+		name
+	}
+	hum935: human(id: $var935) {
+		name
+	}
+	hum936: human(id: $var936) {
+		name
+	}
+	hum937: human(id: $var937) {
+		name
+	}
+	hum938: human(id: $var938) {
+		name
+	}
+	hum939: human(id: $var939) {
+		name
+	}
+	hum940: human(id: $var940) {
+		name
+	}
+	hum941: human(id: $var941) {
+		name
+	}
+	hum942: human(id: $var942) {
+		name
+	}
+	hum943: human(id: $var943) {
+		name
+	}
+	hum944: human(id: $var944) {
+		name
+	}
+	hum945: human(id: $var945) {
+		name
+	}
+	hum946: human(id: $var946) {
+		name
+	}
+	hum947: human(id: $var947) {
+		name
+	}
+	hum948: human(id: $var948) {
+		name
+	}
+	hum949: human(id: $var949) {
+		name
+	}
+	hum950: human(id: $var950) {
+		name
+	}
+	hum951: human(id: $var951) {
+		name
+	}
+	hum952: human(id: $var952) {
+		name
+	}
+	hum953: human(id: $var953) {
+		name
+	}
+	hum954: human(id: $var954) {
+		name
+	}
+	hum955: human(id: $var955) {
+		name
+	}
+	hum956: human(id: $var956) {
+		name
+	}
+	hum957: human(id: $var957) {
+		name
+	}
+	hum958: human(id: $var958) {
+		name
+	}
+	hum959: human(id: $var959) {
+		name
+	}
+	hum960: human(id: $var960) {
+		name
+	}
+	hum961: human(id: $var961) {
+		name
+	}
+	hum962: human(id: $var962) {
+		name
+	}
+	hum963: human(id: $var963) {
+		name
+	}
+	hum964: human(id: $var964) {
+		name
+	}
+	hum965: human(id: $var965) {
+		name
+	}
+	hum966: human(id: $var966) {
+		name
+	}
+	hum967: human(id: $var967) {
+		name
+	}
+	hum968: human(id: $var968) {
+		name
+	}
+	hum969: human(id: $var969) {
+		name
+	}
+	hum970: human(id: $var970) {
+		name
+	}
+	hum971: human(id: $var971) {
+		name
+	}
+	hum972: human(id: $var972) {
+		name
+	}
+	hum973: human(id: $var973) {
+		name
+	}
+	hum974: human(id: $var974) {
+		name
+	}
+	hum975: human(id: $var975) {
+		name
+	}
+	hum976: human(id: $var976) {
+		name
+	}
+	hum977: human(id: $var977) {
+		name
+	}
+	hum978: human(id: $var978) {
+		name
+	}
+	hum979: human(id: $var979) {
+		name
+	}
+	hum980: human(id: $var980) {
+		name
+	}
+	hum981: human(id: $var981) {
+		name
+	}
+	hum982: human(id: $var982) {
+		name
+	}
+	hum983: human(id: $var983) {
+		name
+	}
+	hum984: human(id: $var984) {
+		name
+	}
+	hum985: human(id: $var985) {
+		name
+	}
+	hum986: human(id: $var986) {
+		name
+	}
+	hum987: human(id: $var987) {
+		name
+	}
+	hum988: human(id: $var988) {
+		name
+	}
+	hum989: human(id: $var989) {
+		name
+	}
+	hum990: human(id: $var990) {
+		name
+	}
+	hum991: human(id: $var991) {
+		name
+	}
+	hum992: human(id: $var992) {
+		name
+	}
+	hum993: human(id: $var993) {
+		name
+	}
+	hum994: human(id: $var994) {
+		name
+	}
+	hum995: human(id: $var995) {
+		name
+	}
+	hum996: human(id: $var996) {
+		name
+	}
+	hum997: human(id: $var997) {
+		name
+	}
+	hum998: human(id: $var998) {
+		name
+	}
+	hum999: human(id: $var999) {
+		name
+	}
+	hum1000: human(id: $var1000) {
+		name
+	}
+}

--- a/benchmarks/corpus/example_query.graphql
+++ b/benchmarks/corpus/example_query.graphql
@@ -1,0 +1,11 @@
+query ExampleQuery($topProductsFirst: Int) {
+  me { 
+    id
+  }
+  topProducts(first:  $topProductsFirst) {
+    name
+    price
+    inStock
+ weight
+ test test test test test test test test test test test test }
+}

--- a/benchmarks/examples/gate.rs
+++ b/benchmarks/examples/gate.rs
@@ -1,0 +1,74 @@
+//! Run the correctness gate on its own and exit non-zero if any corpus entry is excluded.
+//!
+//! The bench runs the same gate in-process before timing; this exists so the gate's table and its
+//! verdict can be captured without a full criterion run, and so CI or a reviewer can ask the
+//! question "are both parsers doing the same job on this corpus?" and get an exit code:
+//!
+//! ```text
+//! cargo run -p smear-apollo-bench --example gate --release          # table + verdict
+//! cargo run -p smear-apollo-bench --example gate --release -- kinds # + node-kind histograms
+//! ```
+//!
+//! **An example rather than a `[[bin]]`, deliberately.** Every existing workspace member is a
+//! library, so smear's CI `cross` job — `cargo build --target <t>` over fifteen targets, with
+//! nothing installed but `rustup target add` — has never had to *link an executable*. A `[[bin]]`
+//! here would be the workspace's first, and `cargo build` builds bins by default: the job then
+//! fails at link time on every target whose cross linker the runner lacks (verified locally:
+//! `aarch64-linux-android` and `x86_64-pc-windows-gnu` both fail with
+//! `could not compile ... (bin "gate")`). `cargo build` does **not** build examples, so as an
+//! example this file leaves the cross job building exactly what it built before.
+
+use smear_apollo_bench::{CORPUS, kind_histograms, print_gate, run_gate};
+
+fn main() -> std::process::ExitCode {
+  // `gate kinds` additionally dumps each side's node-kind histogram, which is what turns gate
+  // 3's node-count difference from a bare number into an explanation.
+  let want_kinds = std::env::args().any(|a| a == "kinds");
+
+  println!("## Corpus");
+  println!();
+  println!("| entry | bytes | tier-2 shape | provenance |");
+  println!("|---|---:|---|---|");
+  for entry in CORPUS {
+    println!(
+      "| {} | {} | {:?} | {} |",
+      entry.name,
+      entry.len(),
+      entry.shape,
+      entry.provenance
+    );
+  }
+  println!();
+
+  let rows = run_gate();
+  print_gate(&rows);
+
+  if want_kinds {
+    for entry in CORPUS {
+      let (smear, apollo) = kind_histograms(entry);
+      println!("### node kinds — {}", entry.name);
+      println!();
+      println!("| rank | smear kind | count | apollo kind | count |");
+      println!("|---:|---|---:|---|---:|");
+      let rows = smear.len().max(apollo.len());
+      for i in 0..rows {
+        let (sk, sn) = smear
+          .get(i)
+          .map(|(k, n)| (k.as_str(), n.to_string()))
+          .unwrap_or(("", String::new()));
+        let (ak, an) = apollo
+          .get(i)
+          .map(|(k, n)| (k.as_str(), n.to_string()))
+          .unwrap_or(("", String::new()));
+        println!("| {} | {} | {} | {} | {} |", i + 1, sk, sn, ak, an);
+      }
+      println!();
+    }
+  }
+
+  if rows.iter().all(|r| r.eligible()) {
+    std::process::ExitCode::SUCCESS
+  } else {
+    std::process::ExitCode::FAILURE
+  }
+}

--- a/benchmarks/examples/perfloop.rs
+++ b/benchmarks/examples/perfloop.rs
@@ -1,0 +1,58 @@
+//! A/B timing loop for one corpus entry: **min over blocks**, not mean.
+//!
+//! Criterion reports a mean with a bootstrap interval, which is the right statistic for an
+//! idle machine and the wrong one for a shared one: a single interfering process inflates the
+//! mean of a whole block and the interval with it. The minimum over independent blocks is the
+//! order statistic that interference can only move in one direction, so on a loaded machine it
+//! is the estimator that compares two builds rather than two schedulings.
+//!
+//! ```text
+//! cargo run -q -p smear-apollo-bench --example perfloop --release -- alias
+//! ```
+
+use std::{hint::black_box, time::Instant};
+
+use smear_apollo_bench::{CORPUS, apollo_parse, smear_parse};
+
+fn main() {
+  let args: Vec<String> = std::env::args().skip(1).collect();
+  let want = args.first().map_or("alias", String::as_str);
+  let entry = CORPUS
+    .iter()
+    .find(|e| e.name == want)
+    .expect("no such corpus entry");
+  let src = entry.source;
+
+  // Block sizes chosen so one block is ~0.3 s on this entry: long enough to amortise the
+  // clock read, short enough that a block is unlikely to span an interference event.
+  let iters = (60_000_000 / src.len().max(1)).clamp(20, 20_000);
+
+  for _ in 0..iters / 4 {
+    black_box(smear_parse(black_box(src)));
+  }
+
+  let mut smear_best = f64::MAX;
+  let mut apollo_best = f64::MAX;
+  for _ in 0..9 {
+    let t = Instant::now();
+    for _ in 0..iters {
+      black_box(smear_parse(black_box(src)));
+    }
+    let us = t.elapsed().as_secs_f64() * 1e6 / iters as f64;
+    smear_best = smear_best.min(us);
+
+    let t = Instant::now();
+    for _ in 0..iters {
+      black_box(apollo_parse(black_box(src)));
+    }
+    let us = t.elapsed().as_secs_f64() * 1e6 / iters as f64;
+    apollo_best = apollo_best.min(us);
+  }
+
+  println!(
+    "{} {} bytes  iters={iters}  smear {smear_best:.1} us  apollo {apollo_best:.1} us  gap {:.1} us",
+    entry.name,
+    src.len(),
+    smear_best - apollo_best,
+  );
+}

--- a/benchmarks/examples/treedump.rs
+++ b/benchmarks/examples/treedump.rs
@@ -13,7 +13,40 @@
 //! cargo run -p smear-apollo-bench --example treedump --release | shasum -a 256
 //! cargo run -p smear-apollo-bench --example treedump --release -- perturbed | shasum -a 256
 //! cargo run -p smear-apollo-bench --example treedump --release -- selfcheck
+//! cargo run -p smear-apollo-bench --example treedump --release -- malformed | shasum -a 256
 //! ```
+//!
+//! # Two more modes, because the clean corpus cannot exercise recovery at all
+//!
+//! The three entries in [`CORPUS`] are real, hand-picked-*clean* GraphQL documents: every one of
+//! them takes **zero** emitter checkpoints, so a clean run exercises no rewind, no recovery-hole
+//! wrap, no gap tile and no error-coverage decision — the entire recovery path stays dark. A
+//! byte-identity claim resting only on that corpus is not evidence about any of those; it is
+//! silent about them. These two modes are what makes the recovery path non-vacuous:
+//!
+//! * **`malformed`** — [`MALFORMED`], 24 hand-broken documents: unclosed braces, unterminated
+//!   strings and block strings, junk prefixes and suffixes, input with nothing lexable, empty
+//!   input, bad defaults, bad variables. Cheap; safe to run any time.
+//!
+//!   ```text
+//!   cargo run -p smear-apollo-bench --example treedump --release -- malformed | shasum -a 256
+//!   ```
+//!
+//! * **`prefixes`** — [`prefixes_dump`] over every [`CORPUS`] entry: every byte offset for the
+//!   two small entries, every 37th byte of `alias` (a prime stride, so the cut points never align
+//!   with a repeating structure in the document). Truncating at each offset is the cheapest way
+//!   to reach thousands of *independent* recovery sites, each ending mid-production somewhere
+//!   different. **This mode is not cheap**: roughly 9,300 documents, on the order of 45 million
+//!   lines of dump. It is gated behind the explicit `prefixes` argument exactly like every other
+//!   mode on this page, so it is never what the no-argument default, `perturbed`, `selfcheck` or
+//!   `malformed` run. Nothing in this repository invokes it from CI — `cargo build`/`cargo test`
+//!   only ever *compile* an example, never run its `main`, and no workflow passes this example
+//!   any argument at all. Do not add one that does; redirect to a file rather than a terminal.
+//!
+//!   ```text
+//!   cargo run -p smear-apollo-bench --example treedump --release -- prefixes > /tmp/prefixes.dump
+//!   shasum -a 256 /tmp/prefixes.dump
+//!   ```
 //!
 //! # Comparing two tokora checkouts
 //!
@@ -389,6 +422,58 @@ fn selfcheck() -> bool {
   all_ok
 }
 
+/// Hand-written broken documents — the corpus the clean entries cannot be.
+///
+/// A clean parse of this grammar takes **zero** emitter checkpoints, so it exercises no rewind,
+/// no recovery-hole wrap, no gap tile and no error-coverage decision. Every one of those lives
+/// on the recovery path, and the recovery path is only reachable from input that is wrong. A
+/// byte-identity claim about the sink that rests on clean input says nothing about them.
+const MALFORMED: &[(&str, &str)] = &[
+  ("unclosed_brace", "query Q { a { b "),
+  ("stray_colon", "query Q { : a }"),
+  ("bad_directive", "query Q @ @@ { a }"),
+  ("unterminated_string", "{ f(a: \"abc) }"),
+  ("junk_prefix", "%%% query Q { a }"),
+  ("empty_args", "{ f() }"),
+  ("bad_type", "query Q($v: ) { a }"),
+  ("dangling_spread", "{ ... }"),
+  ("bad_variable", "query Q($ $x: Int = ) { a }"),
+  ("mixed_garbage", "type T { f: Int } ### $$$ ### { a }"),
+  ("deep_nest_broken", "{ a { b { c { d { e ("),
+  ("bad_default", "query Q($x: Int = @) { a }"),
+  ("unterminated_block_string", "{ f(a: \"\"\"body ) }"),
+  ("lone_dollar", "$"),
+  ("nothing_lexable", "\u{7}\u{7}\u{7}"),
+  ("empty", ""),
+  ("only_trivia", "   \n\t # comment\n"),
+  ("trailing_garbage_after_doc", "{ a } %%%"),
+  ("leading_and_trailing_garbage", "%% { a } %%"),
+  ("bad_escape_in_string", "{ f(a: \"x\\q\") }"),
+  ("unclosed_paren_then_brace", "{ f(a: 1 }"),
+  ("repeated_colons", "{ a:::: b }"),
+  ("sdl_and_executable_mixed", "schema { query: } { a }"),
+  ("number_garbage", "{ f(a: 1.2.3e) }"),
+];
+
+/// Every prefix of a source — the editor-typing corpus.
+///
+/// Truncating a document at each byte in turn is the cheapest way to reach thousands of
+/// *independent* recovery sites: each prefix ends mid-production somewhere different, so
+/// between them they drive the recovery scanner, the hole wrap and the trailing-gap tile
+/// across the whole grammar rather than at the handful of points a hand-written broken
+/// document happens to hit.
+fn prefixes_dump(name: &str, src: &str, stride: usize) -> String {
+  let mut out = String::new();
+  let mut at = 0usize;
+  while at <= src.len() {
+    if src.is_char_boundary(at) {
+      out.push_str(&dump(&format!("{name} prefix {at}"), &src[..at]));
+    }
+    at += stride;
+  }
+  out
+}
+
 fn main() -> ExitCode {
   let args: Vec<String> = std::env::args().skip(1).collect();
 
@@ -398,6 +483,30 @@ fn main() -> ExitCode {
     } else {
       ExitCode::FAILURE
     };
+  }
+
+  if args.iter().any(|a| a == "malformed") {
+    let mut out = String::new();
+    for (name, src) in MALFORMED {
+      out.push_str(&dump(&format!("{name} : {} bytes", src.len()), src));
+    }
+    print!("{out}");
+    return ExitCode::SUCCESS;
+  }
+
+  // ~45 million lines of dump. Gated behind this explicit argument exactly like every other mode
+  // on this page (see the module doc); nothing in this repository's CI passes any argument to
+  // this example, so this can only run when a human types `-- prefixes` on purpose.
+  if args.iter().any(|a| a == "prefixes") {
+    let mut out = String::new();
+    for entry in CORPUS {
+      // Every byte of the small entries; every 37th of the big one (a prime stride, so the cut
+      // points do not align with any repeating structure in the document).
+      let stride = if entry.source.len() > 20_000 { 37 } else { 1 };
+      out.push_str(&prefixes_dump(entry.name, entry.source, stride));
+    }
+    print!("{out}");
+    return ExitCode::SUCCESS;
   }
 
   let perturbed = args.iter().any(|a| a == "perturbed");

--- a/benchmarks/examples/treedump.rs
+++ b/benchmarks/examples/treedump.rs
@@ -16,43 +16,50 @@
 //! cargo run -p smear-apollo-bench --example treedump --release -- malformed | shasum -a 256
 //! ```
 //!
+//! # This file is the human-facing half of the harness
+//!
+//! The machinery — the row projection, the escape, the renderer, the four corpora and the recorded
+//! hashes — lives in [`smear_apollo_bench::dump`], not here. That is so the *other* caller can
+//! reach it: `tests/byte_identity.rs` recomputes all four hashes and fails if any has moved. This
+//! example and that gate therefore dump the same bytes by construction rather than by two
+//! implementations agreeing, which is the only arrangement in which `treedump | shasum` and the
+//! gate can never disagree.
+//!
 //! # Two more modes, because the clean corpus cannot exercise recovery at all
 //!
-//! The three entries in [`CORPUS`] are real, hand-picked-*clean* GraphQL documents: every one of
+//! The three entries in `CORPUS` are real, hand-picked-*clean* GraphQL documents: every one of
 //! them takes **zero** emitter checkpoints, so a clean run exercises no rewind, no recovery-hole
 //! wrap, no gap tile and no error-coverage decision — the entire recovery path stays dark. A
 //! byte-identity claim resting only on that corpus is not evidence about any of those; it is
 //! silent about them. These two modes are what makes the recovery path non-vacuous:
 //!
-//! * **`malformed`** — [`MALFORMED`], 24 hand-broken documents: unclosed braces, unterminated
-//!   strings and block strings, junk prefixes and suffixes, input with nothing lexable, empty
-//!   input, bad defaults, bad variables. Cheap; safe to run any time.
+//! * **`malformed`** — 24 hand-broken documents: unclosed braces, unterminated strings and block
+//!   strings, junk prefixes and suffixes, input with nothing lexable, empty input, bad defaults,
+//!   bad variables. Cheap; safe to run any time.
 //!
-//!   ```text
-//!   cargo run -p smear-apollo-bench --example treedump --release -- malformed | shasum -a 256
-//!   ```
-//!
-//! * **`prefixes`** — [`prefixes_dump`] over every [`CORPUS`] entry: every byte offset for the
-//!   two small entries, every 37th byte of `alias` (a prime stride, so the cut points never align
-//!   with a repeating structure in the document). Truncating at each offset is the cheapest way
-//!   to reach thousands of *independent* recovery sites, each ending mid-production somewhere
-//!   different. **This mode is not cheap**: roughly 9,300 documents, on the order of 45 million
-//!   lines of dump. It is gated behind the explicit `prefixes` argument exactly like every other
-//!   mode on this page, so it is never what the no-argument default, `perturbed`, `selfcheck` or
-//!   `malformed` run. Nothing in this repository invokes it from CI — `cargo build`/`cargo test`
-//!   only ever *compile* an example, never run its `main`, and no workflow passes this example
-//!   any argument at all. Do not add one that does; redirect to a file rather than a terminal.
+//! * **`prefixes`** — every cut point of every clean entry: every byte offset for the two small
+//!   entries, every 37th byte of `alias` (a prime stride, so the cut points never align with a
+//!   repeating structure in the document). Truncating at each offset is the cheapest way to reach
+//!   thousands of *independent* recovery sites, each ending mid-production somewhere different.
+//!   **This mode is not cheap**: roughly 9,300 documents, on the order of 45 million lines of
+//!   dump. It is gated behind the explicit `prefixes` argument exactly like every other mode on
+//!   this page, so it is never what the no-argument default, `perturbed`, `selfcheck` or
+//!   `malformed` run. Redirect it to a file rather than a terminal.
 //!
 //!   ```text
 //!   cargo run -p smear-apollo-bench --example treedump --release -- prefixes > /tmp/prefixes.dump
 //!   shasum -a 256 /tmp/prefixes.dump
 //!   ```
 //!
+//!   Note that `tests/byte_identity.rs` hashes this same corpus in **bounded memory** without
+//!   writing 1.4 GB anywhere, so checking it does not require the redirect above.
+//!
 //! # Comparing two tokora checkouts
 //!
-//! Point the `tokora` patch at each checkout in turn with `--config`, never by editing the
-//! committed `[patch.crates-io]` path, and give each variant its own `CARGO_TARGET_DIR` so the two
-//! builds cannot contaminate each other:
+//! This crate takes tokora from crates.io, so the committed configuration measures what a real
+//! consumer gets. To measure an unpublished tokora instead, point the patch at each checkout in
+//! turn with `--config`, never by editing a committed manifest, and give each variant its own
+//! `CARGO_TARGET_DIR` so the two builds cannot contaminate each other:
 //!
 //! ```text
 //! for t in /path/to/tokora-a /path/to/tokora-b; do
@@ -97,184 +104,15 @@
 //! fifteen-target `cross` job ever had to link, and it would fail on every target whose linker the
 //! runner lacks.
 
-use core::fmt::Write as _;
-use std::process::ExitCode;
+use std::{
+  io::{BufWriter, Write as _},
+  process::ExitCode,
+};
 
-use rowan::{NodeOrToken, WalkEvent};
-use smear_apollo_bench::{CORPUS, Entry, smear_parse};
-use smear_parser::graphql::lossless::SyntaxNode;
-
-/// One element of a CST, projected onto the four axes the dump prints.
-///
-/// Materialised rather than streamed straight to the output so that [`selfcheck`] can compare two
-/// trees **column by column** — and therefore state "these two differ only in kind" as a checked
-/// fact rather than as a hope about the source pair it chose.
-struct Row {
-  /// Levels of nesting below the root. The root itself is 0.
-  depth: usize,
-  /// `{:?}` of the node's or token's `SyntaxKind`.
-  kind: String,
-  /// Absolute byte offset of the element's first byte.
-  start: u32,
-  /// Absolute byte offset one past the element's last byte.
-  end: u32,
-  /// `Some` for a token, carrying its escaped text; `None` for an interior node.
-  ///
-  /// This is also what tells a node line from a token line on the page: a token always carries a
-  /// quoted text and a node never does.
-  text: Option<String>,
-}
-
-/// Escape a token's text so that one token is always one line, forever.
-///
-/// Lifted from `smear-parser/tests/lossless_golden.rs`, and for its reason: backslash, quote and
-/// the three whitespace forms that would break the layout are spelled out; every other C0/C1
-/// control, plus the byte-order mark, becomes `\u{…}`. Anything else — including ordinary
-/// multi-byte text — is written through verbatim.
-///
-/// `char::escape_debug` is the wrong tool here: its notion of "printable" is a Unicode table that
-/// moves between toolchain releases, so a dump hashed on one toolchain and compared on another
-/// could differ for a reason that has nothing to do with the tree. `char::is_control` is a fixed
-/// two-range test and cannot drift.
-fn escape(text: &str) -> String {
-  let mut out = String::with_capacity(text.len());
-  for ch in text.chars() {
-    match ch {
-      '\\' => out.push_str("\\\\"),
-      '"' => out.push_str("\\\""),
-      '\n' => out.push_str("\\n"),
-      '\r' => out.push_str("\\r"),
-      '\t' => out.push_str("\\t"),
-      c if c.is_control() || c == '\u{feff}' => {
-        let _ = write!(out, "\\u{{{:04x}}}", c as u32);
-      }
-      c => out.push(c),
-    }
-  }
-  out
-}
-
-/// Walk a tree with `preorder_with_tokens` and project every element onto a [`Row`].
-///
-/// `preorder_with_tokens` rather than `descendants_with_tokens` because only the former reports
-/// `Leave`, and without `Leave` there is no depth — which would cost the dump its one defence
-/// against two differently-nested trees flattening to the same sequence.
-fn rows(root: &SyntaxNode) -> Vec<Row> {
-  let mut out = Vec::new();
-  let mut depth = 0usize;
-  for event in root.preorder_with_tokens() {
-    match event {
-      WalkEvent::Enter(element) => {
-        let range = element.text_range();
-        out.push(Row {
-          depth,
-          kind: match &element {
-            NodeOrToken::Node(node) => format!("{:?}", node.kind()),
-            NodeOrToken::Token(token) => format!("{:?}", token.kind()),
-          },
-          start: u32::from(range.start()),
-          end: u32::from(range.end()),
-          text: match &element {
-            NodeOrToken::Node(_) => None,
-            NodeOrToken::Token(token) => Some(escape(token.text())),
-          },
-        });
-        depth += 1;
-      }
-      WalkEvent::Leave(_) => depth -= 1,
-    }
-  }
-  out
-}
-
-/// Render rows in `.rast` style: `<indent><Kind>@<start>..<end>` for a node, plus ` "<text>"` for
-/// a token.
-fn render(rows: &[Row]) -> String {
-  let mut out = String::new();
-  for row in rows {
-    for _ in 0..row.depth {
-      out.push_str("  ");
-    }
-    let _ = write!(out, "{}@{}..{}", row.kind, row.start, row.end);
-    if let Some(text) = &row.text {
-      let _ = write!(out, " \"{text}\"");
-    }
-    out.push('\n');
-  }
-  out
-}
-
-/// The full dump for one source: a header, the tree, a footer, one line per diagnostic, a blank.
-///
-/// The footer is a summary of facts already implied by the lines above it, restated in one place
-/// so that a `diff` of two dumps that disagree opens with *what* disagreed — a node count, a root
-/// span, a round-trip verdict — before the reader has to find the first differing element line.
-fn dump(header: &str, src: &str) -> String {
-  let parse = smear_parse(src);
-  let root = parse.syntax();
-  let rows = rows(&root);
-
-  let nodes = rows.iter().filter(|r| r.text.is_none()).count();
-  let tokens = rows.len() - nodes;
-  let round_trips = root.text() == src;
-
-  let mut out = String::new();
-  let _ = writeln!(out, "== {header} ==");
-  out.push_str(&render(&rows));
-  let _ = writeln!(
-    out,
-    "-- {nodes} nodes, {tokens} tokens, root {}..{}, round-trip {}, {} diagnostics --",
-    u32::from(root.text_range().start()),
-    u32::from(root.text_range().end()),
-    if round_trips {
-      "byte-exact"
-    } else {
-      "MISMATCH"
-    },
-    parse.diagnostics().len(),
-  );
-  for (i, d) in parse.diagnostics().iter().enumerate() {
-    let span = d.span();
-    let _ = writeln!(
-      out,
-      "   diagnostic {i}: {}..{} {:?} skipped={}",
-      span.start,
-      span.end,
-      d.severity(),
-      match d.skipped_tokens() {
-        Some(n) => n.to_string(),
-        None => "-".to_string(),
-      },
-    );
-  }
-  out.push('\n');
-  out
-}
-
-/// Replace the entry's first `:` with a space, and report which byte moved.
-///
-/// **Why this perturbation.** The requirement on a control is that it change the *tree* and not
-/// merely the page. A colon in GraphQL is a grammatical separator — variable definition, argument,
-/// field definition, object field — and turning one into whitespace makes the production that
-/// required it fail and recover. What makes it a good control specifically is what it does *not*
-/// change: it is a one-byte substitution, so the document's length is identical, every byte other
-/// than that one is identical, the root span is unchanged, the token count is unchanged, and the
-/// parse still round-trips byte-exactly. So the perturbed dump is not a differently-*formatted*
-/// dump and it is not a dump of differently-sized input; the hash moves because the tree moved.
-///
-/// Measured, on the three entries as they stand: node counts go 33/1082/11017 → 32/1076/12016 and
-/// the diagnostic counts go 0/0/0 → 2/7/7004, while **round-trip stays byte-exact on all three**.
-/// So `gate.rs`'s round-trip column is blind to this perturbation and only its error column is
-/// not — and the pair in [`selfcheck`] is blind to the error column too.
-fn perturb(src: &str) -> Option<(String, usize)> {
-  // `:` is ASCII, so the byte index `find` returns is a char boundary in both directions.
-  let at = src.find(':')?;
-  let mut out = String::with_capacity(src.len());
-  out.push_str(&src[..at]);
-  out.push(' ');
-  out.push_str(&src[at + 1..]);
-  Some((out, at))
-}
+use smear_apollo_bench::{
+  dump::{Corpus, for_each_chunk, render, rows},
+  smear_parse,
+};
 
 /// One `selfcheck` case: a pair of sources chosen so that their trees differ along exactly one
 /// axis.
@@ -422,58 +260,6 @@ fn selfcheck() -> bool {
   all_ok
 }
 
-/// Hand-written broken documents — the corpus the clean entries cannot be.
-///
-/// A clean parse of this grammar takes **zero** emitter checkpoints, so it exercises no rewind,
-/// no recovery-hole wrap, no gap tile and no error-coverage decision. Every one of those lives
-/// on the recovery path, and the recovery path is only reachable from input that is wrong. A
-/// byte-identity claim about the sink that rests on clean input says nothing about them.
-const MALFORMED: &[(&str, &str)] = &[
-  ("unclosed_brace", "query Q { a { b "),
-  ("stray_colon", "query Q { : a }"),
-  ("bad_directive", "query Q @ @@ { a }"),
-  ("unterminated_string", "{ f(a: \"abc) }"),
-  ("junk_prefix", "%%% query Q { a }"),
-  ("empty_args", "{ f() }"),
-  ("bad_type", "query Q($v: ) { a }"),
-  ("dangling_spread", "{ ... }"),
-  ("bad_variable", "query Q($ $x: Int = ) { a }"),
-  ("mixed_garbage", "type T { f: Int } ### $$$ ### { a }"),
-  ("deep_nest_broken", "{ a { b { c { d { e ("),
-  ("bad_default", "query Q($x: Int = @) { a }"),
-  ("unterminated_block_string", "{ f(a: \"\"\"body ) }"),
-  ("lone_dollar", "$"),
-  ("nothing_lexable", "\u{7}\u{7}\u{7}"),
-  ("empty", ""),
-  ("only_trivia", "   \n\t # comment\n"),
-  ("trailing_garbage_after_doc", "{ a } %%%"),
-  ("leading_and_trailing_garbage", "%% { a } %%"),
-  ("bad_escape_in_string", "{ f(a: \"x\\q\") }"),
-  ("unclosed_paren_then_brace", "{ f(a: 1 }"),
-  ("repeated_colons", "{ a:::: b }"),
-  ("sdl_and_executable_mixed", "schema { query: } { a }"),
-  ("number_garbage", "{ f(a: 1.2.3e) }"),
-];
-
-/// Every prefix of a source — the editor-typing corpus.
-///
-/// Truncating a document at each byte in turn is the cheapest way to reach thousands of
-/// *independent* recovery sites: each prefix ends mid-production somewhere different, so
-/// between them they drive the recovery scanner, the hole wrap and the trailing-gap tile
-/// across the whole grammar rather than at the handful of points a hand-written broken
-/// document happens to hit.
-fn prefixes_dump(name: &str, src: &str, stride: usize) -> String {
-  let mut out = String::new();
-  let mut at = 0usize;
-  while at <= src.len() {
-    if src.is_char_boundary(at) {
-      out.push_str(&dump(&format!("{name} prefix {at}"), &src[..at]));
-    }
-    at += stride;
-  }
-  out
-}
-
 fn main() -> ExitCode {
   let args: Vec<String> = std::env::args().skip(1).collect();
 
@@ -485,67 +271,22 @@ fn main() -> ExitCode {
     };
   }
 
-  if args.iter().any(|a| a == "malformed") {
-    let mut out = String::new();
-    for (name, src) in MALFORMED {
-      out.push_str(&dump(&format!("{name} : {} bytes", src.len()), src));
-    }
-    print!("{out}");
-    return ExitCode::SUCCESS;
-  }
+  // `prefixes` is ~45 million lines. Gated behind its explicit argument exactly like every other
+  // mode on this page (see the module doc); nothing in this repository's CI passes any argument
+  // to this example, so it can only run when a human types `-- prefixes` on purpose.
+  let corpus = Corpus::ALL
+    .into_iter()
+    .find(|c| args.iter().any(|a| a == c.name()))
+    .unwrap_or(Corpus::Clean);
 
-  // ~45 million lines of dump. Gated behind this explicit argument exactly like every other mode
-  // on this page (see the module doc); nothing in this repository's CI passes any argument to
-  // this example, so this can only run when a human types `-- prefixes` on purpose.
-  if args.iter().any(|a| a == "prefixes") {
-    let mut out = String::new();
-    for entry in CORPUS {
-      // Every byte of the small entries; every 37th of the big one (a prime stride, so the cut
-      // points do not align with any repeating structure in the document).
-      let stride = if entry.source.len() > 20_000 { 37 } else { 1 };
-      out.push_str(&prefixes_dump(entry.name, entry.source, stride));
-    }
-    print!("{out}");
-    return ExitCode::SUCCESS;
-  }
-
-  let perturbed = args.iter().any(|a| a == "perturbed");
-
-  // Built whole and written once. At ~45,000 lines a `println!` per element spends most of its
-  // time re-acquiring the stdout lock, and the dump is a single artifact anyway — it is going to
-  // be hashed or diffed, never read as it streams.
-  let mut out = String::new();
-  for entry in CORPUS {
-    out.push_str(&entry_dump(entry, perturbed));
-  }
-  print!("{out}");
+  // Streamed through one buffered, locked handle. At ~45,000 lines an unbuffered write per
+  // element spends most of its time re-acquiring the stdout lock, and the dump is a single
+  // artifact anyway — it is going to be hashed or diffed, never read as it streams.
+  let stdout = std::io::stdout();
+  let mut out = BufWriter::with_capacity(1 << 20, stdout.lock());
+  for_each_chunk(corpus, |chunk| {
+    let _ = out.write_all(chunk.as_bytes());
+  });
+  let _ = out.flush();
   ExitCode::SUCCESS
-}
-
-/// One corpus entry's dump, in whichever of the two modes was asked for.
-fn entry_dump(entry: &Entry, perturbed: bool) -> String {
-  if perturbed {
-    match perturb(entry.source) {
-      Some((src, at)) => dump(
-        &format!(
-          "{} : {} bytes : PERTURBED byte {at} ':' -> ' '",
-          entry.name,
-          src.len()
-        ),
-        &src,
-      ),
-      // Not a case any current entry hits, and not one to paper over: a corpus entry with no
-      // colon would silently make the control identical to the dump it is a control for.
-      None => format!(
-        "== {} : {} bytes : NOT PERTURBED (no ':' in the source) ==\n\n",
-        entry.name,
-        entry.len()
-      ),
-    }
-  } else {
-    dump(
-      &format!("{} : {} bytes", entry.name, entry.len()),
-      entry.source,
-    )
-  }
 }

--- a/benchmarks/examples/treedump.rs
+++ b/benchmarks/examples/treedump.rs
@@ -1,0 +1,442 @@
+//! Dump every corpus entry's finished CST — every node and every token, in document order, with
+//! its depth, its kind and its exact byte span — so that two builds of the parser can be compared
+//! as **trees** rather than as text.
+//!
+//! Every tokora performance branch ships on the claim "the output trees are byte-identical". This
+//! is the command that decides it. Its sibling [`gate.rs`](./gate.rs) checks that each side parses
+//! without error and that `tree.text()` reproduces the source byte-for-byte; that is necessary and
+//! it is *not* sufficient, because text is the tree with its shape projected away. `query Q { f }`
+//! is one `OperationDefinition` through the mixed root and five `Error` nodes through the SDL-only
+//! root, and the two round-trip to the same bytes. Everything in that gap is this file's to catch.
+//!
+//! ```text
+//! cargo run -p smear-apollo-bench --example treedump --release | shasum -a 256
+//! cargo run -p smear-apollo-bench --example treedump --release -- perturbed | shasum -a 256
+//! cargo run -p smear-apollo-bench --example treedump --release -- selfcheck
+//! ```
+//!
+//! # Comparing two tokora checkouts
+//!
+//! Point the `tokora` patch at each checkout in turn with `--config`, never by editing the
+//! committed `[patch.crates-io]` path, and give each variant its own `CARGO_TARGET_DIR` so the two
+//! builds cannot contaminate each other:
+//!
+//! ```text
+//! for t in /path/to/tokora-a /path/to/tokora-b; do
+//!   CARGO_TARGET_DIR=/tmp/td-$(basename $t) \
+//!   cargo --config "patch.crates-io.tokora.path=\"$t\"" \
+//!     run -p smear-apollo-bench --example treedump --release | shasum -a 256
+//! done
+//! ```
+//!
+//! Equal hashes mean the two builds produced the same tree, node for node, token for token, span
+//! for span. Unequal hashes mean they did not, and `diff` over the two dumps names where.
+//!
+//! # The format, and why it discriminates
+//!
+//! rust-analyzer's `.rast` style, the same one `smear-parser`'s golden-tree gate uses
+//! (`smear-parser/tests/lossless_golden.rs`): one line per element, two spaces of indent per level
+//! of depth, each line carrying the kind and the absolute byte range, and each **token** line
+//! additionally carrying its text, escaped so that one element is always exactly one line. Each
+//! column is one axis of structural change, and none of the four is redundant:
+//!
+//! * **indent** — a re-parented subtree shifts a whole block, so re-parenting is the loudest diff
+//!   the format can produce rather than a diff it cannot produce at all. Two trees can share a
+//!   flat preorder sequence of `(kind, span)` pairs and still nest differently; the indent is what
+//!   separates them.
+//! * **kind** — a production that opens the wrong node changes one word per site. This is the
+//!   difference the round-trip check is structurally incapable of seeing: `{f(a:true)}` and
+//!   `{f(a:null)}` place a `BooleanValue` and a `NullValue` at *identical* spans.
+//! * **range** — a node boundary that moved changes numbers even when no line appears or vanishes:
+//!   the "`Arguments` opened after the `(` instead of before" shape.
+//! * **token text** — tokens are in the tree, so a token attached to the wrong parent is a moved
+//!   line rather than an invisible one. Trivia is included deliberately: which node a comment
+//!   commits into is a real decision this parser makes.
+//!
+//! `selfcheck` is the proof that the format does not collapse the first two of those. It is here
+//! because a dump that printed the same thing regardless of the tree would satisfy "the hashes
+//! match" vacuously and prove nothing. **A harness you cannot make disagree is not a harness.**
+//!
+//! # Why an example rather than a `[[bin]]`
+//!
+//! For exactly the reason [`gate.rs`](./gate.rs) gives at length: `cargo build` builds bins by
+//! default and does not build examples, so a `[[bin]]` here would be the first executable smear's
+//! fifteen-target `cross` job ever had to link, and it would fail on every target whose linker the
+//! runner lacks.
+
+use core::fmt::Write as _;
+use std::process::ExitCode;
+
+use rowan::{NodeOrToken, WalkEvent};
+use smear_apollo_bench::{CORPUS, Entry, smear_parse};
+use smear_parser::graphql::lossless::SyntaxNode;
+
+/// One element of a CST, projected onto the four axes the dump prints.
+///
+/// Materialised rather than streamed straight to the output so that [`selfcheck`] can compare two
+/// trees **column by column** — and therefore state "these two differ only in kind" as a checked
+/// fact rather than as a hope about the source pair it chose.
+struct Row {
+  /// Levels of nesting below the root. The root itself is 0.
+  depth: usize,
+  /// `{:?}` of the node's or token's `SyntaxKind`.
+  kind: String,
+  /// Absolute byte offset of the element's first byte.
+  start: u32,
+  /// Absolute byte offset one past the element's last byte.
+  end: u32,
+  /// `Some` for a token, carrying its escaped text; `None` for an interior node.
+  ///
+  /// This is also what tells a node line from a token line on the page: a token always carries a
+  /// quoted text and a node never does.
+  text: Option<String>,
+}
+
+/// Escape a token's text so that one token is always one line, forever.
+///
+/// Lifted from `smear-parser/tests/lossless_golden.rs`, and for its reason: backslash, quote and
+/// the three whitespace forms that would break the layout are spelled out; every other C0/C1
+/// control, plus the byte-order mark, becomes `\u{…}`. Anything else — including ordinary
+/// multi-byte text — is written through verbatim.
+///
+/// `char::escape_debug` is the wrong tool here: its notion of "printable" is a Unicode table that
+/// moves between toolchain releases, so a dump hashed on one toolchain and compared on another
+/// could differ for a reason that has nothing to do with the tree. `char::is_control` is a fixed
+/// two-range test and cannot drift.
+fn escape(text: &str) -> String {
+  let mut out = String::with_capacity(text.len());
+  for ch in text.chars() {
+    match ch {
+      '\\' => out.push_str("\\\\"),
+      '"' => out.push_str("\\\""),
+      '\n' => out.push_str("\\n"),
+      '\r' => out.push_str("\\r"),
+      '\t' => out.push_str("\\t"),
+      c if c.is_control() || c == '\u{feff}' => {
+        let _ = write!(out, "\\u{{{:04x}}}", c as u32);
+      }
+      c => out.push(c),
+    }
+  }
+  out
+}
+
+/// Walk a tree with `preorder_with_tokens` and project every element onto a [`Row`].
+///
+/// `preorder_with_tokens` rather than `descendants_with_tokens` because only the former reports
+/// `Leave`, and without `Leave` there is no depth — which would cost the dump its one defence
+/// against two differently-nested trees flattening to the same sequence.
+fn rows(root: &SyntaxNode) -> Vec<Row> {
+  let mut out = Vec::new();
+  let mut depth = 0usize;
+  for event in root.preorder_with_tokens() {
+    match event {
+      WalkEvent::Enter(element) => {
+        let range = element.text_range();
+        out.push(Row {
+          depth,
+          kind: match &element {
+            NodeOrToken::Node(node) => format!("{:?}", node.kind()),
+            NodeOrToken::Token(token) => format!("{:?}", token.kind()),
+          },
+          start: u32::from(range.start()),
+          end: u32::from(range.end()),
+          text: match &element {
+            NodeOrToken::Node(_) => None,
+            NodeOrToken::Token(token) => Some(escape(token.text())),
+          },
+        });
+        depth += 1;
+      }
+      WalkEvent::Leave(_) => depth -= 1,
+    }
+  }
+  out
+}
+
+/// Render rows in `.rast` style: `<indent><Kind>@<start>..<end>` for a node, plus ` "<text>"` for
+/// a token.
+fn render(rows: &[Row]) -> String {
+  let mut out = String::new();
+  for row in rows {
+    for _ in 0..row.depth {
+      out.push_str("  ");
+    }
+    let _ = write!(out, "{}@{}..{}", row.kind, row.start, row.end);
+    if let Some(text) = &row.text {
+      let _ = write!(out, " \"{text}\"");
+    }
+    out.push('\n');
+  }
+  out
+}
+
+/// The full dump for one source: a header, the tree, a footer, one line per diagnostic, a blank.
+///
+/// The footer is a summary of facts already implied by the lines above it, restated in one place
+/// so that a `diff` of two dumps that disagree opens with *what* disagreed — a node count, a root
+/// span, a round-trip verdict — before the reader has to find the first differing element line.
+fn dump(header: &str, src: &str) -> String {
+  let parse = smear_parse(src);
+  let root = parse.syntax();
+  let rows = rows(&root);
+
+  let nodes = rows.iter().filter(|r| r.text.is_none()).count();
+  let tokens = rows.len() - nodes;
+  let round_trips = root.text() == src;
+
+  let mut out = String::new();
+  let _ = writeln!(out, "== {header} ==");
+  out.push_str(&render(&rows));
+  let _ = writeln!(
+    out,
+    "-- {nodes} nodes, {tokens} tokens, root {}..{}, round-trip {}, {} diagnostics --",
+    u32::from(root.text_range().start()),
+    u32::from(root.text_range().end()),
+    if round_trips {
+      "byte-exact"
+    } else {
+      "MISMATCH"
+    },
+    parse.diagnostics().len(),
+  );
+  for (i, d) in parse.diagnostics().iter().enumerate() {
+    let span = d.span();
+    let _ = writeln!(
+      out,
+      "   diagnostic {i}: {}..{} {:?} skipped={}",
+      span.start,
+      span.end,
+      d.severity(),
+      match d.skipped_tokens() {
+        Some(n) => n.to_string(),
+        None => "-".to_string(),
+      },
+    );
+  }
+  out.push('\n');
+  out
+}
+
+/// Replace the entry's first `:` with a space, and report which byte moved.
+///
+/// **Why this perturbation.** The requirement on a control is that it change the *tree* and not
+/// merely the page. A colon in GraphQL is a grammatical separator — variable definition, argument,
+/// field definition, object field — and turning one into whitespace makes the production that
+/// required it fail and recover. What makes it a good control specifically is what it does *not*
+/// change: it is a one-byte substitution, so the document's length is identical, every byte other
+/// than that one is identical, the root span is unchanged, the token count is unchanged, and the
+/// parse still round-trips byte-exactly. So the perturbed dump is not a differently-*formatted*
+/// dump and it is not a dump of differently-sized input; the hash moves because the tree moved.
+///
+/// Measured, on the three entries as they stand: node counts go 33/1082/11017 → 32/1076/12016 and
+/// the diagnostic counts go 0/0/0 → 2/7/7004, while **round-trip stays byte-exact on all three**.
+/// So `gate.rs`'s round-trip column is blind to this perturbation and only its error column is
+/// not — and the pair in [`selfcheck`] is blind to the error column too.
+fn perturb(src: &str) -> Option<(String, usize)> {
+  // `:` is ASCII, so the byte index `find` returns is a char boundary in both directions.
+  let at = src.find(':')?;
+  let mut out = String::with_capacity(src.len());
+  out.push_str(&src[..at]);
+  out.push(' ');
+  out.push_str(&src[at + 1..]);
+  Some((out, at))
+}
+
+/// One `selfcheck` case: a pair of sources chosen so that their trees differ along exactly one
+/// axis.
+struct Probe {
+  /// What the case claims to prove.
+  claim: &'static str,
+  /// The axis that must differ between the two trees.
+  differs: Axis,
+  /// The left-hand source.
+  a: &'static str,
+  /// The right-hand source.
+  b: &'static str,
+}
+
+/// Which column of the dump a [`Probe`] isolates.
+#[derive(Clone, Copy)]
+enum Axis {
+  /// Kinds differ; depths and byte ranges are identical.
+  Kind,
+  /// Byte ranges differ; depths and kinds are identical.
+  Range,
+}
+
+/// The anti-vacuity gate: prove the format does not collapse a kind-only or a range-only
+/// difference.
+///
+/// Each probe is checked in two steps, and the first step is the one that matters. Before the
+/// dumps are compared at all, the two trees are compared **column by column** to establish that
+/// they really do differ along the claimed axis and along no other — same element count, same
+/// depth at every position, and identity on the two columns the probe is not about. Only then is
+/// `render` asked whether it can tell them apart. A probe whose precondition fails is reported as
+/// a failure rather than skipped, because a source pair that stopped exercising the axis it was
+/// chosen for would otherwise turn this gate green by testing nothing.
+///
+/// A note on what "range-only" can mean. In a rowan tree a span *is* the running sum of the token
+/// texts before it, so two trees over different sources cannot differ in their ranges while
+/// agreeing on every token's text — a genuinely text-identical, range-different pair can only be
+/// built synthetically. The honest claim, and the one [`Axis::Range`] checks, is the one that
+/// matters for a diff: the kind column and the depth column are identical across the pair, so the
+/// difference the dump reports is carried by the range.
+fn selfcheck() -> bool {
+  const PROBES: &[Probe] = &[
+    Probe {
+      claim: "kind-only: BooleanValue vs NullValue at identical spans",
+      differs: Axis::Kind,
+      a: "{f(a:true)}",
+      b: "{f(a:null)}",
+    },
+    Probe {
+      claim: "range-only: the same Int value one byte wider",
+      differs: Axis::Range,
+      a: "{f(a:1)}",
+      b: "{f(a:11)}",
+    },
+  ];
+
+  let mut all_ok = true;
+  for probe in PROBES {
+    let (pa, pb) = (smear_parse(probe.a), smear_parse(probe.b));
+    let ra = rows(&pa.syntax());
+    let rb = rows(&pb.syntax());
+
+    // Recorded so the PASS line evidences the point rather than asserting it: when both sides
+    // parse clean and round-trip byte-exactly, `gate.rs` has nothing left to report a difference
+    // *with*, and the dump is the only thing in the harness that still can.
+    let clean = |p: &smear_parser::graphql::lossless::Parse, src: &str| {
+      p.diagnostics().is_empty() && p.syntax().text() == src
+    };
+    let both_clean = clean(&pa, probe.a) && clean(&pb, probe.b);
+
+    let mut problems: Vec<String> = Vec::new();
+
+    if ra.len() != rb.len() {
+      problems.push(format!(
+        "element counts differ ({} vs {}), so the pair is not an isolated-axis pair",
+        ra.len(),
+        rb.len()
+      ));
+    } else {
+      let mut same_depth = true;
+      let mut same_kind = true;
+      let mut same_range = true;
+      for (x, y) in ra.iter().zip(rb.iter()) {
+        same_depth &= x.depth == y.depth;
+        same_kind &= x.kind == y.kind;
+        same_range &= (x.start, x.end) == (y.start, y.end);
+      }
+      if !same_depth {
+        problems.push("depths differ, so more than one axis moved".to_string());
+      }
+      match probe.differs {
+        Axis::Kind => {
+          if same_kind {
+            problems.push("kinds are identical, so this probe exercises nothing".to_string());
+          }
+          if !same_range {
+            problems.push("ranges differ too, so this is not a kind-only pair".to_string());
+          }
+        }
+        Axis::Range => {
+          if same_range {
+            problems.push("ranges are identical, so this probe exercises nothing".to_string());
+          }
+          if !same_kind {
+            problems.push("kinds differ too, so this is not a range-only pair".to_string());
+          }
+        }
+      }
+    }
+
+    let da = render(&ra);
+    let db = render(&rb);
+    if da == db {
+      problems.push(
+        "THE DUMP IS IDENTICAL FOR THE TWO TREES — the format collapses this axis".to_string(),
+      );
+    }
+
+    if problems.is_empty() {
+      println!("PASS  {}", probe.claim);
+      println!(
+        "      {:?} vs {:?}, {} lines each, both sides {}; differing lines:",
+        probe.a,
+        probe.b,
+        da.lines().count(),
+        if both_clean {
+          "parse clean and round-trip byte-exactly, so gate.rs sees no difference at all"
+        } else {
+          "NOT both a clean byte-exact parse"
+        }
+      );
+      for (x, y) in da.lines().zip(db.lines()).filter(|(x, y)| x != y) {
+        println!("      -{x}");
+        println!("      +{y}");
+      }
+    } else {
+      all_ok = false;
+      println!("FAIL  {}", probe.claim);
+      for problem in problems {
+        println!("      {problem}");
+      }
+    }
+    println!();
+  }
+  all_ok
+}
+
+fn main() -> ExitCode {
+  let args: Vec<String> = std::env::args().skip(1).collect();
+
+  if args.iter().any(|a| a == "selfcheck") {
+    return if selfcheck() {
+      ExitCode::SUCCESS
+    } else {
+      ExitCode::FAILURE
+    };
+  }
+
+  let perturbed = args.iter().any(|a| a == "perturbed");
+
+  // Built whole and written once. At ~45,000 lines a `println!` per element spends most of its
+  // time re-acquiring the stdout lock, and the dump is a single artifact anyway — it is going to
+  // be hashed or diffed, never read as it streams.
+  let mut out = String::new();
+  for entry in CORPUS {
+    out.push_str(&entry_dump(entry, perturbed));
+  }
+  print!("{out}");
+  ExitCode::SUCCESS
+}
+
+/// One corpus entry's dump, in whichever of the two modes was asked for.
+fn entry_dump(entry: &Entry, perturbed: bool) -> String {
+  if perturbed {
+    match perturb(entry.source) {
+      Some((src, at)) => dump(
+        &format!(
+          "{} : {} bytes : PERTURBED byte {at} ':' -> ' '",
+          entry.name,
+          src.len()
+        ),
+        &src,
+      ),
+      // Not a case any current entry hits, and not one to paper over: a corpus entry with no
+      // colon would silently make the control identical to the dump it is a control for.
+      None => format!(
+        "== {} : {} bytes : NOT PERTURBED (no ':' in the source) ==\n\n",
+        entry.name,
+        entry.len()
+      ),
+    }
+  } else {
+    dump(
+      &format!("{} : {} bytes", entry.name, entry.len()),
+      entry.source,
+    )
+  }
+}

--- a/benchmarks/src/dump.rs
+++ b/benchmarks/src/dump.rs
@@ -1,0 +1,380 @@
+//! The tree dump, and the four byte-identity constants it is checked against.
+//!
+//! This module holds the machinery that [`examples/treedump.rs`](../examples/treedump.rs) used to
+//! own outright. It lives in the library so that **two** callers can reach it: the example, which
+//! prints a dump for a human to read or pipe into `shasum`, and
+//! [`tests/byte_identity.rs`](../tests/byte_identity.rs), which recomputes the four hashes and
+//! fails if any of them moved.
+//!
+//! That second caller is the point. Before it existed, the four hashes lived in an issue and in a
+//! commit message — which is a note, not a baseline. Nothing recomputed them, so a change that
+//! altered every tree in the corpus would go green through every gate this repository had.
+//!
+//! # What the constants are pinned to
+//!
+//! A hash here is a function of **three** inputs, and all three have to be named or the number is
+//! not reproducible:
+//!
+//! * the corpus, which is committed under `benchmarks/corpus/` and does not move;
+//! * smear's own parser, which is what the gate is *for* — if this moves, the gate reds;
+//! * tokora, which this crate takes from crates.io as a published version, not from a sibling
+//!   checkout, so the constants reproduce on any machine with no path patch in play.
+//!
+//! Blessed against **published `tokora 0.8.0`**. Two of the four moved when this harness was
+//! rebased onto the trunk, and both moved for one reason: `NamedType` now opens *after* its
+//! leading trivia rather than before. The other two were byte-identical across that move, because
+//! no `NamedType` in either of them has leading trivia to relocate.
+//!
+//! # Re-blessing
+//!
+//! Do not edit a constant to make the gate pass. A hash that moved is a claim about the tree, and
+//! the diff names where: dump the corpus before and after and `diff` them. Re-bless only once the
+//! change is understood and intended, and record *what* moved it in the same commit.
+
+use core::fmt::Write as _;
+
+use sha2::{Digest as _, Sha256};
+use smear_parser::graphql::lossless::SyntaxNode;
+
+use crate::{CORPUS, Entry, smear_parse};
+
+/// One element of a CST, projected onto the four axes the dump prints.
+///
+/// Materialised rather than streamed straight to the output so that the example's `selfcheck`
+/// mode can compare two trees **column by column** — and therefore state "these two differ only
+/// in kind" as a checked fact rather than as a hope about the source pair it chose.
+pub struct Row {
+  /// Levels of nesting below the root. The root itself is 0.
+  pub depth: usize,
+  /// `{:?}` of the node's or token's `SyntaxKind`.
+  pub kind: String,
+  /// Absolute byte offset of the element's first byte.
+  pub start: u32,
+  /// Absolute byte offset one past the element's last byte.
+  pub end: u32,
+  /// `Some` for a token, carrying its escaped text; `None` for an interior node.
+  ///
+  /// This is also what tells a node line from a token line on the page: a token always carries a
+  /// quoted text and a node never does.
+  pub text: Option<String>,
+}
+
+/// Escape a token's text so that one token is always one line, forever.
+///
+/// Backslash, quote and the three whitespace forms that would break the layout are spelled out;
+/// every other C0/C1 control, plus the byte-order mark, becomes `\u{…}`. Anything else —
+/// including ordinary multi-byte text — is written through verbatim.
+///
+/// `char::escape_debug` is the wrong tool here: its notion of "printable" is a Unicode table that
+/// moves between toolchain releases, so a dump hashed on one toolchain and compared on another
+/// could differ for a reason that has nothing to do with the tree. `char::is_control` is a fixed
+/// two-range test and cannot drift — which is what makes the constants in this module portable.
+pub fn escape(text: &str) -> String {
+  let mut out = String::with_capacity(text.len());
+  for ch in text.chars() {
+    match ch {
+      '\\' => out.push_str("\\\\"),
+      '"' => out.push_str("\\\""),
+      '\n' => out.push_str("\\n"),
+      '\r' => out.push_str("\\r"),
+      '\t' => out.push_str("\\t"),
+      c if c.is_control() || c == '\u{feff}' => {
+        let _ = write!(out, "\\u{{{:04x}}}", c as u32);
+      }
+      c => out.push(c),
+    }
+  }
+  out
+}
+
+/// Walk a tree with `preorder_with_tokens` and project every element onto a [`Row`].
+///
+/// `preorder_with_tokens` rather than `descendants_with_tokens` because only the former reports
+/// `Leave`, and without `Leave` there is no depth — which would cost the dump its one defence
+/// against two differently-nested trees flattening to the same sequence.
+pub fn rows(root: &SyntaxNode) -> Vec<Row> {
+  let mut out = Vec::new();
+  let mut depth = 0usize;
+  for event in root.preorder_with_tokens() {
+    match event {
+      rowan::WalkEvent::Enter(element) => {
+        let range = element.text_range();
+        out.push(Row {
+          depth,
+          kind: match &element {
+            rowan::NodeOrToken::Node(node) => format!("{:?}", node.kind()),
+            rowan::NodeOrToken::Token(token) => format!("{:?}", token.kind()),
+          },
+          start: u32::from(range.start()),
+          end: u32::from(range.end()),
+          text: match &element {
+            rowan::NodeOrToken::Node(_) => None,
+            rowan::NodeOrToken::Token(token) => Some(escape(token.text())),
+          },
+        });
+        depth += 1;
+      }
+      rowan::WalkEvent::Leave(_) => depth -= 1,
+    }
+  }
+  out
+}
+
+/// Render rows in `.rast` style: `<indent><Kind>@<start>..<end>` for a node, plus ` "<text>"` for
+/// a token.
+pub fn render(rows: &[Row]) -> String {
+  let mut out = String::new();
+  for row in rows {
+    for _ in 0..row.depth {
+      out.push_str("  ");
+    }
+    let _ = write!(out, "{}@{}..{}", row.kind, row.start, row.end);
+    if let Some(text) = &row.text {
+      let _ = write!(out, " \"{text}\"");
+    }
+    out.push('\n');
+  }
+  out
+}
+
+/// The full dump for one source: a header, the tree, a footer, one line per diagnostic, a blank.
+///
+/// The footer is a summary of facts already implied by the lines above it, restated in one place
+/// so that a `diff` of two dumps that disagree opens with *what* disagreed — a node count, a root
+/// span, a round-trip verdict — before the reader has to find the first differing element line.
+pub fn dump(header: &str, src: &str) -> String {
+  let parse = smear_parse(src);
+  let root = parse.syntax();
+  let rows = rows(&root);
+
+  let nodes = rows.iter().filter(|r| r.text.is_none()).count();
+  let tokens = rows.len() - nodes;
+  let round_trips = root.text() == src;
+
+  let mut out = String::new();
+  let _ = writeln!(out, "== {header} ==");
+  out.push_str(&render(&rows));
+  let _ = writeln!(
+    out,
+    "-- {nodes} nodes, {tokens} tokens, root {}..{}, round-trip {}, {} diagnostics --",
+    u32::from(root.text_range().start()),
+    u32::from(root.text_range().end()),
+    if round_trips {
+      "byte-exact"
+    } else {
+      "MISMATCH"
+    },
+    parse.diagnostics().len(),
+  );
+  for (i, d) in parse.diagnostics().iter().enumerate() {
+    let span = d.span();
+    let _ = writeln!(
+      out,
+      "   diagnostic {i}: {}..{} {:?} skipped={}",
+      span.start,
+      span.end,
+      d.severity(),
+      match d.skipped_tokens() {
+        Some(n) => n.to_string(),
+        None => "-".to_string(),
+      },
+    );
+  }
+  out.push('\n');
+  out
+}
+
+/// Replace the entry's first `:` with a space, and report which byte moved.
+///
+/// The requirement on a control is that it change the *tree* and not merely the page. A colon in
+/// GraphQL is a grammatical separator, and turning one into whitespace makes the production that
+/// required it fail and recover. What makes it a good control specifically is what it does *not*
+/// change: a one-byte substitution, so the document's length is identical, the root span is
+/// unchanged, and the parse still round-trips byte-exactly. The hash moves because the tree moved.
+pub fn perturb(src: &str) -> Option<(String, usize)> {
+  // `:` is ASCII, so the byte index `find` returns is a char boundary in both directions.
+  let at = src.find(':')?;
+  let mut out = String::with_capacity(src.len());
+  out.push_str(&src[..at]);
+  out.push(' ');
+  out.push_str(&src[at + 1..]);
+  Some((out, at))
+}
+
+/// Hand-written broken documents — the corpus the clean entries cannot be.
+///
+/// A clean parse of this grammar takes **zero** emitter checkpoints, so it exercises no rewind,
+/// no recovery-hole wrap, no gap tile and no error-coverage decision. Every one of those lives
+/// on the recovery path, and the recovery path is only reachable from input that is wrong.
+pub const MALFORMED: &[(&str, &str)] = &[
+  ("unclosed_brace", "query Q { a { b "),
+  ("stray_colon", "query Q { : a }"),
+  ("bad_directive", "query Q @ @@ { a }"),
+  ("unterminated_string", "{ f(a: \"abc) }"),
+  ("junk_prefix", "%%% query Q { a }"),
+  ("empty_args", "{ f() }"),
+  ("bad_type", "query Q($v: ) { a }"),
+  ("dangling_spread", "{ ... }"),
+  ("bad_variable", "query Q($ $x: Int = ) { a }"),
+  ("mixed_garbage", "type T { f: Int } ### $$$ ### { a }"),
+  ("deep_nest_broken", "{ a { b { c { d { e ("),
+  ("bad_default", "query Q($x: Int = @) { a }"),
+  ("unterminated_block_string", "{ f(a: \"\"\"body ) }"),
+  ("lone_dollar", "$"),
+  ("nothing_lexable", "\u{7}\u{7}\u{7}"),
+  ("empty", ""),
+  ("only_trivia", "   \n\t # comment\n"),
+  ("trailing_garbage_after_doc", "{ a } %%%"),
+  ("leading_and_trailing_garbage", "%% { a } %%"),
+  ("bad_escape_in_string", "{ f(a: \"x\\q\") }"),
+  ("unclosed_paren_then_brace", "{ f(a: 1 }"),
+  ("repeated_colons", "{ a:::: b }"),
+  ("sdl_and_executable_mixed", "schema { query: } { a }"),
+  ("number_garbage", "{ f(a: 1.2.3e) }"),
+];
+
+/// One corpus entry's dump, in whichever of the two modes was asked for.
+pub fn entry_dump(entry: &Entry, perturbed: bool) -> String {
+  if perturbed {
+    match perturb(entry.source) {
+      Some((src, at)) => dump(
+        &format!(
+          "{} : {} bytes : PERTURBED byte {at} ':' -> ' '",
+          entry.name,
+          src.len()
+        ),
+        &src,
+      ),
+      // Not a case any current entry hits, and not one to paper over: a corpus entry with no
+      // colon would silently make the control identical to the dump it is a control for.
+      None => format!(
+        "== {} : {} bytes : NOT PERTURBED (no ':' in the source) ==\n\n",
+        entry.name,
+        entry.len()
+      ),
+    }
+  } else {
+    dump(
+      &format!("{} : {} bytes", entry.name, entry.len()),
+      entry.source,
+    )
+  }
+}
+
+/// The stride at which [`Corpus::Prefixes`] cuts an entry.
+///
+/// Every byte of the small entries; every 37th of the big one — a prime, so the cut points do not
+/// align with any repeating structure in the document.
+fn prefix_stride(entry: &Entry) -> usize {
+  if entry.source.len() > 20_000 { 37 } else { 1 }
+}
+
+/// Which corpus a dump covers.
+///
+/// The four are not interchangeable and none is redundant. `Clean` is the only one over real
+/// documents; `Perturbed` is its one-byte-broken control; `Malformed` reaches the recovery path
+/// that clean input leaves entirely dark; `Prefixes` reaches thousands of *independent* recovery
+/// sites by truncating each clean document at every cut point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Corpus {
+  /// The three corpus entries, as they stand.
+  Clean,
+  /// The three corpus entries, each with its first `:` turned into a space.
+  Perturbed,
+  /// [`MALFORMED`], 24 hand-broken documents.
+  Malformed,
+  /// Every cut point of every clean entry — roughly 9,300 documents.
+  Prefixes,
+}
+
+impl Corpus {
+  /// All four, in the order the gate reports them.
+  pub const ALL: [Self; 4] = [
+    Self::Clean,
+    Self::Perturbed,
+    Self::Malformed,
+    Self::Prefixes,
+  ];
+
+  /// The argument that selects this corpus on the example's command line.
+  pub const fn name(self) -> &'static str {
+    match self {
+      Self::Clean => "clean",
+      Self::Perturbed => "perturbed",
+      Self::Malformed => "malformed",
+      Self::Prefixes => "prefixes",
+    }
+  }
+
+  /// The recorded SHA-256 of this corpus's dump.
+  ///
+  /// See the module documentation for what these are pinned to and how to re-bless one. Editing a
+  /// value here to make [`tests/byte_identity.rs`](../tests/byte_identity.rs) pass converts the
+  /// only byte-identity gate this repository has into a tautology.
+  pub const fn expected(self) -> &'static str {
+    match self {
+      Self::Clean => "00f2b8b2bce48001aff45f8049141a13ca740fc6fe8eb4d9e287d1ccd4a46fc9",
+      Self::Perturbed => "a42a39d41d4b8495f1ab5420292f9c76d194fd89697867fae1e2546ca64486b9",
+      Self::Malformed => "2b5f293717f54346007f48459a2f0bd8cde76ea9344a56fb4010599296dab1c7",
+      Self::Prefixes => "ab57d222a70151c1473072cb5b0d949719cc5c9958e0bd03fb1db96e9db30858",
+    }
+  }
+
+  /// Roughly how much output this corpus produces, for a human deciding whether to redirect.
+  pub const fn is_large(self) -> bool {
+    matches!(self, Self::Prefixes)
+  }
+}
+
+/// Stream this corpus's dump, one top-level unit at a time.
+///
+/// The concatenation of every chunk is exactly the dump — the same bytes the example prints and
+/// the same bytes the recorded hashes are over. Streaming rather than returning one `String`
+/// matters for [`Corpus::Prefixes`], whose dump is roughly 1.4 GB: the gate hashes it in bounded
+/// memory instead of materialising it.
+pub fn for_each_chunk(corpus: Corpus, mut f: impl FnMut(&str)) {
+  match corpus {
+    Corpus::Clean | Corpus::Perturbed => {
+      let perturbed = corpus == Corpus::Perturbed;
+      for entry in CORPUS {
+        f(&entry_dump(entry, perturbed));
+      }
+    }
+    Corpus::Malformed => {
+      for (name, src) in MALFORMED {
+        f(&dump(&format!("{name} : {} bytes", src.len()), src));
+      }
+    }
+    Corpus::Prefixes => {
+      for entry in CORPUS {
+        let stride = prefix_stride(entry);
+        let mut at = 0usize;
+        while at <= entry.source.len() {
+          if entry.source.is_char_boundary(at) {
+            f(&dump(
+              &format!("{} prefix {at}", entry.name),
+              &entry.source[..at],
+            ));
+          }
+          at += stride;
+        }
+      }
+    }
+  }
+}
+
+/// The SHA-256 of this corpus's dump, as lowercase hex.
+///
+/// Computed by streaming [`for_each_chunk`] into the hasher, so this is O(1) in memory even for
+/// [`Corpus::Prefixes`], and is by construction the same value as
+/// `treedump … | shasum -a 256`.
+pub fn hash(corpus: Corpus) -> String {
+  let mut hasher = Sha256::new();
+  for_each_chunk(corpus, |chunk| hasher.update(chunk.as_bytes()));
+  let digest = hasher.finalize();
+  let mut out = String::with_capacity(64);
+  for byte in digest {
+    let _ = write!(out, "{byte:02x}");
+  }
+  out
+}

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,0 +1,518 @@
+//! Like-for-like benchmark support: smear's GraphQL lossless CST parser vs `apollo-parser`.
+//!
+//! Both sides build a **rowan 0.16 CST** over the same source. `apollo-parser` depends on
+//! `rowan = "0.16.0"` directly; smear reaches the same crate through tokora, and cargo unifies
+//! the two into one build of one `rowan`. So the artifact produced is the same kind of thing,
+//! not merely analogous.
+//!
+//! This module holds everything the timing harness needs to be *honest*:
+//!
+//! * the corpus, taken byte-for-byte from `apollo-parser`'s own benches and test data, so the
+//!   inputs cannot be accused of having been chosen to flatter smear;
+//! * the three tiers' work functions, written once and called from both the correctness gate
+//!   and the criterion bench, so what is measured is what was checked;
+//! * the correctness gate itself — error-free parse, byte-exact round-trip, non-trivial node
+//!   counts — which decides which entries are eligible to be timed at all.
+//!
+//! Nothing here is timed. [`benches/apollo_comparison.rs`] does the timing and calls into this.
+
+use core::hint::black_box;
+
+use apollo_parser::cst::{self, CstNode as _};
+use smear_parser::graphql::lossless::{
+  self as smear_lossless, GraphqlLosslessLexer, Parse as SmearParse,
+  ast::{self as smear_ast, cast as smear_cast},
+};
+use tokora::{Lexer as _, emitter::Severity};
+
+/// One corpus entry: a name, its source, and which of `apollo-parser`'s two published
+/// traversals matches its content.
+#[derive(Debug, Clone, Copy)]
+pub struct Entry {
+  /// Short id used in criterion benchmark names and in the report's tables.
+  pub name: &'static str,
+  /// The source text, embedded at compile time so no I/O happens inside a timed region.
+  pub source: &'static str,
+  /// Where the bytes came from, reproduced in the report.
+  pub provenance: &'static str,
+  /// Which tier-2 traversal shape applies.
+  pub shape: Shape,
+}
+
+impl Entry {
+  /// The entry's size in bytes — criterion's throughput denominator.
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.source.len()
+  }
+
+  /// Whether the entry is empty. Present only because clippy pairs it with [`Entry::len`].
+  #[inline]
+  pub fn is_empty(&self) -> bool {
+    self.source.is_empty()
+  }
+}
+
+/// Which of `apollo-parser`'s two published bench traversals a corpus entry calls for.
+///
+/// `apollo-parser` ships two, and applying the executable one to a schema document would walk
+/// nothing at all — a vacuous tier 2. So each entry gets the one that matches its content, and
+/// both sides run the *same* one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shape {
+  /// `benches/query.rs`: walk operation definitions, walk their selection sets, black-box each
+  /// field's own selection set.
+  Executable,
+  /// `benches/supergraph.rs`: walk object type definitions, walk their field definitions,
+  /// black-box each field's type.
+  Sdl,
+}
+
+/// The corpus. Every byte is `apollo-parser`'s own.
+///
+/// `alias.graphql` and `0032_supergraph.graphql` are verbatim copies (verified by sha256 against
+/// the upstream checkout); `example_query.graphql` is the inline query string from
+/// `apollo-parser`'s `benches/query.rs`, written out with its escapes resolved and no trailing
+/// newline.
+pub const CORPUS: &[Entry] = &[
+  Entry {
+    name: "example_query",
+    source: include_str!("../corpus/example_query.graphql"),
+    provenance: "apollo-parser benches/query.rs, inline `query ExampleQuery` string",
+    shape: Shape::Executable,
+  },
+  Entry {
+    name: "supergraph",
+    source: include_str!("../corpus/0032_supergraph.graphql"),
+    provenance: "apollo-parser test_data/parser/ok/0032_supergraph.graphql",
+    shape: Shape::Sdl,
+  },
+  Entry {
+    name: "alias",
+    source: include_str!("../corpus/alias.graphql"),
+    provenance: "apollo-parser benches/testdata/alias.graphql",
+    shape: Shape::Executable,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tier 0 — lex only
+// ---------------------------------------------------------------------------
+
+/// Drive smear's GraphQL **lossless** lexer to exhaustion, black-boxing every token.
+///
+/// Returns the token count. Panics on a lexer error: the gate has already established that the
+/// corpus lexes clean, so an error here means the harness is measuring something other than what
+/// it checked.
+#[inline]
+pub fn smear_lex(src: &str) -> usize {
+  let mut lexer = GraphqlLosslessLexer::<'_, str>::new(src);
+  let mut count = 0usize;
+  while let Some(res) = lexer.lex() {
+    black_box(res.expect("smear lexer error on a gate-passing entry"));
+    count += 1;
+  }
+  count
+}
+
+/// Drive `apollo_parser::Lexer` to exhaustion, black-boxing every token.
+///
+/// The same shape as `apollo-parser`'s own `bench_query_lexer`. Note that apollo emits a
+/// terminal `Eof` token and smear does not, so apollo's count is one higher for the same input.
+#[inline]
+pub fn apollo_lex(src: &str) -> usize {
+  let lexer = apollo_parser::Lexer::new(src);
+  let mut count = 0usize;
+  for res in lexer {
+    black_box(res.expect("apollo lexer error on a gate-passing entry"));
+    count += 1;
+  }
+  count
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 — parse to CST
+// ---------------------------------------------------------------------------
+
+/// Parse to smear's lossless rowan CST. No traversal.
+#[inline]
+pub fn smear_parse(src: &str) -> SmearParse {
+  smear_lossless::parse_str(src)
+}
+
+/// Parse to apollo's rowan CST. No traversal.
+#[inline]
+pub fn apollo_parse(src: &str) -> apollo_parser::SyntaxTree {
+  apollo_parser::Parser::new(src).parse()
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 — typed traversal over an already-built tree
+// ---------------------------------------------------------------------------
+
+/// smear's stand-in for `apollo_parser::cst::Type`, which smear's typed layer does not have.
+///
+/// apollo generates a `Type` union enum and reaches it in **one** child scan that tests three
+/// kinds. smear's `FieldDefinition` exposes the three arms as three separate getters, so the
+/// equivalent call costs up to **three** child scans. Materialising the result into this enum
+/// makes the two sides produce the same shape of value; it does not erase the extra scans, which
+/// are a genuine API difference and are called out in the report.
+#[derive(Debug)]
+pub enum SmearFieldTy {
+  /// `T`
+  Named(smear_ast::NamedType),
+  /// `[T]`
+  List(smear_ast::ListType),
+  /// `T!`
+  NonNull(smear_ast::NonNullType),
+}
+
+/// The one [`smear_ast::Document`] a `parse_str` tree carries.
+///
+/// A structural difference from apollo worth naming: apollo's tree root **is** the `Document`,
+/// while smear's root is a `Root` node that wraps exactly one `Document`. So smear's typed
+/// traversal starts one `cast::child` deeper, and smear's CST carries one node apollo's does not.
+#[inline]
+pub fn smear_document(parse: &SmearParse) -> smear_ast::Document {
+  smear_cast::child(&parse.syntax()).expect("Root wraps exactly one Document")
+}
+
+/// Walk operation definitions and black-box each field's selection set.
+///
+/// `apollo-parser`'s `benches/query.rs` traversal, on smear's typed layer. apollo iterates the
+/// document's `definitions()` and discriminates on a `Definition` union; smear has no union and
+/// exposes one iterator per kind, so `operation_definitions()` is the counterpart. Both are a
+/// single ordered scan of the document's children with a kind test, and both visit exactly the
+/// operation definitions, in document order.
+///
+/// Returns the number of fields visited — the gate uses it to prove the traversal is not vacuous.
+#[inline]
+pub fn smear_traverse_executable(parse: &SmearParse) -> usize {
+  let doc = smear_document(parse);
+  let mut visited = 0usize;
+  for operation in doc.operation_definitions() {
+    let selection_set = operation
+      .selection_set()
+      .expect("the node SelectionSet is not optional in the spec; qed");
+    for field in selection_set.fields() {
+      black_box(field.selection_set());
+      visited += 1;
+    }
+  }
+  visited
+}
+
+/// `benches/query.rs`'s traversal, verbatim apart from returning a visit count.
+#[inline]
+pub fn apollo_traverse_executable(tree: &apollo_parser::SyntaxTree) -> usize {
+  let document = tree.document();
+  let mut visited = 0usize;
+  for definition in document.definitions() {
+    if let cst::Definition::OperationDefinition(operation) = definition {
+      let selection_set = operation
+        .selection_set()
+        .expect("the node SelectionSet is not optional in the spec; qed");
+      for selection in selection_set.selections() {
+        if let cst::Selection::Field(field) = selection {
+          black_box(field.selection_set());
+          visited += 1;
+        }
+      }
+    }
+  }
+  visited
+}
+
+/// Walk object type definitions and black-box each field definition's type.
+///
+/// `apollo-parser`'s `benches/supergraph.rs` traversal, on smear's typed layer.
+///
+/// One deliberate deviation from upstream, applied identically to **both** sides: upstream
+/// `.expect()`s `fields_definition()`, which would panic on a legal `type T @directive` with no
+/// field block. Both sides here skip such a definition instead, so neither can panic and both do
+/// the same work.
+#[inline]
+pub fn smear_traverse_sdl(parse: &SmearParse) -> usize {
+  let doc = smear_document(parse);
+  let mut visited = 0usize;
+  for object in doc.object_type_definitions() {
+    if let Some(fields) = object.fields_definition() {
+      for field in fields.field_definitions() {
+        let ty = field
+          .named_type()
+          .map(SmearFieldTy::Named)
+          .or_else(|| field.list_type().map(SmearFieldTy::List))
+          .or_else(|| field.non_null_type().map(SmearFieldTy::NonNull));
+        black_box(ty);
+        visited += 1;
+      }
+    }
+  }
+  visited
+}
+
+/// `benches/supergraph.rs`'s traversal, with the `fields_definition` deviation described on
+/// [`smear_traverse_sdl`].
+#[inline]
+pub fn apollo_traverse_sdl(tree: &apollo_parser::SyntaxTree) -> usize {
+  let document = tree.document();
+  let mut visited = 0usize;
+  for definition in document.definitions() {
+    if let cst::Definition::ObjectTypeDefinition(object) = definition {
+      if let Some(fields) = object.fields_definition() {
+        for field in fields.field_definitions() {
+          black_box(field.ty());
+          visited += 1;
+        }
+      }
+    }
+  }
+  visited
+}
+
+/// Parse and traverse in one call — tier 2's smear side.
+#[inline]
+pub fn smear_parse_and_traverse(src: &str, shape: Shape) -> usize {
+  let parse = smear_parse(src);
+  match shape {
+    Shape::Executable => smear_traverse_executable(&parse),
+    Shape::Sdl => smear_traverse_sdl(&parse),
+  }
+}
+
+/// Parse and traverse in one call — tier 2's apollo side.
+#[inline]
+pub fn apollo_parse_and_traverse(src: &str, shape: Shape) -> usize {
+  let tree = apollo_parse(src);
+  match shape {
+    Shape::Executable => apollo_traverse_executable(&tree),
+    Shape::Sdl => apollo_traverse_sdl(&tree),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Correctness gate
+// ---------------------------------------------------------------------------
+
+/// What one parser did with one corpus entry.
+#[derive(Debug, Clone)]
+pub struct SideGate {
+  /// Number of hard parse errors. Must be zero to pass.
+  pub errors: usize,
+  /// Whether `tree.text().to_string() == source`. Must hold to pass.
+  pub round_trips: bool,
+  /// Length of the round-tripped text, so a failure can be described rather than just flagged.
+  pub round_trip_len: usize,
+  /// Interior nodes in the CST, including the root.
+  pub nodes: usize,
+  /// Leaf tokens in the CST.
+  pub tokens: usize,
+  /// Tokens the standalone lexer produced for the same source.
+  pub lex_tokens: usize,
+  /// Nodes the tier-2 traversal visited.
+  pub traversal_visits: usize,
+}
+
+impl SideGate {
+  /// Whether this side is fit to be timed.
+  ///
+  /// Non-zero node and token counts are the "non-trivial tree" half of gate 3: a parser that
+  /// returned a bare root would round-trip only on empty input, but the check is cheap and
+  /// states the requirement explicitly rather than leaving it implied.
+  #[inline]
+  pub fn passed(&self) -> bool {
+    self.errors == 0 && self.round_trips && self.nodes > 0 && self.tokens > 0
+  }
+}
+
+/// Both sides' verdict on one corpus entry.
+#[derive(Debug, Clone)]
+pub struct GateRow {
+  /// The entry's name.
+  pub name: &'static str,
+  /// The entry's size in bytes.
+  pub bytes: usize,
+  /// Which traversal shape tier 2 used.
+  pub shape: Shape,
+  /// smear's verdict.
+  pub smear: SideGate,
+  /// apollo's verdict.
+  pub apollo: SideGate,
+}
+
+impl GateRow {
+  /// Whether the entry is eligible for timing. Both sides must pass; an entry that fails is
+  /// excluded from the timing run **and named** in the report.
+  #[inline]
+  pub fn eligible(&self) -> bool {
+    self.smear.passed() && self.apollo.passed()
+  }
+}
+
+fn gate_smear(entry: &Entry) -> SideGate {
+  let parse = smear_parse(entry.source);
+  let root = parse.syntax();
+  let text = root.text().to_string();
+  let nodes = root.descendants().count();
+  let tokens = root
+    .descendants_with_tokens()
+    .filter(|e| e.as_token().is_some())
+    .count();
+
+  SideGate {
+    errors: parse
+      .diagnostics()
+      .iter()
+      .filter(|d| d.severity() == Severity::Error)
+      .count(),
+    round_trips: text == entry.source,
+    round_trip_len: text.len(),
+    nodes,
+    tokens,
+    lex_tokens: smear_lex(entry.source),
+    traversal_visits: match entry.shape {
+      Shape::Executable => smear_traverse_executable(&parse),
+      Shape::Sdl => smear_traverse_sdl(&parse),
+    },
+  }
+}
+
+fn gate_apollo(entry: &Entry) -> SideGate {
+  let tree = apollo_parse(entry.source);
+  let document = tree.document();
+  let root = document.syntax();
+  let text = root.text().to_string();
+  let nodes = root.descendants().count();
+  let tokens = root
+    .descendants_with_tokens()
+    .filter(|e| e.as_token().is_some())
+    .count();
+
+  SideGate {
+    errors: tree.errors().len(),
+    round_trips: text == entry.source,
+    round_trip_len: text.len(),
+    nodes,
+    tokens,
+    lex_tokens: apollo_lex(entry.source),
+    traversal_visits: match entry.shape {
+      Shape::Executable => apollo_traverse_executable(&tree),
+      Shape::Sdl => apollo_traverse_sdl(&tree),
+    },
+  }
+}
+
+/// Run the correctness gate over the whole corpus.
+///
+/// Nothing is timed here. Every entry is parsed by both sides, round-tripped, counted and
+/// traversed; the caller decides what to do with the verdicts.
+pub fn run_gate() -> Vec<GateRow> {
+  CORPUS
+    .iter()
+    .map(|entry| GateRow {
+      name: entry.name,
+      bytes: entry.len(),
+      shape: entry.shape,
+      smear: gate_smear(entry),
+      apollo: gate_apollo(entry),
+    })
+    .collect()
+}
+
+/// Node-kind histograms for one entry, both sides, sorted by descending count.
+///
+/// Gate 3 requires that a node-count difference be *explained* rather than published bare. The
+/// two kind spaces have no common vocabulary — they are different `rowan::Language`s — so the
+/// histograms cannot be diffed automatically; what they do is show, per side, which kinds carry
+/// the difference, which is enough for a reader to name the cause.
+pub fn kind_histograms(entry: &Entry) -> (Vec<(String, usize)>, Vec<(String, usize)>) {
+  fn sorted(mut counts: std::collections::HashMap<String, usize>) -> Vec<(String, usize)> {
+    let mut out: Vec<(String, usize)> = counts.drain().collect();
+    out.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    out
+  }
+
+  let parse = smear_parse(entry.source);
+  let mut smear_counts: std::collections::HashMap<String, usize> = Default::default();
+  for node in parse.syntax().descendants() {
+    *smear_counts
+      .entry(format!("{:?}", node.kind()))
+      .or_default() += 1;
+  }
+
+  let tree = apollo_parse(entry.source);
+  let mut apollo_counts: std::collections::HashMap<String, usize> = Default::default();
+  for node in tree.document().syntax().descendants() {
+    *apollo_counts
+      .entry(format!("{:?}", node.kind()))
+      .or_default() += 1;
+  }
+
+  (sorted(smear_counts), sorted(apollo_counts))
+}
+
+/// Print the gate's findings as a markdown table on stdout, then a line per exclusion.
+///
+/// Called from the bench before any timing so the run's own log carries the evidence, and from
+/// the `gate` binary so the numbers can be captured on their own.
+pub fn print_gate(rows: &[GateRow]) {
+  println!("## Correctness gate");
+  println!();
+  println!(
+    "| entry | bytes | shape | side | errors | round-trip | CST nodes | CST tokens | lexer tokens | tier-2 visits | verdict |"
+  );
+  println!("|---|---:|---|---|---:|---|---:|---:|---:|---:|---|");
+  for row in rows {
+    for (side, gate) in [("smear", &row.smear), ("apollo", &row.apollo)] {
+      println!(
+        "| {} | {} | {:?} | {} | {} | {} | {} | {} | {} | {} | {} |",
+        row.name,
+        row.bytes,
+        row.shape,
+        side,
+        gate.errors,
+        if gate.round_trips {
+          "byte-exact".to_string()
+        } else {
+          format!("MISMATCH ({} bytes out)", gate.round_trip_len)
+        },
+        gate.nodes,
+        gate.tokens,
+        gate.lex_tokens,
+        gate.traversal_visits,
+        if gate.passed() { "pass" } else { "FAIL" },
+      );
+    }
+  }
+  println!();
+
+  let excluded: Vec<&GateRow> = rows.iter().filter(|r| !r.eligible()).collect();
+  if excluded.is_empty() {
+    println!("All {} corpus entries eligible for timing.", rows.len());
+  } else {
+    println!("EXCLUDED FROM TIMING ({}):", excluded.len());
+    for row in excluded {
+      println!(
+        "  - {}: smear {}, apollo {}",
+        row.name,
+        if row.smear.passed() {
+          "pass".to_string()
+        } else {
+          format!(
+            "FAIL (errors={}, round_trips={})",
+            row.smear.errors, row.smear.round_trips
+          )
+        },
+        if row.apollo.passed() {
+          "pass".to_string()
+        } else {
+          format!(
+            "FAIL (errors={}, round_trips={})",
+            row.apollo.errors, row.apollo.round_trips
+          )
+        },
+      );
+    }
+  }
+  println!();
+}

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -258,12 +258,12 @@ pub fn apollo_traverse_sdl(tree: &apollo_parser::SyntaxTree) -> usize {
   let document = tree.document();
   let mut visited = 0usize;
   for definition in document.definitions() {
-    if let cst::Definition::ObjectTypeDefinition(object) = definition {
-      if let Some(fields) = object.fields_definition() {
-        for field in fields.field_definitions() {
-          black_box(field.ty());
-          visited += 1;
-        }
+    if let cst::Definition::ObjectTypeDefinition(object) = definition
+      && let Some(fields) = object.fields_definition()
+    {
+      for field in fields.field_definitions() {
+        black_box(field.ty());
+        visited += 1;
       }
     }
   }
@@ -419,15 +419,22 @@ pub fn run_gate() -> Vec<GateRow> {
     .collect()
 }
 
+/// One side's node-kind histogram: `(kind name, occurrence count)` pairs, sorted by descending
+/// count.
+///
+/// Named so the pair `kind_histograms` returns spells as two named types rather than the
+/// `clippy::type_complexity`-tripping tuple of nested generics written out in full.
+pub type KindHistogram = Vec<(String, usize)>;
+
 /// Node-kind histograms for one entry, both sides, sorted by descending count.
 ///
 /// Gate 3 requires that a node-count difference be *explained* rather than published bare. The
 /// two kind spaces have no common vocabulary — they are different `rowan::Language`s — so the
 /// histograms cannot be diffed automatically; what they do is show, per side, which kinds carry
 /// the difference, which is enough for a reader to name the cause.
-pub fn kind_histograms(entry: &Entry) -> (Vec<(String, usize)>, Vec<(String, usize)>) {
-  fn sorted(mut counts: std::collections::HashMap<String, usize>) -> Vec<(String, usize)> {
-    let mut out: Vec<(String, usize)> = counts.drain().collect();
+pub fn kind_histograms(entry: &Entry) -> (KindHistogram, KindHistogram) {
+  fn sorted(mut counts: std::collections::HashMap<String, usize>) -> KindHistogram {
+    let mut out: KindHistogram = counts.drain().collect();
     out.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
     out
   }

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -25,6 +25,8 @@ use smear_parser::graphql::lossless::{
 };
 use tokora::{Lexer as _, emitter::Severity};
 
+pub mod dump;
+
 /// One corpus entry: a name, its source, and which of `apollo-parser`'s two published
 /// traversals matches its content.
 #[derive(Debug, Clone, Copy)]

--- a/benchmarks/tests/byte_identity.rs
+++ b/benchmarks/tests/byte_identity.rs
@@ -1,0 +1,122 @@
+//! The byte-identity gate: recompute all four corpus hashes and fail if any has moved.
+//!
+//! # Why this file exists
+//!
+//! Before it, the four hashes lived in a GitHub issue and in a commit message. That is a note, not
+//! a baseline: nothing recomputed it, so a change that re-shaped every tree in the corpus would go
+//! green through every gate this repository had. `smear-parser`'s own golden-tree suite covers the
+//! hand-written fixtures under `tests/golden/`; this covers the three real `apollo-parser`
+//! documents, their one-byte-broken controls, 24 hand-broken documents and ~9,300 truncations, and
+//! it is the only thing that does.
+//!
+//! # What a failure here means
+//!
+//! The tree changed. Not the text — `gate.rs` already checks that every corpus entry round-trips
+//! byte-exactly, and a parse can round-trip perfectly while opening entirely different nodes. A
+//! moved hash is a claim about **structure**: an indent shift is a re-parented subtree, a changed
+//! kind is a production opening the wrong node, a changed range is a node boundary that moved.
+//!
+//! To see which:
+//!
+//! ```text
+//! cargo run -p smear-apollo-bench --example treedump --release -- <corpus> > /tmp/after.dump
+//! git stash && cargo run -p smear-apollo-bench --example treedump --release -- <corpus> > /tmp/before.dump
+//! git stash pop && diff /tmp/before.dump /tmp/after.dump
+//! ```
+//!
+//! **Do not edit the constant to make this pass.** The constants live in `src/dump.rs` with a note
+//! on what they are pinned to; re-bless one only after the diff above is understood and intended,
+//! and record what moved it in the same commit. Editing a recorded hash to match whatever the code
+//! now produces turns the only byte-identity gate in this repository into a tautology.
+
+use smear_apollo_bench::dump::{Corpus, hash};
+
+/// The corpora [`cheap`] covers — everything that is not the 45-million-line one.
+const CHEAP: &[Corpus] = &[Corpus::Clean, Corpus::Perturbed, Corpus::Malformed];
+
+/// The corpora [`prefixes`] covers.
+const EXPENSIVE: &[Corpus] = &[Corpus::Prefixes];
+
+/// Recompute each corpus's hash and collect every mismatch, rather than tripping on the first.
+///
+/// Collecting matters: if a parser change moves three corpora, the reader wants all three named in
+/// one run, because *which* corpora moved is the strongest available clue about what changed. A
+/// change that moves `clean` but not `malformed` is a change on the accepting path; one that moves
+/// only `malformed` and `prefixes` is a change to recovery.
+fn check(corpora: &[Corpus]) {
+  assert!(
+    !corpora.is_empty(),
+    "this gate was handed an empty corpus set, so it would pass without checking anything"
+  );
+
+  let mut failures = Vec::new();
+  for &corpus in corpora {
+    let got = hash(corpus);
+    let want = corpus.expected();
+    if got != want {
+      failures.push(format!(
+        "  {:<10} recorded {want}\n  {:<10} computed {got}",
+        corpus.name(),
+        ""
+      ));
+    }
+  }
+
+  assert!(
+    failures.is_empty(),
+    "{} of {} corpus dump(s) no longer hash to their recorded value:\n{}\n\n\
+     The tree changed. Read this as a claim about structure, not text: a parse can round-trip \
+     byte-exactly and still open different nodes. `diff` the before/after dumps to see where \
+     (see this file's header), and do NOT edit the constant in src/dump.rs to make this pass.",
+    failures.len(),
+    corpora.len(),
+    failures.join("\n"),
+  );
+}
+
+/// The three corpora that are cheap enough to hash unconditionally.
+#[test]
+fn cheap() {
+  check(CHEAP);
+}
+
+/// The truncation corpus — ~9,300 documents and roughly 45 million lines of dump.
+///
+/// `#[ignore]` because in an unoptimised build this is minutes rather than seconds, and it would
+/// otherwise be paid by every `cargo test --workspace` on every member. It is **not** dropped: CI
+/// runs it in release with `--include-ignored`, and [`every_corpus_is_covered`] fails if a corpus
+/// ever stops being reachable from one of the two lists above.
+///
+/// Locally: `cargo test -p smear-apollo-bench --release -- --include-ignored`.
+#[test]
+#[ignore = "45M lines; run in release, CI covers it via --include-ignored"]
+fn prefixes() {
+  check(EXPENSIVE);
+}
+
+/// Every corpus is covered by exactly one of the two tests above.
+///
+/// The failure this exists to prevent is the quiet one. Adding a fifth corpus to
+/// [`Corpus::ALL`] and forgetting to list it would leave it unchecked while the suite stayed
+/// green — the same shape as a cargo target filter that matches nothing and exits 0. This turns
+/// that into a red test naming the corpus that has no home.
+#[test]
+fn every_corpus_is_covered() {
+  for corpus in Corpus::ALL {
+    let in_cheap = CHEAP.contains(&corpus);
+    let in_expensive = EXPENSIVE.contains(&corpus);
+    assert!(
+      in_cheap ^ in_expensive,
+      "corpus `{}` is covered by {} of this file's two test lists; it must be covered by exactly \
+       one, or it is either unchecked or checked twice",
+      corpus.name(),
+      if in_cheap { "both" } else { "neither" },
+    );
+  }
+
+  assert_eq!(
+    CHEAP.len() + EXPENSIVE.len(),
+    Corpus::ALL.len(),
+    "the two lists name more corpora between them than `Corpus::ALL` has"
+  );
+}


### PR DESCRIPTION
Moves the `apollo-comparison` harness onto the current trunk and puts its four byte-identity
hashes **in the repository, behind a gate that reds**. Closes the blocker in tokora#209.

Rebased onto `c736b13`. The branch is now **the harness and nothing else**: +4,932 lines, zero
deletions, zero parser source, no manifest feature change, no `[patch.crates-io]`.

## The port turned out to be obsolete

The original plan was to port smear-parser to post-#175 tokora. That work is already on the trunk:
`75da4fc` (#55) landed #175's construction door and the `EmitterView` change, and **published
tokora 0.8.0 already carries those APIs** — which is why #55 could also delete the path patch.

So commit `03731ae`, which hand-applied #55's hunks, is redundant and has been dropped. Measured,
not assumed: the harness grafted onto a pristine trunk builds clean against published `tokora
0.8.0` with **no** parser changes, **no** `combinators`, and **no** patch (`cargo check -p
smear-apollo-bench --examples --benches --release` → 0 errors).

That has a consequence beyond tidiness: the harness resolves from crates.io, so **CI can run the
byte-identity gate on any runner** with no sibling tokora checkout. That is what made the gate
below possible at all.

## Correction: my earlier "the trunk is broken" finding inverts

An earlier revision of this description claimed smear's trunk fails against tokora `main` with 167
`combinators` errors and that the fix "arguably belongs on the trunk". **That is backwards, and
acting on it would break the trunk.**

The trunk's manifest is `tokora = { version = "0.8.0", … }` with no path patch — it builds against
the *published* crate. Published 0.8.0 has 26 features and `combinators` is not one of them; it is
unreleased 0.9.0 surface. Adding the word today fails at dependency resolution:

```
package `…` depends on `tokora` with feature `combinators` but `tokora` does not have that feature.
help: available features: alloc, bstr, …, trace, unstable-raw
```

The trunk builds clean as it stands (`cargo check -p smear-parser --features rowan,graphql` → 0
errors). My 167 errors came from forcing an unreleased tokora onto it with `--config`; they are a
preview of the 0.9.0 adoption, not a present defect. **Do not add `combinators` to the trunk.**

## Re-blessed hashes, with attribution

| corpus | old | new | moved by |
|---|---|---|---|
| clean | `cbd516b9…` | `00f2b8b2…` | `68a9a40` |
| perturbed | `a42a39d4…` | `a42a39d4…` | *unchanged* |
| malformed | `2b5f2937…` | `2b5f2937…` | *unchanged* |
| prefixes | `1c3b8f1f…` | `ab57d222…` | `68a9a40` |

The movement is entirely the trunk's, and specifically one commit. Evidence:

* **tokora is not the cause.** Holding smear constant, published `0.8.0` and unreleased `main`
  (`b42257b`) produce **byte-identical dumps on all four corpora**. The version difference
  contributes nothing.
* **The cause is `68a9a40`, "open `NamedType` after its leading trivia, not before".** The whole
  `clean` diff is 12 lines over exactly 2 sites, and every changed line is a `NamedType` or the
  `Space` that moved out of it.
* **Why only two of four moved.** `NamedType` counts are identical old and new in every corpus
  (clean 1156, perturbed 152, malformed 2), and in `perturbed` and `malformed` no `NamedType` has
  leading trivia to relocate — so those two dumps are byte-identical old vs new. `prefixes` moved
  because it truncates the same clean documents.
* **This branch is tree-neutral by construction.** Its diff against the trunk touches no parser
  source at all, so "trunk alone" and "trunk + branch" are the same tree.
* **`#71` (`a6fe85c`) and `#72` (`c736b13`) are both inert — checked, not assumed.** #72 rewrote
  span computation at 95 sites, which is exactly the kind of "obviously unrelated" change worth
  falsifying; all four dumps are byte-identical across it. It moves AST spans, and these hashes
  come from the lossless CST.

## The gate (`benchmarks/tests/byte_identity.rs`)

The constants now live in `benchmarks/src/dump.rs` with a note on what they are pinned to. The
dump machinery moved out of `examples/treedump.rs` into the library so the example and the gate
are **one implementation**, incapable of disagreeing. The lift is proven output-preserving: all
four dumps byte-identical before and after, all four hashes unchanged.

`hash` streams into the hasher rather than materialising a `String`, so the 1.4 GB / 45-million-line
`prefixes` corpus is checked in bounded memory with no redirect to a file.

**Cost, measured.** Release: all four in **10.15 s**. Debug: `prefixes` alone **does not finish
inside ten minutes**. So `prefixes` carries `#[ignore]` and is opted into exactly once — by the CI
job, in release. The three cheap corpora need no opt-in and are also picked up by the ordinary
`test` job. No corpus is dropped, and `every_corpus_is_covered` fails if one is ever added to
`Corpus::ALL` without being listed, so coverage cannot silently narrow.

**Placement: `ci.yml`, its own Linux job.** Deliberately not `macos.yml` or `miri.yml` — those two
exist to hold legs that are queue-bound or slow so CI can reach a conclusion, and this is ten
seconds of pure computation whose verdict is a property of the parser's output, not the host.
Behind the macOS queue a moved hash would surface hours after the PR that moved it. It names
`--test byte_identity` rather than filtering, because a filter that matches nothing warns and
exits 0 while a named target that has been renamed is a hard error.

**It discriminates — proven, not asserted.** Flipping one byte of `corpus/example_query.graphql`
(`id` → `iD`):

```
GATE EXIT=101
test cheap ... FAILED
2 of 3 corpus dump(s) no longer hash to their recorded value:
  clean      recorded 00f2b8b2bce48001aff45f8049141a13ca740fc6fe8eb4d9e287d1ccd4a46fc9
             computed af0751fd1fca8787ae2a6dc803204dae329aff8053d8f5cedffff7a26fcaf304
  perturbed  recorded a42a39d41d4b8495f1ab5420292f9c76d194fd89697867fae1e2546ca64486b9
             computed 66d93df7c030b5e061b8f2ddd2e0b9bfde06dacb1e0e45871c44b8b35d4367d0
```

It names which corpora moved, and `malformed` — which does not read the corpus files — correctly
stays green. Reverted; green again on all four.

## tokora #212 (`9bc7137`): all four unmoved

Holding smear constant and varying only tokora, #212 is **tree-neutral on every corpus**:

| corpus | tokora `main` | tokora #212 | |
|---|---|---|---|
| clean | `00f2b8b2…` | `00f2b8b2…` | unmoved |
| perturbed | `a42a39d4…` | `a42a39d4…` | unmoved |
| malformed | `2b5f2937…` | `2b5f2937…` | unmoved |
| prefixes | `ab57d222…` | `ab57d222…` | unmoved |

#212's central claim — that naming a node's kind up front is observationally identical to the
retro path on every accepted stream — holds across ~9,300 documents including the whole recovery
corpus.

### Perf, before/after — these are **lossless** numbers, the lower-priority track

`alias`, 57,741 bytes, release, same machine and session. apollo is the unchanged control.

| measurement | tokora `main` | tokora #212 | Δ smear |
|---|---|---|---|
| `tier1_parse` smear | 1.5189 ms | **1.4872 ms** | −2.1% |
| `tier1_parse` apollo | 1.2300 ms | 1.2357 ms | +0.5% (control) |
| `tier2_parse_traverse` smear | 1.5461 ms | **1.5192 ms** | −1.7% |
| `tier0_lex` smear | 152.14 µs | 152.92 µs | +0.5% (noise) |
| `perfloop` smear / apollo / gap | 1620.1 / 1220.6 / 399.5 µs | 1563.0 / 1209.6 / **353.4 µs** | gap −11.5% |

The gap on `tier1_parse` narrows from 1.235× to 1.204×. The `tier2` apollo cell came back
contaminated (interval `[1.2665, 1.6039]`, spanning 27%) and is excluded rather than quoted.

Caution on the numbers in the previous revision of this description (`tier1_parse` 1.5501 ms,
`perfloop` gap 462.5 µs): those were a different session, and apollo — whose code did not change —
moved 3.3% between them. Only the within-session A/B above should be read as a measurement.

## An automated agent pushed a non-building branch here while this was in flight

`copilot-swe-agent[bot]` pushed two commits to `bench/apollo-comparison` during this work:
`9e773b2` (merge the trunk, resolving the four conflicts) and `c8a15c5` (remove
`[patch.crates-io]`). It reached the same conclusion I did about the patch — but it **kept
`combinators` in the manifest while removing the patch**, which cannot resolve:

```
EXIT=101
package `smear-apollo-bench` depends on `tokora` with feature `combinators`
but `tokora` does not have that feature.
```

Reproduced locally against that exact configuration. This is a *resolution* failure, not a build
failure, so nothing in the workspace compiles — and GitHub still reported the PR `MERGEABLE`,
because mergeability is a git property and says nothing about whether the result builds.

This branch has been force-pushed over that work with a lease pinned to `c8a15c5`. Both Copilot
commits remain reachable from this PR's timeline if any of it is wanted.

## Verification summary, all at `c736b13` + published `tokora 0.8.0`

* `cargo test -p smear-apollo-bench --release --test byte_identity -- --include-ignored` — 3 passed
* `cargo check --workspace --all-targets` — 0 errors
* `cargo clippy -p smear-apollo-bench --all-targets -- -D warnings` — clean
* `cargo fmt --all -- --check` — clean
* `treedump selfcheck` — both anti-vacuity probes pass
* `treedump gate` — all 3 corpus entries eligible, both sides 0 errors and byte-exact round-trip
* `cargo test -p smear-parser --features rowan --test lossless_golden` — 7 passed, 0 failed (the
  two failures the pre-rebase branch carried were trunk-drift and are gone with the rebase)

Refs: tokora#209
