### PR TITLE
ci: split the macOS-bound lanes out of CI so it can conclude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,26 @@
 name: CI
 
+# ── THIS IS THE FAST LANE ───────────────────────────────────────────────────────────────────
+#
+# Every job here runs on `ubuntu-latest` or `windows-latest`. Nothing macOS-bound lives in this
+# file: the Miri matrices are in `.github/workflows/miri.yml` and the four ordinary macOS legs
+# are in `.github/workflows/macos.yml`, and those two headers carry the measurement that
+# separated them.
+#
+# The short version: on 2026-08-06 `CI` had not concluded on any of the last four pull requests
+# — two of which merged anyway — while `loc` completed on the same refs, so it was never an
+# outage. On #64's run (31051592352) 29 of 39 jobs finished and every one was green, but a
+# conclusion is a property of the WHOLE run, so none of those 29 verdicts was readable. The 10
+# that did not finish were 8 macOS-bound jobs plus 2 ubuntu Miri cells still running, and
+# `coverage` was never even created because it `needs:` matrices those macOS cells sat in.
+#
+# So the contract is: this workflow's conclusion is the one a merge waits for, and it is
+# answerable in tens of minutes because nothing in it queues for a macOS runner. Adding a
+# `runs-on: macos-*` here gives that up — the whole lane is then only as fast as its scarcest
+# host, which is the state this split undid. Adding a Miri cell here gives it up for a different
+# reason: Miri sets its own wall clock (4h20m for the longest cell in the last run that
+# concluded) regardless of how free the runners are.
+
 on:
   push:
     branches:
@@ -28,6 +49,23 @@ on:
   workflow_dispatch:
   schedule: [cron: "0 1 */7 * *"]
 
+concurrency:
+  # There was no concurrency group here at all before the split, so every push to a branch left
+  # its predecessor's run alive and competing for the same runners — which fed the very queue
+  # that stopped this workflow concluding. One in-flight run per workflow per ref now, so a
+  # branch's CI reflects its tip rather than a backlog of superseded commits.
+  #
+  # `main` is the exception: the group is keyed on the commit SHA so that every main commit gets
+  # its own group and its own verdict. Do NOT collapse that back to one group per ref —
+  # `cancel-in-progress: false` does not protect a main run on its own, because a run queued
+  # into a group that already has one in progress cancels whichever run was PENDING there
+  # regardless of that setting.
+  #
+  # `${{ github.workflow }}` leading the group is what keeps the three lanes apart: `CI-...`,
+  # `Miri-...` and `macOS-...` are different groups, so no lane can cancel another's run.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings -C debuginfo=0 -C codegen-units=16
@@ -41,9 +79,10 @@ jobs:
     name: rustfmt
     strategy:
       matrix:
+        # `macos-latest` is deliberately absent — it lives in
+        # `.github/workflows/macos.yml`. See this file's header before adding it back.
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,9 +99,10 @@ jobs:
     name: clippy
     strategy:
       matrix:
+        # `macos-latest` is deliberately absent — it lives in
+        # `.github/workflows/macos.yml`. See this file's header before adding it back.
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -121,9 +161,10 @@ jobs:
     name: build
     strategy:
       matrix:
+        # `macos-latest` is deliberately absent — it lives in
+        # `.github/workflows/macos.yml`. See this file's header before adding it back.
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -155,9 +196,10 @@ jobs:
     name: test
     strategy:
       matrix:
+        # `macos-latest` is deliberately absent — it lives in
+        # `.github/workflows/macos.yml`. See this file's header before adding it back.
         os:
           - ubuntu-latest
-          - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -206,33 +248,9 @@ jobs:
         # Make PDB generation lighter & avoid incremental weirdness in CI
         echo "RUSTFLAGS=$env:RUSTFLAGS -C link-arg=/DEBUG:FASTLINK -C link-arg=/INCREMENTAL:NO" >> $env:GITHUB_ENV
 
-    - name: Install LLVM + LLD and use ld64.lld (macOS)
-      if: runner.os == 'macOS'
-      run: |
-        brew update
-        brew install llvm lld
-
-        LLVM_PREFIX="$(brew --prefix llvm)"
-        LLD_PREFIX="$(brew --prefix lld)"
-        LLD_PATH="$LLD_PREFIX/bin/ld64.lld"
-
-        # Sanity checks (helpful in logs)
-        echo "LLVM_PREFIX=$LLVM_PREFIX"
-        echo "LLD_PREFIX=$LLD_PREFIX"
-        test -x "$LLVM_PREFIX/bin/clang" || { echo "clang missing"; exit 1; }
-        test -x "$LLD_PATH" || { echo "ld64.lld missing at $LLD_PATH"; exit 1; }
-
-        # Use Homebrew clang as the driver
-        echo "PATH=$LLVM_PREFIX/bin:$PATH" >> $GITHUB_ENV
-        echo "CC=$LLVM_PREFIX/bin/clang" >> $GITHUB_ENV
-        echo "CXX=$LLVM_PREFIX/bin/clang++" >> $GITHUB_ENV
-
-        # Ensure Cargo uses clang on macOS targets
-        echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=$LLVM_PREFIX/bin/clang" >> $GITHUB_ENV
-        echo "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=$LLVM_PREFIX/bin/clang" >> $GITHUB_ENV
-
-        # Tell clang to use ld64.lld explicitly (absolute path required on macOS)
-        echo "RUSTFLAGS=${RUSTFLAGS} -C linker=$LLVM_PREFIX/bin/clang -C link-arg=-fuse-ld=$LLD_PATH" >> $GITHUB_ENV
+    # The `if: runner.os == 'macOS'` step that used to sit here moved with the macOS leg to
+    # `.github/workflows/macos.yml`; no host in this job's matrix can satisfy that guard, so
+    # leaving it would have been a step that reads as coverage and compiles nothing.
 
     - name: Run test
       run: cargo test --all-features -- --quiet
@@ -339,133 +357,11 @@ jobs:
     - name: cargo build --workspace --all-features
       run: cargo build --workspace --all-features
 
-  miri-tb:
-    name: miri-tb-${{ matrix.target }}
-    strategy:
-      # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
-      # a cross toolchain (installed below); don't let a failure there
-      # cancel the other, unrelated cells in this matrix.
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-        target:
-          - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - aarch64-apple-darwin
-        # Exclude invalid combinations
-        exclude:
-          - os: ubuntu-latest
-            target: x86_64-apple-darwin
-          - os: ubuntu-latest
-            target: aarch64-apple-darwin
-          - os: macos-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: i686-unknown-linux-gnu
-          - os: macos-latest
-            target: powerpc64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-      - name: Cache cargo build and registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-miri-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-miri-
-      - name: Install cargo-hack
-        run: cargo install cargo-hack
-      - name: Install cross C toolchain for ${{ matrix.target }}
-        # x86_64-unknown-linux-gnu and the macOS targets build with the
-        # runner's native toolchain; only the two Linux cross targets need
-        # an extra package, so install exactly the one each needs.
-        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
-        run: |
-          case "${{ matrix.target }}" in
-            i686-unknown-linux-gnu)
-              sudo apt-get update
-              sudo apt-get install -y gcc-multilib
-              ;;
-            powerpc64-unknown-linux-gnu)
-              sudo apt-get update
-              sudo apt-get install -y gcc-powerpc64-linux-gnu
-              ;;
-          esac
-      - name: Miri
-        run: |
-          bash ci/miri_tb.sh ${{ matrix.target }}
-
-  miri-sb:
-    name: miri-sb-${{ matrix.target }}
-    strategy:
-      # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
-      # a cross toolchain (installed below); don't let a failure there
-      # cancel the other, unrelated cells in this matrix.
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-        target:
-          - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - aarch64-apple-darwin
-        # Exclude invalid combinations
-        exclude:
-          - os: ubuntu-latest
-            target: x86_64-apple-darwin
-          - os: ubuntu-latest
-            target: aarch64-apple-darwin
-          - os: macos-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: i686-unknown-linux-gnu
-          - os: macos-latest
-            target: powerpc64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v5
-      - name: Cache cargo build and registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-miri-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-miri-
-      - name: Install cargo-hack
-        run: cargo install cargo-hack
-      - name: Install cross C toolchain for ${{ matrix.target }}
-        # x86_64-unknown-linux-gnu and the macOS targets build with the
-        # runner's native toolchain; only the two Linux cross targets need
-        # an extra package, so install exactly the one each needs.
-        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
-        run: |
-          case "${{ matrix.target }}" in
-            i686-unknown-linux-gnu)
-              sudo apt-get update
-              sudo apt-get install -y gcc-multilib
-              ;;
-            powerpc64-unknown-linux-gnu)
-              sudo apt-get update
-              sudo apt-get install -y gcc-powerpc64-linux-gnu
-              ;;
-          esac
-      - name: Miri
-        run: |
-          bash ci/miri_sb.sh ${{ matrix.target }}
+  # `needs:` is unchanged, but its effect is not. Every matrix named below used to contain a
+  # `macos-latest` cell, so on a run where those cells never got a runner this job was never
+  # created at all — it does not appear in the job list of #64's or #66's run. With the macOS
+  # cells gone from those matrices it becomes reachable again, which means the first runs after
+  # this change are the first time in a while that anything has watched `coverage` finish.
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,191 @@
+name: macOS
+
+# ── THE QUEUE-BOUND LANE ────────────────────────────────────────────────────────────────────
+#
+# These four legs used to be the `macos-latest` row of `CI`'s `rustfmt`, `clippy`, `build` and
+# `test` matrices. They are here for the same reason the Miri matrices are in
+# `.github/workflows/miri.yml`, and the two files' headers describe one measurement: on
+# 2026-08-06 `CI` had not concluded on any of the last four pull requests, because the only jobs
+# that never started were macOS-bound and a run's conclusion is a property of the WHOLE run. Two
+# of those four merged with no CI verdict at all.
+#
+# The distinction between this file and `miri.yml` is queue versus clock. These four legs are
+# FAST once they start and slow only because they wait: in run 30963710061 — the last `CI` run
+# that concluded at all — `rustfmt (macos-latest)` waited 6h38m to run for 9 seconds,
+# `clippy (macos-latest)` waited 6h08m to run 7m24s, `build (macos-latest)` waited 9h17m to run
+# 6m05s, and `test (macos-latest)` waited 9h26m to run 18m12s. The Miri cells in that run were
+# both queue-bound AND slow (4h20m of runtime for the longest). Same cause, different shape, and
+# they are separated so that a macOS formatting failure and a Miri UB report can be read apart.
+#
+# This is a SCHEDULING change, not a coverage change. Every step below is what `CI` ran on
+# `macos-latest` before, unchanged, and the job names are unchanged too — the single-entry `os`
+# matrix is kept precisely so these still report as `rustfmt (macos-latest)` and friends. The one
+# thing dropped is `test`'s `if: runner.os == 'Windows'` step, which can never fire here.
+#
+# Worth knowing when this lane's cost is next reviewed: `cargo fmt --all -- --check` is decided
+# by the rustfmt version and `rustfmt.toml`, not by the host, so `rustfmt (macos-latest)` is the
+# leg with the least to say — 9 seconds of work behind a 6h38m queue. It is kept because moving
+# coverage and deleting it are different decisions, and it costs `CI` nothing from here.
+
+# Triggers and `paths-ignore` are deliberately identical to `.github/workflows/ci.yml` and
+# `.github/workflows/miri.yml`; read the comment there for why the ignore list carries no
+# blanket `**.md`.
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'COPYRIGHT'
+      - 'LICENSE-*'
+      - 'docs/**.md'
+      - 'legacy/**.md'
+      - '**.txt'
+  pull_request:
+    paths-ignore:
+      - 'COPYRIGHT'
+      - 'LICENSE-*'
+      - 'docs/**.md'
+      - 'legacy/**.md'
+      - '**.txt'
+  workflow_dispatch:
+  schedule: [cron: "0 1 */7 * *"]
+
+concurrency:
+  # Identical to `CI`'s and `Miri`'s; see the comment in `miri.yml` for why `${{ github.workflow }}`
+  # leads the group and why `main` is keyed on the commit SHA.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# Carried from `CI` verbatim: these are the same jobs, and `RUSTFLAGS` is what they compiled
+# with. `CI`'s `nightly` / `stable` entries are not carried — no step here, or there, reads them.
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings -C debuginfo=0 -C codegen-units=16
+  RUST_BACKTRACE: 1
+
+jobs:
+  # Check formatting
+  rustfmt:
+    name: rustfmt
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+
+  # Apply clippy lints
+  clippy:
+    name: clippy
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v5
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - name: Install cargo-hack
+      run: cargo install cargo-hack
+    - name: Apply clippy lints
+      run: cargo hack clippy --each-feature
+
+  build:
+    name: build
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v5
+    - name: Cache cargo build and registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-build-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - name: Install cargo-hack
+      run: cargo install cargo-hack
+    - name: Cache ~/.cargo
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo
+        key: ${{ runner.os }}-coverage-dotcargo
+    - name: Run build
+      run: cargo hack build --each-feature
+
+  test:
+    name: test
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v5
+    - name: Cache cargo build and registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-test-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-test-
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - name: Install cargo-hack
+      run: cargo install cargo-hack
+    - name: Cache ~/.cargo
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo
+        key: ${{ runner.os }}-coverage-dotcargo
+
+    # No `if: runner.os == 'macOS'` guard: the matrix has one host and it is this one, so the
+    # guard would be vacuously true. A vacuously-true guard is worth deleting rather than
+    # keeping — if it ever evaluated false the step would skip in silence and `cargo test` would
+    # link with a different linker than the one this job exists to exercise.
+    - name: Install LLVM + LLD and use ld64.lld
+      run: |
+        brew update
+        brew install llvm lld
+
+        LLVM_PREFIX="$(brew --prefix llvm)"
+        LLD_PREFIX="$(brew --prefix lld)"
+        LLD_PATH="$LLD_PREFIX/bin/ld64.lld"
+
+        # Sanity checks (helpful in logs)
+        echo "LLVM_PREFIX=$LLVM_PREFIX"
+        echo "LLD_PREFIX=$LLD_PREFIX"
+        test -x "$LLVM_PREFIX/bin/clang" || { echo "clang missing"; exit 1; }
+        test -x "$LLD_PATH" || { echo "ld64.lld missing at $LLD_PATH"; exit 1; }
+
+        # Use Homebrew clang as the driver
+        echo "PATH=$LLVM_PREFIX/bin:$PATH" >> $GITHUB_ENV
+        echo "CC=$LLVM_PREFIX/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$LLVM_PREFIX/bin/clang++" >> $GITHUB_ENV
+
+        # Ensure Cargo uses clang on macOS targets
+        echo "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER=$LLVM_PREFIX/bin/clang" >> $GITHUB_ENV
+        echo "CARGO_TARGET_X86_64_APPLE_DARWIN_LINKER=$LLVM_PREFIX/bin/clang" >> $GITHUB_ENV
+
+        # Tell clang to use ld64.lld explicitly (absolute path required on macOS)
+        echo "RUSTFLAGS=${RUSTFLAGS} -C linker=$LLVM_PREFIX/bin/clang -C link-arg=-fuse-ld=$LLD_PATH" >> $GITHUB_ENV
+
+    - name: Run test
+      run: cargo test --all-features -- --quiet

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,251 @@
+name: Miri
+
+# ── THE SLOW LANE ───────────────────────────────────────────────────────────────────────────
+#
+# Miri lives in its own workflow so that `CI` can reach a CONCLUSION. Measured 2026-08-06 on the
+# last five pull requests: `CI` concluded on exactly one of them. The four most recent — #60 and
+# #63 (both MERGED anyway), #64 and #66 — were still `queued` hours later, while `loc` completed
+# on the same refs in the same window, so it was never an outage.
+#
+# The jobs were not the problem; the RUN was. On #64's run (31051592352) 29 of 39 jobs completed
+# and every one of them was green, but a conclusion is a property of the WHOLE run, so all 29 of
+# those verdicts were unreadable. The 8 that never started were the 4 `macos-latest` legs of
+# `rustfmt`/`clippy`/`build`/`test` and the 4 apple-darwin Miri cells; `coverage` never even got
+# created, because it `needs:` matrices those macOS cells belong to. Nothing else was outstanding.
+#
+# WHY: the account's macOS runner concurrency is the binding constraint, and it is shared. At the
+# time of measurement 96 macOS-bound jobs were queued or running in another repository's Miri
+# workflow. smear's eight sat behind all of them.
+#
+# The one run that did conclude (30963710061, created 00:34:20Z) shows the cost with no queue
+# theory needed: the last job to finish was `miri-tb-x86_64-apple-darwin` at 15:16:25Z — a
+# 14h42m wall clock, of which the entire tail was macOS. `rustfmt (macos-latest)` in that run
+# waited 6h38m to run for 9 seconds.
+#
+# WHY MIRI AND NOT ONLY THE APPLE CELLS. The 6 ubuntu Miri cells are not queue-bound, but they
+# are the wall clock: in that same run `miri-tb-x86_64-apple-darwin` ran 4h20m and
+# `miri-tb-aarch64-apple-darwin` 3h56m once started. Leaving any Miri cell in `CI` would keep
+# `CI`'s answer hours away even with every runner free, so the whole gate moves and Miri reports
+# on its own clock. The four ordinary macOS legs are queue-bound rather than slow, so they went
+# to `.github/workflows/macos.yml` instead — a third lane, not this one, because a macOS
+# formatting failure and a Miri UB report are different findings and should be readable apart.
+#
+# This is a SCHEDULING change, not a coverage change. Every job, matrix cell and step below runs
+# what `.github/workflows/ci.yml` ran before, unchanged — the same 10 cells, the same two
+# aliasing models, the same `ci/miri_tb.sh` / `ci/miri_sb.sh`. The one step dropped in the move
+# was `cargo install cargo-hack`, which neither script invokes: both run `cargo miri setup` and
+# `cargo miri test` and nothing else, so it compiled a tool no cell used, on every cell.
+#
+# What this does NOT do is make Miri faster. It cannot: the macOS queue is a runner-concurrency
+# constraint this repository does not own. What the split buys is that `CI`'s answer no longer
+# waits behind it.
+
+# ── WHY THE APPLE CELLS STILL RUN ON A macOS HOST ───────────────────────────────────────────
+#
+# Miri interprets a TARGET, so the host ought to be irrelevant, and if it were, these 4 cells
+# would become ubuntu ones and the queue that forced this split would stop mattering here.
+# Measured rather than assumed, and the answer is the same one tokora reached: `cargo build` is
+# the obstacle, not Miri.
+#
+# `criterion 0.8.2` is an UNCONDITIONAL dev-dependency of both `smear-lexer` and `smear-parser`,
+# and it depends on `alloca 0.4.0`, whose build script is a `cc::Build` that compiles `alloca.c`.
+# `cargo check --workspace --tests` on this tree produces
+# `target/debug/build/alloca/*/out/libcalloca.a`, so the C file is built for the target selected
+# by `--tests` — which is exactly the selection `ci/miri_tb.sh` and `ci/miri_sb.sh` make. On a
+# Linux host targeting `*-apple-darwin`, cc-rs invokes the host `cc` with `-arch x86_64` /
+# `-arch arm64` and `-mmacosx-version-min=...`; a Linux `cc` rejects those, and compiling them
+# needs Apple clang and the macOS SDK.
+#
+# So `macos-latest` here is load-bearing for a reason that has nothing to do with Miri, and it is
+# not a leftover. Moving these cells means getting criterion out of the dev-dependency graph
+# first — cargo has no optional dev-dependencies, so that means the benches moving to their own
+# workspace member — or putting an osxcross toolchain on the runner, which trades a runner queue
+# for an unmanaged SDK. Neither is a CI edit.
+#
+# WHAT THE TARGET AXIS BUYS, separately from the host. This workspace contains no `target_arch`,
+# `target_os`, `target_vendor`, `target_pointer_width` or `target_endian` cfg anywhere, so every
+# cell interprets the same source and what varies is only what Miri models: word size, byte
+# order and layout. On that axis `i686-unknown-linux-gnu` (32-bit) and
+# `powerpc64-unknown-linux-gnu` (big-endian) are each unique, and `x86_64-unknown-linux-gnu`,
+# `x86_64-apple-darwin` and `aarch64-apple-darwin` are all 64-bit little-endian. The two apple
+# cells are therefore the weakest of the five, and `x86_64-apple-darwin` is the weakest of those
+# — it shares its word size and byte order with the linux x86_64 cell and its OS with the other
+# apple cell. They are kept because dropping coverage is a different decision from moving it,
+# and because they cost `CI` nothing from here; if the macOS budget ever has to shrink,
+# `x86_64-apple-darwin` is the cell to spend first.
+
+# Triggers and `paths-ignore` are deliberately identical to `.github/workflows/ci.yml` and
+# `.github/workflows/macos.yml`; read the comment there for why the ignore list carries no
+# blanket `**.md`.
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'COPYRIGHT'
+      - 'LICENSE-*'
+      - 'docs/**.md'
+      - 'legacy/**.md'
+      - '**.txt'
+  pull_request:
+    paths-ignore:
+      - 'COPYRIGHT'
+      - 'LICENSE-*'
+      - 'docs/**.md'
+      - 'legacy/**.md'
+      - '**.txt'
+  workflow_dispatch:
+  schedule: [cron: "0 1 */7 * *"]
+
+concurrency:
+  # Same expression as `CI`'s and `macOS`'s, and `${{ github.workflow }}` leading it is what keeps
+  # the three lanes independent: `CI-...`, `Miri-...` and `macOS-...` are different groups, so no
+  # lane can cancel another's run. One in-flight run per ref, except on `main`, where the group is
+  # keyed on the commit SHA so that every main commit gets its own group and its own verdict. Do
+  # NOT collapse that back to one group per ref: `cancel-in-progress: false` does not protect a
+  # main run on its own, because a run queued into a group that already has one in progress
+  # cancels whichever run was PENDING there regardless of that setting — and this workflow is
+  # precisely the one whose runs stay pending long enough for the next push to do it.
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# `RUSTFLAGS` is carried over from `CI` verbatim even though `ci/miri_tb.sh` and `ci/miri_sb.sh`
+# both set `MIRIFLAGS` before any `cargo miri test`: neither script touches `RUSTFLAGS`, so this
+# value is what `cargo miri setup` and the test build see, and changing it here would change what
+# these cells compile. `CI`'s `nightly` / `stable` entries are not carried — no step in this
+# workflow, or in that one, references them.
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings -C debuginfo=0 -C codegen-units=16
+  RUST_BACKTRACE: 1
+
+jobs:
+  miri-tb:
+    name: miri-tb-${{ matrix.target }}
+    strategy:
+      # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
+      # a cross toolchain (installed below); don't let a failure there
+      # cancel the other, unrelated cells in this matrix.
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        target:
+          - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+        # Exclude invalid combinations. All five entries below are live: each
+        # names an `os` and a `target` that both appear in the lists above, so
+        # each removes a cell that the product would otherwise create. 2 x 5
+        # minus 5 leaves the 5 cells this matrix runs.
+        exclude:
+          - os: ubuntu-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: i686-unknown-linux-gnu
+          - os: macos-latest
+            target: powerpc64-unknown-linux-gnu
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache cargo build and registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-miri-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-miri-
+      - name: Install cross C toolchain for ${{ matrix.target }}
+        # x86_64-unknown-linux-gnu and the macOS targets build with the
+        # runner's native toolchain; only the two Linux cross targets need
+        # an extra package, so install exactly the one each needs.
+        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
+        run: |
+          case "${{ matrix.target }}" in
+            i686-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-multilib
+              ;;
+            powerpc64-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-powerpc64-linux-gnu
+              ;;
+          esac
+      - name: Miri
+        run: |
+          bash ci/miri_tb.sh ${{ matrix.target }}
+
+  miri-sb:
+    name: miri-sb-${{ matrix.target }}
+    strategy:
+      # i686-unknown-linux-gnu and powerpc64-unknown-linux-gnu currently need
+      # a cross toolchain (installed below); don't let a failure there
+      # cancel the other, unrelated cells in this matrix.
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        target:
+          - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-gnu
+          - powerpc64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+        # Exclude invalid combinations. All five entries below are live: each
+        # names an `os` and a `target` that both appear in the lists above, so
+        # each removes a cell that the product would otherwise create. 2 x 5
+        # minus 5 leaves the 5 cells this matrix runs.
+        exclude:
+          - os: ubuntu-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: i686-unknown-linux-gnu
+          - os: macos-latest
+            target: powerpc64-unknown-linux-gnu
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache cargo build and registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-miri-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-miri-
+      - name: Install cross C toolchain for ${{ matrix.target }}
+        # x86_64-unknown-linux-gnu and the macOS targets build with the
+        # runner's native toolchain; only the two Linux cross targets need
+        # an extra package, so install exactly the one each needs.
+        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
+        run: |
+          case "${{ matrix.target }}" in
+            i686-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-multilib
+              ;;
+            powerpc64-unknown-linux-gnu)
+              sudo apt-get update
+              sudo apt-get install -y gcc-powerpc64-linux-gnu
+              ;;
+          esac
+      - name: Miri
+        run: |
+          bash ci/miri_sb.sh ${{ matrix.target }}


### PR DESCRIPTION
Closes #69.