### PR TITLE
fix(parser): composite spans are token extents, not lookahead positions

### DIFF
--- a/smear-parser/src/combinator/extent.rs
+++ b/smear-parser/src/combinator/extent.rs
@@ -1,0 +1,194 @@
+//! Token-extent spans: a composite node's span is the extent of the tokens it contains.
+//!
+//! # The two positions a parser can be at, and why only one of them is a span endpoint
+//!
+//! tokora's [`InputRef`] tracks two offsets, and they are not the same number:
+//!
+//! - [`cursor()`](InputRef::cursor) — the **lookahead** position. It is the start of the first
+//!   cached token when a peek has filled the cache, and the end of the last committed token when
+//!   it has not. tokora documents it as "not a progress metric": a peek or a declined scan moves
+//!   it across skipped bytes without committing anything.
+//! - [`span().end()`](InputRef::span) — **committed progress**: where the last consumed token
+//!   actually ended.
+//!
+//! tokora's [`spanned()`](tokora::ParseInput::spanned) and
+//! [`span_since`](InputRef::span_since) build a span out of `cursor()` at both ends, which is
+//! right for a lexer that has no trivia to skip and wrong for one that does. A production that
+//! peeks past its own last token to decide whether an optional tail follows closes its span at
+//! **the next token's start**, so the span swallows the whitespace in between; a production
+//! entered with a cold cache opens its span at **the previous token's end**, so it swallows the
+//! whitespace in front. On compact input the two rules coincide, which is why a corpus of tightly
+//! written source cannot tell them apart.
+//!
+//! This module is the other rule. A node's span runs from the start of its **first** token to the
+//! end of its **last committed** token, and no ignorable byte on either side belongs to it.
+//!
+//! # The three entry points
+//!
+//! [`extent_start`] opens a node, [`extent_end`] closes one, and [`extent_since`] pairs them.
+//! [`TokenSpannedExt::token_spanned`] is the combinator form and is the drop-in replacement for
+//! `.spanned()` — the same `Spanned<O, L::Span>` output, measured the other way.
+//!
+//! # The peek in `extent_start`
+//!
+//! Opening a node needs the first token's *start*, and the only way to learn it is to look at the
+//! token. So [`extent_start`] peeks one token, which is what makes `cursor()` report a token start
+//! rather than the previous token's end. The peek is not extra lexing: a peeked token lands in the
+//! cache and the production that follows consumes it from there, and every dispatching production
+//! in both dialects already peeks its own head before this runs. What it does add is an *earlier*
+//! observation point for a lexer error on that first token — the error a production entered on
+//! unlexable bytes would have raised a moment later anyway.
+//!
+//! # The empty node
+//!
+//! A parser that succeeds without consuming a token leaves `extent_end` behind `extent_start`.
+//! [`extent_since`] answers with an empty span at the start rather than an inverted one — which is
+//! also what [`SimpleSpan::new`](tokora::SimpleSpan) would panic on. No production in either
+//! dialect is in that state today; the clamp is there so that a future one degrades to a point
+//! rather than to an abort.
+
+use core::marker::PhantomData;
+
+use tokora::{
+  Complete, Completeness, InputRef, Lexer, ParseContext, ParseInput,
+  cache::PeekedTokenExt,
+  span::{Span, Spanned},
+  utils::typenum::U1,
+};
+
+use super::{ErrorOf, ParseCtx};
+
+/// The offset the node about to be parsed **begins** at: the start of the next token.
+///
+/// At end of input there is no next token, and the answer is the current offset — an anchor for
+/// the empty span a production that parses nothing there would carry.
+///
+/// See the module docs for why this peeks and what the peek does and does not cost.
+#[inline]
+pub fn extent_start<'inp, L, Ctx, Lang, Cmpl>(
+  inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+) -> Result<L::Offset, ErrorOf<'inp, L, Ctx, Lang>>
+where
+  L: Lexer<'inp>,
+  Ctx: ParseCtx<'inp, L, Lang>,
+  Lang: ?Sized,
+  Cmpl: Completeness,
+{
+  let head = {
+    let mut peeked = inp.peek::<U1>()?;
+    peeked.pop_front().map(|token| token.span().start())
+  };
+  Ok(match head {
+    Some(start) => start,
+    None => inp.offset().clone(),
+  })
+}
+
+/// The offset the node just parsed **ends** at: the end of the last committed token.
+///
+/// This is tokora's committed-progress reading, deliberately not
+/// [`cursor()`](InputRef::cursor) — see the module docs.
+#[inline]
+pub fn extent_end<'inp, L, Ctx, Lang, Cmpl>(
+  inp: &InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+) -> L::Offset
+where
+  L: Lexer<'inp>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Lang: ?Sized,
+  Cmpl: Completeness,
+{
+  inp.span().end()
+}
+
+/// The token extent of everything parsed since `start`, as a span.
+///
+/// `start` comes from [`extent_start`] and the end from [`extent_end`]. A parser that consumed
+/// nothing yields the empty span at `start`; see the module docs.
+#[inline]
+pub fn extent_since<'inp, L, Ctx, Lang, Cmpl>(
+  inp: &InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  start: L::Offset,
+) -> L::Span
+where
+  L: Lexer<'inp>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  Lang: ?Sized,
+  Cmpl: Completeness,
+{
+  let end = extent_end(inp);
+  let end = if end < start { start.clone() } else { end };
+  L::Span::new(start, end)
+}
+
+/// A parser wrapped so its output carries the **token extent** of what it consumed.
+///
+/// Built by [`TokenSpannedExt::token_spanned`]; the `.spanned()` shape with the other span rule.
+pub struct TokenSpanned<P, Cmpl = Complete> {
+  parser: P,
+  _cmpl: PhantomData<Cmpl>,
+}
+
+impl<P, Cmpl> TokenSpanned<P, Cmpl> {
+  /// Wraps `parser`.
+  #[inline(always)]
+  pub const fn new(parser: P) -> Self {
+    Self {
+      parser,
+      _cmpl: PhantomData,
+    }
+  }
+}
+
+impl<'inp, L, O, Ctx, P, Lang, Cmpl> ParseInput<'inp, L, Spanned<O, L::Span>, Ctx, Lang, Cmpl>
+  for TokenSpanned<P, Cmpl>
+where
+  P: ParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  L: Lexer<'inp>,
+  Ctx: ParseCtx<'inp, L, Lang>,
+  Lang: ?Sized,
+  Cmpl: Completeness,
+{
+  #[inline(always)]
+  fn parse_input(
+    &mut self,
+    inp: &mut InputRef<'inp, '_, L, Ctx, Lang, Cmpl>,
+  ) -> Result<Spanned<O, L::Span>, ErrorOf<'inp, L, Ctx, Lang>> {
+    let start = extent_start(inp)?;
+    let data = self.parser.parse_input(inp)?;
+    Ok(Spanned::new(extent_since(inp, start), data))
+  }
+}
+
+/// The `.token_spanned()` method, on every parser.
+///
+/// Deliberately a separate trait rather than a wider `ParseInput`: tokora owns that trait, and a
+/// dialect's span rule is not tokora's to choose.
+pub trait TokenSpannedExt<'inp, L, O, Ctx, Lang, Cmpl>:
+  ParseInput<'inp, L, O, Ctx, Lang, Cmpl> + Sized
+where
+  L: Lexer<'inp>,
+  Ctx: ParseCtx<'inp, L, Lang>,
+  Lang: ?Sized,
+  Cmpl: Completeness,
+{
+  /// Wraps this parser's output in a [`Spanned`] carrying the **token extent** it consumed.
+  ///
+  /// The replacement for tokora's [`spanned()`](tokora::ParseInput::spanned) in dialect
+  /// productions: same output type, span measured from the first token's start to the last
+  /// committed token's end instead of from lookahead position to lookahead position.
+  #[inline(always)]
+  fn token_spanned(self) -> TokenSpanned<Self, Cmpl> {
+    TokenSpanned::new(self)
+  }
+}
+
+impl<'inp, L, O, Ctx, P, Lang, Cmpl> TokenSpannedExt<'inp, L, O, Ctx, Lang, Cmpl> for P
+where
+  P: ParseInput<'inp, L, O, Ctx, Lang, Cmpl>,
+  L: Lexer<'inp>,
+  Ctx: ParseCtx<'inp, L, Lang>,
+  Lang: ?Sized,
+  Cmpl: Completeness,
+{
+}

--- a/smear-parser/src/combinator/mod.rs
+++ b/smear-parser/src/combinator/mod.rs
@@ -29,9 +29,17 @@
 //! cross-flavor comparison trait, so a dispatch can byte-compare a source slice
 //! against a spelling (`slice.equivalent("true")`) without an `AsRef<[u8]>`
 //! detour that pins the source representation.
+//!
+//! The **span-extent** vocabulary — [`extent_start`], [`extent_end`], [`extent_since`] and
+//! [`token_spanned`](TokenSpannedExt::token_spanned) — is the one place this layer does *not* take
+//! tokora's answer as given. A composite node's span is a fact about the tokens it contains, and
+//! tokora's `.spanned()` measures the lookahead position instead; the difference, and why it is
+//! invisible on compact input, is on [`extent_start`].
 
+mod extent;
 mod token;
 
+pub use extent::*;
 pub use token::*;
 pub use tokora::{
   ComposableEmitter, ComposableParseContext as ParseCtx, ErrorOf, SliceOf, utils::cmp::Equivalent,

--- a/smear-parser/src/graphql/syntactic/argument/mod.rs
+++ b/smear-parser/src/graphql/syntactic/argument/mod.rs
@@ -24,7 +24,7 @@ use super::{
   value::{HeadKind, const_value, value, value_head_kind},
 };
 use crate::{
-  combinator::{ParseCtx, colon},
+  combinator::{ParseCtx, TokenSpannedExt, colon, extent_end},
   graphql::{
     GraphQL,
     ast::{Argument, ArgumentList, Arguments, ConstArgument, ConstArguments},
@@ -116,7 +116,7 @@ argument_parser!(
         })?;
         value(inp)
       })
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data: (name, value) }| Argument::new(span, name, value))
       .parse_input(inp)
   }
@@ -151,7 +151,7 @@ argument_parser!(
         })?;
         const_value(inp)
       })
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data: (name, value) }| ConstArgument::new(span, name, value))
       .parse_input(inp)
   }
@@ -201,7 +201,7 @@ argument_parser!(
       .repeated_while::<_, U1>(decide_argument_head::<Src, Ctx>)
       .delimited_by_parens()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| ArgumentList::new(span, data))
   }
@@ -216,7 +216,7 @@ argument_parser!(
       .repeated_while::<_, U1>(decide_argument_head::<Src, Ctx>)
       .delimited_by_parens()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| ArgumentList::new(span, data))
   }
@@ -234,7 +234,10 @@ argument_parser!(
   inp,
   Arguments<GraphqlSlice<'inp, Src>>,
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     committed_arguments
       .peek_then_try::<_, U1>(decide_arguments_head::<Src, Ctx>)
       .try_parse_input(inp)
@@ -258,7 +261,10 @@ argument_parser!(
   inp,
   ConstArguments<GraphqlSlice<'inp, Src>>,
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     committed_const_arguments
       .peek_then_try::<_, U1>(decide_arguments_head::<Src, Ctx>)
       .try_parse_input(inp)

--- a/smear-parser/src/graphql/syntactic/definition/arguments.rs
+++ b/smear-parser/src/graphql/syntactic/definition/arguments.rs
@@ -51,7 +51,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_parens()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| ArgumentsDefinition::new(span, data))
   }

--- a/smear-parser/src/graphql/syntactic/definition/directive.rs
+++ b/smear-parser/src/graphql/syntactic/definition/directive.rs
@@ -150,7 +150,7 @@ definition_parser!(
       .allow_leading()
       .at_least(1)
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)?;
     Ok(DirectiveLocations::new(span, locations))
   }

--- a/smear-parser/src/graphql/syntactic/definition/document.rs
+++ b/smear-parser/src/graphql/syntactic/definition/document.rs
@@ -118,11 +118,11 @@ definition_parser!(
   Described<TypeSystemDefinition<GraphqlSlice<'inp, Src>>, GraphqlSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let definition = type_system_definition(inp)?;
     Ok(Described::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))
@@ -308,7 +308,7 @@ definition_parser!(
       .map(
         |definitions: Vec<TypeSystemDefinitionOrExtension<GraphqlSlice<'inp, Src>>>| definitions,
       )
-      .spanned()
+      .token_spanned()
       .parse_input(inp)?;
     Ok(TypeSystemDocument::new(span, definitions))
   }

--- a/smear-parser/src/graphql/syntactic/definition/enum_type.rs
+++ b/smear-parser/src/graphql/syntactic/definition/enum_type.rs
@@ -45,11 +45,11 @@ definition_parser!(
   EnumValueDefinition<GraphqlSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let value = take_enum_value(inp)?;
     let directives = optional_const_directives(inp)?;
-    let span = inp.span_since(&cursor);
+    let span = extent_since(inp, node_start);
     Ok(Described::new(
       span,
       description,
@@ -72,7 +72,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| EnumValuesDefinition::new(span, data))
   }
@@ -104,7 +104,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlLexer<'inp, Src>, GraphQL>,
   GraphqlError<'inp, Src, Ctx>: From<DialectGraphqlError<GraphqlSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = take_name(inp)?;
   let directives = optional_const_directives(inp)?;
   let enum_values_definition = match try_enum_values_definition(inp)? {
@@ -112,7 +111,7 @@ where
     ParseAttempt::Decline => None,
   };
   Ok(EnumTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
     enum_values_definition,

--- a/smear-parser/src/graphql/syntactic/definition/field.rs
+++ b/smear-parser/src/graphql/syntactic/definition/field.rs
@@ -11,14 +11,14 @@ definition_parser!(
   FieldDefinition<GraphqlSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let name = take_name(inp)?;
     let arguments_definition = try_arguments_definition(inp)?.into();
     take_colon(inp)?;
     let ty = take_type(inp)?;
     let directives = optional_const_directives(inp)?;
-    let span = inp.span_since(&cursor);
+    let span = extent_since(inp, node_start);
     Ok(Described::new(
       span,
       description,
@@ -41,7 +41,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| FieldsDefinition::new(span, data))
   }

--- a/smear-parser/src/graphql/syntactic/definition/input_object.rs
+++ b/smear-parser/src/graphql/syntactic/definition/input_object.rs
@@ -16,7 +16,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| InputFieldsDefinition::new(span, data))
   }
@@ -48,7 +48,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlLexer<'inp, Src>, GraphQL>,
   GraphqlError<'inp, Src, Ctx>: From<DialectGraphqlError<GraphqlSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = take_name(inp)?;
   let directives = optional_const_directives(inp)?;
   let fields_definition = match try_input_fields_definition(inp)? {
@@ -56,7 +55,7 @@ where
     ParseAttempt::Decline => None,
   };
   Ok(InputObjectTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
     fields_definition,

--- a/smear-parser/src/graphql/syntactic/definition/input_value.rs
+++ b/smear-parser/src/graphql/syntactic/definition/input_value.rs
@@ -11,14 +11,14 @@ definition_parser!(
   InputValueDefinition<GraphqlSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let name = take_name(inp)?;
     take_colon(inp)?;
     let ty = take_type(inp)?;
     let default_value = default_value(inp)?;
     let directives = optional_const_directives(inp)?;
-    let span = inp.span_since(&cursor);
+    let span = extent_since(inp, node_start);
     Ok(Described::new(
       span,
       description,

--- a/smear-parser/src/graphql/syntactic/definition/interface.rs
+++ b/smear-parser/src/graphql/syntactic/definition/interface.rs
@@ -15,7 +15,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlLexer<'inp, Src>, GraphQL>,
   GraphqlError<'inp, Src, Ctx>: From<DialectGraphqlError<GraphqlSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = take_name(inp)?;
   let implements = match try_implements(inp)? {
     ParseAttempt::Accept(implements) => Some(implements),
@@ -27,7 +26,7 @@ where
     ParseAttempt::Decline => None,
   };
   Ok(InterfaceTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     implements,
     directives,

--- a/smear-parser/src/graphql/syntactic/definition/mod.rs
+++ b/smear-parser/src/graphql/syntactic/definition/mod.rs
@@ -25,7 +25,9 @@ use super::{
   value::default_value,
 };
 use crate::{
-  combinator::{ParseCtx, at, colon, equal, try_equal},
+  combinator::{
+    ParseCtx, TokenSpannedExt, at, colon, equal, extent_end, extent_since, extent_start, try_equal,
+  },
   graphql::{
     GraphQL,
     ast::{

--- a/smear-parser/src/graphql/syntactic/definition/object.rs
+++ b/smear-parser/src/graphql/syntactic/definition/object.rs
@@ -15,7 +15,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlLexer<'inp, Src>, GraphQL>,
   GraphqlError<'inp, Src, Ctx>: From<DialectGraphqlError<GraphqlSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = take_name(inp)?;
   let implements = match try_implements(inp)? {
     ParseAttempt::Accept(implements) => Some(implements),
@@ -27,7 +26,7 @@ where
     ParseAttempt::Decline => None,
   };
   Ok(ObjectTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     implements,
     directives,

--- a/smear-parser/src/graphql/syntactic/definition/scalar.rs
+++ b/smear-parser/src/graphql/syntactic/definition/scalar.rs
@@ -15,11 +15,10 @@ where
   Ctx: ParseCtx<'inp, GraphqlLexer<'inp, Src>, GraphQL>,
   GraphqlError<'inp, Src, Ctx>: From<DialectGraphqlError<GraphqlSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = take_name(inp)?;
   let directives = optional_const_directives(inp)?;
   Ok(ScalarTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
   ))

--- a/smear-parser/src/graphql/syntactic/definition/schema.rs
+++ b/smear-parser/src/graphql/syntactic/definition/schema.rs
@@ -11,12 +11,12 @@ definition_parser!(
   RootOperationTypeDefinition<GraphqlSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let operation_type = operation_type(inp)?;
     take_colon(inp)?;
     let name = take_name(inp)?;
     Ok(RootOperationTypeDefinition::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       operation_type,
       name,
     ))
@@ -37,7 +37,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| RootOperationTypesDefinition::new(span, data))
   }

--- a/smear-parser/src/graphql/syntactic/definition/type_definition.rs
+++ b/smear-parser/src/graphql/syntactic/definition/type_definition.rs
@@ -103,11 +103,11 @@ definition_parser!(
   Described<TypeDefinition<GraphqlSlice<'inp, Src>>, GraphqlSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let definition = type_definition(inp)?;
     Ok(Described::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))

--- a/smear-parser/src/graphql/syntactic/definition/union.rs
+++ b/smear-parser/src/graphql/syntactic/definition/union.rs
@@ -1,7 +1,7 @@
 //! SDL union type-definition parsing.
 
 use super::*;
-use crate::combinator::{pipe, try_pipe};
+use crate::combinator::{extent_end, pipe, try_pipe};
 
 fn take_equal<'inp, Src, Ctx>(
   inp: &mut GraphqlInput<'inp, '_, Src, Ctx>,
@@ -90,7 +90,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlLexer<'inp, Src>, GraphQL>,
   GraphqlError<'inp, Src, Ctx>: From<DialectGraphqlError<GraphqlSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = take_name(inp)?;
   let directives = optional_const_directives(inp)?;
   let member_types = match try_union_members(inp)? {
@@ -98,7 +97,7 @@ where
     ParseAttempt::Decline => None,
   };
   Ok(UnionTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
     member_types,

--- a/smear-parser/src/graphql/syntactic/directive/mod.rs
+++ b/smear-parser/src/graphql/syntactic/directive/mod.rs
@@ -23,7 +23,7 @@ use super::{
   try_name,
 };
 use crate::{
-  combinator::{ParseCtx, try_at},
+  combinator::{ParseCtx, extent_end, try_at},
   graphql::{
     GraphQL,
     ast::{ConstDirective, ConstDirectives, Directive, Directives, Name},
@@ -277,7 +277,10 @@ directive_parser!(
   inp,
   Directives<GraphqlSlice<'inp, Src>>,
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     match try_at(inp)? {
       ParseAttempt::Accept(at) => directives_after_at(inp, at),
       ParseAttempt::Decline => Ok(Directives::new(SimpleSpan::new(start, start), Vec::new())),
@@ -297,7 +300,10 @@ directive_parser!(
   inp,
   ConstDirectives<GraphqlSlice<'inp, Src>>,
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     match try_at(inp)? {
       ParseAttempt::Accept(at) => const_directives_after_at(inp, at),
       ParseAttempt::Decline => Ok(ConstDirectives::new(

--- a/smear-parser/src/graphql/syntactic/document.rs
+++ b/smear-parser/src/graphql/syntactic/document.rs
@@ -31,7 +31,7 @@ use super::{
   selection::selection_set,
 };
 use crate::{
-  combinator::ParseCtx,
+  combinator::{ParseCtx, TokenSpannedExt, extent_since, extent_start},
   graphql::{
     GraphQL,
     ast::{
@@ -253,14 +253,14 @@ document_parser!(
   inp,
   DescribedDefinition<GraphqlSlice<'inp, Src>>,
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = match StringValue::try_graphql(inp)? {
       ParseAttempt::Accept(value) => Some(value),
       ParseAttempt::Decline => None,
     };
     let definition = definition(inp)?;
     Ok(Described::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))
@@ -407,7 +407,7 @@ document_parser!(
       .at_least(1)
       .collect_with(Vec::new())
       .map(|definitions: Vec<DefinitionOrExtension<GraphqlSlice<'inp, Src>>>| definitions)
-      .spanned()
+      .token_spanned()
       .parse_input(inp)?;
     Ok(Document::new(span, definitions))
   }

--- a/smear-parser/src/graphql/syntactic/executable/mod.rs
+++ b/smear-parser/src/graphql/syntactic/executable/mod.rs
@@ -33,7 +33,7 @@ use super::{
   value::default_value,
 };
 use crate::{
-  combinator::ParseCtx,
+  combinator::{ParseCtx, TokenSpannedExt, extent_end, extent_since, extent_start},
   graphql::{
     GraphQL,
     ast::{
@@ -374,10 +374,10 @@ where
   Ctx: ParseCtx<'inp, GraphqlLexer<'inp, Src>, GraphQL>,
   GraphqlError<'inp, Src, Ctx>: From<DialectGraphqlError<GraphqlSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
+  let node_start = extent_start(inp)?;
   take_dollar(inp)?;
   let name = take_name(inp)?;
-  let variable = VariableValue::new(inp.span_since(&cursor), name);
+  let variable = VariableValue::new(extent_since(inp, node_start), name);
   take_colon(inp)?;
   guard_executable_phase(inp, Expectation::Type, |token| {
     token.is_identifier() || token.is_l_bracket()
@@ -391,7 +391,7 @@ where
     Some(directives)
   };
   Ok(VariableDefinition::new(
-    inp.span_since(&cursor),
+    extent_since(inp, node_start),
     variable,
     ty,
     default_value,
@@ -412,14 +412,14 @@ executable_parser!(
   DescribedVariableDefinition<GraphqlSlice<'inp, Src>>,
   [GraphqlToken<'inp, Src>: DowncastRef<ContextualKeyword>,],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = match StringValue::try_graphql(inp)? {
       ParseAttempt::Accept(value) => Some(value),
       ParseAttempt::Decline => None,
     };
     let definition = variable_definition_core(inp)?;
     Ok(DescribedVariableDefinition::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))
@@ -470,7 +470,10 @@ executable_parser!(
   VariablesDefinition<GraphqlSlice<'inp, Src>>,
   [GraphqlToken<'inp, Src>: DowncastRef<ContextualKeyword>,],
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     if !peeks_where(inp, |token| token.is_l_paren())? {
       return Ok(VariablesDefinition::new(
         SimpleSpan::new(start, start),
@@ -478,7 +481,11 @@ executable_parser!(
       ));
     }
 
-    parens(|inp: &mut GraphqlInput<'inp, '_, Src, Ctx>| {
+    // Not the `Delimited`'s own span: tokora builds that one from the lookahead cursor at both
+    // ends, so it opens before the `(`'s leading trivia and closes wherever the peek past `)`
+    // landed. See `crate::combinator::extent`.
+    let node_start = extent_start(inp)?;
+    let delimited = parens(|inp: &mut GraphqlInput<'inp, '_, Src, Ctx>| {
       guard_executable_phase(
         inp,
         Expectation::VariableDefinition,
@@ -491,11 +498,12 @@ executable_parser!(
         .parse_input(inp)?;
       rest.insert(0, first);
       Ok(rest)
-    })(inp)
-    .map(|delimited| {
-      let (span, _open, _close, definitions) = delimited.into_components();
-      VariablesDefinition::new(span, definitions)
-    })
+    })(inp)?;
+    let (_, _open, _close, definitions) = delimited.into_components();
+    Ok(VariablesDefinition::new(
+      extent_since(inp, node_start),
+      definitions,
+    ))
   }
 );
 
@@ -594,7 +602,9 @@ executable_parser!(
   OperationDefinition<GraphqlSlice<'inp, Src>>,
   [GraphqlToken<'inp, Src>: DowncastRef<ContextualKeyword>,],
   {
-    let start = *inp.offset();
+    // A real node start, so the **first token's** start: `inp.offset()` would report the end of a
+    // token the caller had already peeked. See `crate::combinator::extent`.
+    let start = extent_start(inp)?;
     let classified = classify_executable_head(inp)?;
     let found = classified.found();
     let mut named_head = None;
@@ -688,7 +698,7 @@ executable_parser!(
   DescribedExecutableDefinition<GraphqlSlice<'inp, Src>>,
   [GraphqlToken<'inp, Src>: DowncastRef<ContextualKeyword>,],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = match StringValue::try_graphql(inp)? {
       ParseAttempt::Accept(value) => Some(value),
       ParseAttempt::Decline => None,
@@ -733,7 +743,7 @@ executable_parser!(
     );
     let definition = tails.parse_choice(inp, &branch)?;
     Ok(DescribedExecutableDefinition::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))
@@ -779,7 +789,7 @@ executable_parser!(
       .at_least(1)
       .collect_with(Vec::new())
       .map(|definitions: Vec<DescribedExecutableDefinition<GraphqlSlice<'inp, Src>>>| definitions)
-      .spanned()
+      .token_spanned()
       .parse_input(inp)?;
     Ok(ExecutableDocument::new(span, definitions))
   }

--- a/smear-parser/src/graphql/syntactic/selection/mod.rs
+++ b/smear-parser/src/graphql/syntactic/selection/mod.rs
@@ -27,7 +27,7 @@ use super::{
   directive::directives, fragment_name, try_name,
 };
 use crate::{
-  combinator::{ParseCtx, try_colon, try_spread},
+  combinator::{ParseCtx, TokenSpannedExt, try_colon, try_spread},
   graphql::{
     GraphQL,
     ast::{
@@ -559,7 +559,7 @@ selection_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| SelectionSet::new(span, data))
   }

--- a/smear-parser/src/graphql/syntactic/ty/mod.rs
+++ b/smear-parser/src/graphql/syntactic/ty/mod.rs
@@ -17,7 +17,7 @@ use tokora::{
 
 use super::{GraphqlError, GraphqlInput, GraphqlLexer, GraphqlSlice, GraphqlToken};
 use crate::{
-  combinator::{ParseCtx, try_bang},
+  combinator::{ParseCtx, TokenSpannedExt, try_bang},
   graphql::{
     GraphQL,
     ast::{ListType, Name, NamedType, Type},
@@ -112,7 +112,7 @@ where
     }
   })
   .then(try_bang)
-  .spanned()
+  .token_spanned()
   .map(
     |Spanned {
        span,

--- a/smear-parser/src/graphql/syntactic/value/mod.rs
+++ b/smear-parser/src/graphql/syntactic/value/mod.rs
@@ -32,7 +32,7 @@ use smear_lexer::graphql::{ContextualKeyword, syntactic::SyntacticTokenKind};
 
 use super::{GraphqlError, GraphqlInput, GraphqlLexer, GraphqlSlice, GraphqlToken, name};
 use crate::{
-  combinator::{ParseCtx, colon, dollar, equal},
+  combinator::{ParseCtx, TokenSpannedExt, colon, dollar, equal},
   graphql::{
     GraphQL,
     ast::{
@@ -660,7 +660,7 @@ value_parser!(
       .repeated_while::<_, U1>(decide_value_head::<_, Ctx>)
       .delimited_by_brackets()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data: values }| AstList::new(span, values))
   }
@@ -676,7 +676,7 @@ value_parser!(
       .repeated_while::<_, U1>(decide_value_head::<_, Ctx>)
       .delimited_by_brackets()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data: values }| AstConstList::new(span, values))
   }
@@ -715,7 +715,7 @@ value_parser!(
         )?;
         value(inp)
       })
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data: (name, value) }| ObjectField::new(span, name, value))
       .parse_input(inp)
   }
@@ -754,7 +754,7 @@ value_parser!(
         )?;
         const_value(inp)
       })
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data: (name, value) }| ConstObjectField::new(span, name, value))
       .parse_input(inp)
   }
@@ -770,7 +770,7 @@ value_parser!(
       .repeated_while::<_, U1>(decide_object_field_head::<_, Ctx>)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data: fields }| AstObject::new(span, fields))
   }
@@ -786,7 +786,7 @@ value_parser!(
       .repeated_while::<_, U1>(decide_object_field_head::<_, Ctx>)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data: fields }| AstConstObject::new(span, fields))
   }
@@ -1049,7 +1049,7 @@ value_parser!(
 
     equal
       .ignore_then(validated_const_tail)
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data: value }| DefaultInputValue::new(span, value))
       .parse_input(inp)
   }

--- a/smear-parser/src/graphqlx/syntactic/argument/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/argument/mod.rs
@@ -27,7 +27,7 @@ use super::{
   value::{const_value, value},
 };
 use crate::{
-  combinator::{ParseCtx, try_colon},
+  combinator::{ParseCtx, TokenSpannedExt, extent_end, extent_since, extent_start, try_colon},
   graphqlx::{
     GraphQLx,
     ast::{Argument, Arguments, ConstArgument, ConstArguments, Name},
@@ -111,7 +111,7 @@ argument_parser!(
     take_argument_name
       .then_ignore(take_argument_colon)
       .then(value)
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data: (name, value) }| Argument::new(span, name, value))
       .parse_input(inp)
   }
@@ -131,7 +131,7 @@ argument_parser!(
     take_argument_name
       .then_ignore(take_argument_colon)
       .then(const_value)
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data: (name, value) }| ConstArgument::new(span, name, value))
       .parse_input(inp)
   }
@@ -170,19 +170,26 @@ argument_parser!(
   inp,
   Arguments<GraphqlxSlice<'inp, Src>>;
   {
-    let start = *inp.offset();
-    try_parens::<_, _, _, _, Vec<Argument<GraphqlxSlice<'inp, Src>>>, _>(
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
+    // Not the `Delimited`'s own span: tokora builds that one from the lookahead cursor at both
+    // ends, so it opens before the `(`'s leading trivia and closes wherever the peek past `)`
+    // landed. See `crate::combinator::extent`.
+    let node_start = extent_start(inp)?;
+    let parsed = try_parens::<_, _, _, _, Vec<Argument<GraphqlxSlice<'inp, Src>>>, _>(
       (|inp: &mut GraphqlxInput<'inp, '_, Src, Ctx>| argument(inp))
         .repeated_while::<_, U1>(decide_argument_head::<Src, Ctx>)
         .collect_with(Vec::new()),
-    )(inp)
-      .map(|arguments| match arguments {
-        Some(arguments) => {
-          let (span, _, _, arguments) = arguments.into_components();
-          Arguments::new(span, arguments)
-        }
-        None => Arguments::new(SimpleSpan::new(start, start), Vec::new()),
-      })
+    )(inp)?;
+    Ok(match parsed {
+      Some(arguments) => {
+        let (_, _, _, arguments) = arguments.into_components();
+        Arguments::new(extent_since(inp, node_start), arguments)
+      }
+      None => Arguments::new(SimpleSpan::new(start, start), Vec::new()),
+    })
   }
 );
 
@@ -201,19 +208,24 @@ argument_parser!(
   inp,
   ConstArguments<GraphqlxSlice<'inp, Src>>;
   {
-    let start = *inp.offset();
-    try_parens::<_, _, _, _, Vec<ConstArgument<GraphqlxSlice<'inp, Src>>>, _>(
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
+    // Not the `Delimited`'s own span — see `arguments` above and `crate::combinator::extent`.
+    let node_start = extent_start(inp)?;
+    let parsed = try_parens::<_, _, _, _, Vec<ConstArgument<GraphqlxSlice<'inp, Src>>>, _>(
       (|inp: &mut GraphqlxInput<'inp, '_, Src, Ctx>| const_argument(inp))
         .repeated_while::<_, U1>(decide_argument_head::<Src, Ctx>)
         .collect_with(Vec::new()),
-    )(inp)
-      .map(|arguments| match arguments {
-        Some(arguments) => {
-          let (span, _, _, arguments) = arguments.into_components();
-          ConstArguments::new(span, arguments)
-        }
-        None => ConstArguments::new(SimpleSpan::new(start, start), Vec::new()),
-      })
+    )(inp)?;
+    Ok(match parsed {
+      Some(arguments) => {
+        let (_, _, _, arguments) = arguments.into_components();
+        ConstArguments::new(extent_since(inp, node_start), arguments)
+      }
+      None => ConstArguments::new(SimpleSpan::new(start, start), Vec::new()),
+    })
   }
 );
 

--- a/smear-parser/src/graphqlx/syntactic/definition/arguments.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/arguments.rs
@@ -51,7 +51,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_parens()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| ArgumentsDefinition::new(span, data))
   }

--- a/smear-parser/src/graphqlx/syntactic/definition/document.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/document.rs
@@ -121,7 +121,7 @@ definition_parser!(
   {
     description
       .then(type_system_definition)
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned {
         span,
@@ -348,7 +348,7 @@ definition_parser!(
       .map(
         |entries: Vec<ImportOrTypeSystemDefinitionOrExtension<GraphqlxSlice<'inp, Src>>>| entries,
       )
-      .spanned()
+      .token_spanned()
       .parse_input(inp)?;
     Ok(TypeSystemDocument::new(span, entries))
   }

--- a/smear-parser/src/graphqlx/syntactic/definition/enum_type.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/enum_type.rs
@@ -43,11 +43,11 @@ definition_parser!(
   EnumValueDefinition<GraphqlxSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let value = take_enum_value(inp)?;
     let directives = optional_const_directives(inp)?;
-    let span = inp.span_since(&cursor);
+    let span = extent_since(inp, node_start);
     Ok(Described::new(
       span,
       description,
@@ -70,7 +70,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| EnumValuesDefinition::new(span, data))
   }
@@ -104,13 +104,12 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = definition_name(inp)?;
   let directives = optional_const_directives(inp)?;
   let enum_values_definition: Option<EnumValuesDefinition<GraphqlxSlice<'inp, Src>>> =
     try_enum_values_definition(inp)?.into();
   Ok(EnumTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
     enum_values_definition,

--- a/smear-parser/src/graphqlx/syntactic/definition/field.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/field.rs
@@ -13,7 +13,7 @@ definition_parser!(
   FieldDefinition<GraphqlxSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let name = take_name(inp)?;
     let arguments_definition: Option<ArgumentsDefinition<GraphqlxSlice<'inp, Src>>> =
@@ -21,7 +21,7 @@ definition_parser!(
     take_colon(inp)?;
     let ty = take_type(inp)?;
     let directives = optional_const_directives(inp)?;
-    let span = inp.span_since(&cursor);
+    let span = extent_since(inp, node_start);
     Ok(Described::new(
       span,
       description,
@@ -44,7 +44,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| FieldsDefinition::new(span, data))
   }

--- a/smear-parser/src/graphqlx/syntactic/definition/input_object.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/input_object.rs
@@ -16,7 +16,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| InputFieldsDefinition::new(span, data))
   }
@@ -50,7 +50,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = definition_name(inp)?;
   let directives = optional_const_directives(inp)?;
   let where_clause = match try_where_clause(inp)? {
@@ -73,7 +72,7 @@ where
     (None, ParseAttempt::Decline) => None,
   };
   Ok(InputObjectTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
     fields_definition,

--- a/smear-parser/src/graphqlx/syntactic/definition/input_value.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/input_value.rs
@@ -14,14 +14,14 @@ definition_parser!(
   InputValueDefinition<GraphqlxSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let name = take_name(inp)?;
     take_colon(inp)?;
     let ty = take_type(inp)?;
     let default_value = default_value(inp)?;
     let directives = optional_const_directives(inp)?;
-    let span = inp.span_since(&cursor);
+    let span = extent_since(inp, node_start);
     Ok(Described::new(
       span,
       description,

--- a/smear-parser/src/graphqlx/syntactic/definition/interface.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/interface.rs
@@ -15,7 +15,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = definition_name(inp)?;
   let implements: Option<ImplementInterfaces<GraphqlxSlice<'inp, Src>>> =
     try_implements(inp)?.into();
@@ -40,7 +39,7 @@ where
     (None, ParseAttempt::Decline) => None,
   };
   Ok(InterfaceTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     implements,
     directives,

--- a/smear-parser/src/graphqlx/syntactic/definition/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/mod.rs
@@ -27,7 +27,9 @@ use super::{
   value::default_value,
 };
 use crate::{
-  combinator::{ParseCtx, try_at, try_colon, try_equal},
+  combinator::{
+    ParseCtx, TokenSpannedExt, extent_end, extent_since, extent_start, try_at, try_colon, try_equal,
+  },
   graphqlx::{
     GraphQLx,
     ast::{

--- a/smear-parser/src/graphqlx/syntactic/definition/object.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/object.rs
@@ -15,7 +15,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = definition_name(inp)?;
   let implements: Option<ImplementInterfaces<GraphqlxSlice<'inp, Src>>> =
     try_implements(inp)?.into();
@@ -40,7 +39,7 @@ where
     (None, ParseAttempt::Decline) => None,
   };
   Ok(ObjectTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     implements,
     directives,

--- a/smear-parser/src/graphqlx/syntactic/definition/scalar.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/scalar.rs
@@ -15,11 +15,10 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = definition_name(inp)?;
   let directives = optional_const_directives(inp)?;
   Ok(ScalarTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
   ))

--- a/smear-parser/src/graphqlx/syntactic/definition/schema.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/schema.rs
@@ -48,12 +48,12 @@ definition_parser!(
   RootOperationTypeDefinition<GraphqlxSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let operation_type = operation_type(inp)?;
     take_colon(inp)?;
     let name = type_path(inp)?;
     Ok(RootOperationTypeDefinition::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       operation_type,
       name,
     ))
@@ -74,7 +74,7 @@ definition_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| RootOperationTypesDefinition::new(span, data))
   }

--- a/smear-parser/src/graphqlx/syntactic/definition/type_definition.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/type_definition.rs
@@ -99,11 +99,11 @@ definition_parser!(
   Described<TypeDefinition<GraphqlxSlice<'inp, Src>>, GraphqlxSlice<'inp, Src>>,
   [contextual],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = description(inp)?;
     let definition = type_definition(inp)?;
     Ok(Described::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))

--- a/smear-parser/src/graphqlx/syntactic/definition/union.rs
+++ b/smear-parser/src/graphqlx/syntactic/definition/union.rs
@@ -1,7 +1,7 @@
 //! GraphQLx union type definitions and member paths.
 
 use super::*;
-use crate::combinator::{pipe, try_pipe};
+use crate::combinator::{extent_end, pipe, try_pipe};
 
 fn union_members_after_equal<'inp, Src, Ctx>(
   inp: &mut GraphqlxInput<'inp, '_, Src, Ctx>,
@@ -80,7 +80,6 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let name = definition_name(inp)?;
   let directives = optional_const_directives(inp)?;
   let members = try_union_members(inp)?;
@@ -107,7 +106,7 @@ where
     (ParseAttempt::Decline, Some(_)) => unreachable!("a where clause requires union members"),
   };
   Ok(UnionTypeDefinition::new(
-    SimpleSpan::new(start, inp.span_since(&cursor).end()),
+    SimpleSpan::new(start, extent_end(inp)),
     name,
     directives,
     member_types,

--- a/smear-parser/src/graphqlx/syntactic/directive/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/directive/mod.rs
@@ -26,7 +26,7 @@ use super::{
   unexpected_here,
 };
 use crate::{
-  combinator::{ParseCtx, try_at, try_double_colon},
+  combinator::{ParseCtx, TokenSpannedExt, extent_end, extent_since, try_at, try_double_colon},
   graphqlx::{
     GraphQLx,
     ast::{ConstDirective, ConstDirectives, Directive, Directives, TypePath},
@@ -90,20 +90,21 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
   let separator = try_double_colon(inp)?;
   let fully_qualified = matches!(&separator, ParseAttempt::Accept(_));
   let first = match try_name(inp)? {
     ParseAttempt::Accept(name) => name,
     ParseAttempt::Decline => return unexpected_here(inp, Expectation::Path),
   };
+  // Already the first token's start — `::` when the path is fully qualified, the leading segment
+  // otherwise — so this is `extent_start` by another route and does not need to peek again.
   let start = match separator {
     ParseAttempt::Accept(separator) => separator.span().start(),
     ParseAttempt::Decline => first.span().start(),
   };
   let path = path_after_first(start, first, fully_qualified, inp)?;
   let generics = try_type_generics(inp)?;
-  Ok(TypePath::new(inp.span_since(&cursor), path, generics))
+  Ok(TypePath::new(extent_since(inp, start), path, generics))
 }
 
 fn directive_after_at<'inp, Src, Ctx>(
@@ -121,7 +122,7 @@ where
 {
   take_directive_type_path
     .then(arguments)
-    .spanned()
+    .token_spanned()
     .map(
       |Spanned {
          span,
@@ -152,7 +153,7 @@ where
 {
   take_directive_type_path
     .then(const_arguments)
-    .spanned()
+    .token_spanned()
     .map(
       |Spanned {
          span,
@@ -265,7 +266,10 @@ directive_parser!(
   inp,
   Directives<GraphqlxSlice<'inp, Src>>;
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     match try_at(inp)? {
       ParseAttempt::Accept(at) => directives_after_at(inp, at),
       ParseAttempt::Decline => Ok(Directives::new(SimpleSpan::new(start, start), Vec::new())),
@@ -285,7 +289,10 @@ directive_parser!(
   inp,
   ConstDirectives<GraphqlxSlice<'inp, Src>>;
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     match try_at(inp)? {
       ParseAttempt::Accept(at) => const_directives_after_at(inp, at),
       ParseAttempt::Decline => Ok(ConstDirectives::new(

--- a/smear-parser/src/graphqlx/syntactic/document.rs
+++ b/smear-parser/src/graphqlx/syntactic/document.rs
@@ -25,7 +25,7 @@ use super::{
   keyword_of, unexpected_here,
 };
 use crate::{
-  combinator::ParseCtx,
+  combinator::{ParseCtx, TokenSpannedExt},
   graphqlx::{
     GraphQLx,
     ast::{Definition, Described, Document, ImportOrDefinitionOrExtension, StringValue},
@@ -333,7 +333,7 @@ document_parser!(
       .at_least(1)
       .collect_with(Vec::new())
       .map(|entries: Vec<ImportOrDefinitionOrExtension<GraphqlxSlice<'inp, Src>>>| entries)
-      .spanned()
+      .token_spanned()
       .parse_input(inp)?;
     Ok(Document::new(span, entries))
   }

--- a/smear-parser/src/graphqlx/syntactic/executable/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/executable/mod.rs
@@ -34,7 +34,9 @@ use super::{
   value::default_value,
 };
 use crate::{
-  combinator::{ParseCtx, try_colon, try_dollar},
+  combinator::{
+    ParseCtx, TokenSpannedExt, extent_end, extent_since, extent_start, try_colon, try_dollar,
+  },
   graphqlx::{
     GraphQLx,
     ast::{
@@ -308,13 +310,13 @@ where
 {
   take_dollar
     .ignore_then(take_name)
-    .spanned()
+    .token_spanned()
     .map(|Spanned { span, data }| VariableValue::new(span, data))
     .then_ignore(take_colon)
     .then(ty)
     .then(default_value)
     .then(const_directives)
-    .spanned()
+    .token_spanned()
     .map(
       |Spanned {
          span,
@@ -339,14 +341,14 @@ executable_parser!(
   DescribedVariableDefinition<GraphqlxSlice<'inp, Src>>,
   [GraphqlxToken<'inp, Src>: DowncastRef<ContextualKeyword>,],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = match try_description(inp)? {
       ParseAttempt::Accept(description) => Some(description),
       ParseAttempt::Decline => None,
     };
     let definition = variable_definition_core(inp)?;
     Ok(DescribedVariableDefinition::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))
@@ -402,13 +404,16 @@ executable_parser!(
   VariablesDefinition<GraphqlxSlice<'inp, Src>>,
   [GraphqlxToken<'inp, Src>: DowncastRef<ContextualKeyword>,],
   {
-    let start = *inp.offset();
+    // The **committed** end, not `inp.offset()`: `offset()` reports the end of the newest *lexed*
+    // token, so a caller that left a peek in the cache would anchor this absent collection past
+    // the token that follows it. See `crate::combinator::extent`.
+    let start = extent_end(inp);
     let parsed = (|inp: &mut GraphqlxInput<'inp, '_, Src, Ctx>| variable_definition(inp))
       .repeated_while::<_, U1>(decide_variable_definition_tail::<Src, Ctx>)
       .at_least(1)
       .delimited_by_parens()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .peek_then_try::<_, U1>(decide_variables_definition_opener::<Src, Ctx>)
       .try_parse_input(inp)?;
     Ok(match parsed {
@@ -706,14 +711,14 @@ executable_parser!(
   DescribedExecutableDefinition<GraphqlxSlice<'inp, Src>>,
   [GraphqlxToken<'inp, Src>: DowncastRef<ContextualKeyword>,],
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let description = match try_description(inp)? {
       ParseAttempt::Accept(description) => Some(description),
       ParseAttempt::Decline => None,
     };
     let definition = executable_definition_core(inp)?;
     Ok(DescribedExecutableDefinition::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       description,
       definition,
     ))
@@ -803,7 +808,7 @@ executable_parser!(
       .map(
         |definitions: Vec<ImportOrExecutableDefinition<GraphqlxSlice<'inp, Src>>>| definitions,
       )
-      .spanned()
+      .token_spanned()
       .parse_input(inp)?;
     Ok(ExecutableDocument::new(span, definitions))
   }

--- a/smear-parser/src/graphqlx/syntactic/generic/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/generic/mod.rs
@@ -27,7 +27,9 @@ use super::{
   ty::try_type_generics, unexpected_here,
 };
 use crate::{
-  combinator::{ParseCtx, ampersand, colon, try_equal},
+  combinator::{
+    ParseCtx, TokenSpannedExt, ampersand, colon, extent_since, extent_start, try_equal,
+  },
   graphqlx::{
     GraphQLx,
     ast::{
@@ -237,14 +239,14 @@ generic_parser!(
   DefinitionTypeParam<GraphqlxSlice<'inp, Src>>,
   token_bounds = [];
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let name = take_name(inp)?;
     let default = match try_equal(inp)? {
       ParseAttempt::Accept(_) => Some(super::ty::ty(inp)?),
       ParseAttempt::Decline => None,
     };
     Ok(DefinitionTypeParam::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       name,
       default,
     ))
@@ -263,7 +265,7 @@ generic_parser!(
       .at_least(1)
       .delimited_by_angles()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| DefinitionTypeGenerics::new(span, data))
   }
@@ -293,7 +295,7 @@ generic_parser!(
       .at_least(1)
       .delimited_by_angles()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| ExtensionTypeGenerics::new(span, data))
   }
@@ -311,7 +313,7 @@ generic_parser!(
       .at_least(1)
       .delimited_by_angles()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| ExecutableDefinitionTypeGenerics::new(span, data))
   }
@@ -359,10 +361,10 @@ generic_parser!(
   ExtensionName<GraphqlxSlice<'inp, Src>>,
   token_bounds = [];
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let path = path(inp)?;
     let generics = try_extension_type_generics(inp)?;
-    Ok(ExtensionName::new(inp.span_since(&cursor), path, generics))
+    Ok(ExtensionName::new(extent_since(inp, node_start), path, generics))
   }
 );
 
@@ -373,11 +375,11 @@ generic_parser!(
   ExecutableDefinitionName<GraphqlxSlice<'inp, Src>>,
   token_bounds = [];
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let name = take_name(inp)?;
     let generics = try_executable_definition_type_generics(inp)?;
     Ok(ExecutableDefinitionName::new(
-      inp.span_since(&cursor),
+      extent_since(inp, node_start),
       name,
       generics,
     ))
@@ -391,10 +393,10 @@ generic_parser!(
   TypePath<GraphqlxSlice<'inp, Src>>,
   token_bounds = [];
   {
-    let cursor = *inp.cursor();
+    let node_start = extent_start(inp)?;
     let path = path(inp)?;
     let generics = try_type_generics(inp)?;
-    Ok(TypePath::new(inp.span_since(&cursor), path, generics))
+    Ok(TypePath::new(extent_since(inp, node_start), path, generics))
   }
 );
 

--- a/smear-parser/src/graphqlx/syntactic/import.rs
+++ b/smear-parser/src/graphqlx/syntactic/import.rs
@@ -22,7 +22,7 @@ use super::{
   unexpected_here,
 };
 use crate::{
-  combinator::{ParseCtx, asterisk},
+  combinator::{ParseCtx, TokenSpannedExt, asterisk},
   graphqlx::{
     GraphQLx,
     ast::{
@@ -262,7 +262,7 @@ import_parser!(
     .at_least(1)
     .delimited_by_braces()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| ImportList::new(span, data))
   }

--- a/smear-parser/src/graphqlx/syntactic/selection/mod.rs
+++ b/smear-parser/src/graphqlx/syntactic/selection/mod.rs
@@ -22,7 +22,7 @@ use super::{
   directive::directives, keyword_of, path_after_first, ty::try_type_generics, unexpected_here,
 };
 use crate::{
-  combinator::{ParseCtx, try_colon, try_spread},
+  combinator::{ParseCtx, TokenSpannedExt, try_colon, try_spread},
   graphqlx::{
     GraphQLx,
     ast::{
@@ -188,7 +188,7 @@ selection_parser!(
   {
     take_on
       .ignore_then(super::generic::type_path)
-      .spanned()
+      .token_spanned()
       .map(|Spanned { span, data }| TypeCondition::new(span, data))
       .parse_input(inp)
   }
@@ -630,7 +630,7 @@ selection_parser!(
       .at_least(1)
       .delimited_by_braces()
       .collect_with(Vec::new())
-      .spanned()
+      .token_spanned()
       .parse_input(inp)
       .map(|Spanned { span, data }| SelectionSet::new(span, data))
   }

--- a/smear-parser/src/graphqlx/syntactic/ty.rs
+++ b/smear-parser/src/graphqlx/syntactic/ty.rs
@@ -24,7 +24,7 @@ use super::{
   peek_kind, unexpected_here,
 };
 use crate::{
-  combinator::{ParseCtx, try_bang, try_fat_arrow},
+  combinator::{ParseCtx, TokenSpannedExt, extent_since, extent_start, try_bang, try_fat_arrow},
   graphqlx::{
     GraphQLx,
     ast::{DefinitionTypePath, Type, TypeGenerics},
@@ -87,7 +87,7 @@ where
     .at_least(1)
     .delimited_by_angles()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| TypeGenerics::new(span, data))
 }
@@ -210,7 +210,7 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
+  let node_start = extent_start(inp)?;
   let identifier_head =
     |Spanned { span, data: token }: Spanned<GraphqlxToken<'inp, Src>, SimpleSpan>,
      inp: &mut GraphqlxInput<'inp, '_, Src, Ctx>| match token {
@@ -246,7 +246,7 @@ where
     },
   };
   let required = matches!(try_bang(inp)?, ParseAttempt::Accept(_));
-  let span = inp.span_since(&cursor);
+  let span = extent_since(inp, node_start);
   Ok(match core {
     TypeCore::Path(path, generics) => {
       Type::Path(DefinitionTypePath::new(span, path, generics, required))

--- a/smear-parser/src/graphqlx/syntactic/value.rs
+++ b/smear-parser/src/graphqlx/syntactic/value.rs
@@ -27,7 +27,9 @@ use super::{
   path_after_first, unexpected_here,
 };
 use crate::{
-  combinator::{ParseCtx, colon, dollar, fat_arrow, try_equal},
+  combinator::{
+    ParseCtx, TokenSpannedExt, colon, dollar, extent_since, extent_start, fat_arrow, try_equal,
+  },
   graphqlx::{
     GraphQLx,
     ast::{
@@ -355,7 +357,7 @@ value_parser!(
           )
           .parse_input(inp)
       })
-      .spanned()
+      .token_spanned()
       .map(
         |Spanned {
            span,
@@ -488,7 +490,7 @@ value_parser!(
     .repeated_while::<_, U1>(decide_value_head::<_, Ctx>)
     .delimited_by_brackets()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| List::new(span, data))
   }
@@ -510,7 +512,7 @@ value_parser!(
     .repeated_while::<_, U1>(decide_const_value_head::<_, Ctx>)
     .delimited_by_brackets()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| ConstList::new(span, data))
   }
@@ -531,7 +533,7 @@ value_parser!(
   super::name
     .then_ignore(colon)
     .then(value)
-    .spanned()
+    .token_spanned()
     .map(|Spanned { span, data: (name, value) }| ObjectField::new(span, name, value))
     .parse_input(inp)
   }
@@ -552,7 +554,7 @@ value_parser!(
   super::name
     .then_ignore(colon)
     .then(const_value)
-    .spanned()
+    .token_spanned()
     .map(|Spanned { span, data: (name, value) }| ConstObjectField::new(span, name, value))
     .parse_input(inp)
   }
@@ -574,7 +576,7 @@ value_parser!(
     .repeated_while::<_, U1>(decide_brace_member::<_, Ctx>)
     .delimited_by_braces()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| Object::new(span, data))
   }
@@ -596,7 +598,7 @@ value_parser!(
     .repeated_while::<_, U1>(decide_brace_member::<_, Ctx>)
     .delimited_by_braces()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| ConstObject::new(span, data))
   }
@@ -615,7 +617,7 @@ value_parser!(
     value
       .then_ignore(fat_arrow)
       .then(value)
-      .spanned()
+      .token_spanned()
       .map(
         |Spanned {
            span,
@@ -639,7 +641,7 @@ value_parser!(
     const_value
       .then_ignore(fat_arrow)
       .then(const_value)
-      .spanned()
+      .token_spanned()
       .map(
         |Spanned {
            span,
@@ -667,7 +669,7 @@ where
     .repeated_while::<_, U1>(decide_brace_member::<_, Ctx>)
     .delimited_by_braces()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| Set::new(SimpleSpan::new(start, span.end()), data))
 }
@@ -689,7 +691,7 @@ where
     .repeated_while::<_, U1>(decide_brace_member::<_, Ctx>)
     .delimited_by_braces()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| ConstSet::new(SimpleSpan::new(start, span.end()), data))
 }
@@ -711,7 +713,7 @@ where
     .repeated_while::<_, U1>(decide_brace_member::<_, Ctx>)
     .delimited_by_braces()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| Map::new(SimpleSpan::new(start, span.end()), data))
 }
@@ -733,7 +735,7 @@ where
     .repeated_while::<_, U1>(decide_brace_member::<_, Ctx>)
     .delimited_by_braces()
     .collect_with(Vec::new())
-    .spanned()
+    .token_spanned()
     .parse_input(inp)
     .map(|Spanned { span, data }| ConstMap::new(SimpleSpan::new(start, span.end()), data))
 }
@@ -966,12 +968,12 @@ where
   Ctx: ParseCtx<'inp, GraphqlxLexer<'inp, Src>, GraphQLx>,
   GraphqlxError<'inp, Src, Ctx>: From<DialectGraphqlxError<GraphqlxSlice<'inp, Src>>>,
 {
-  let cursor = *inp.cursor();
+  let node_start = extent_start(inp)?;
   match try_equal(inp)? {
     ParseAttempt::Accept(_) => {
       let value = const_value(inp)?;
       Ok(ParseAttempt::Accept(DefaultInputValue::new(
-        inp.span_since(&cursor),
+        extent_since(inp, node_start),
         value,
       )))
     }

--- a/smear-parser/tests/support/span_extent.rs
+++ b/smear-parser/tests/support/span_extent.rs
@@ -1,0 +1,314 @@
+//! The syntactic span-extent derivation, owned in one place and read by both dialects' gates.
+//!
+//! # What this measures
+//!
+//! A composite AST node's span must be the **extent of the tokens it contains**: it opens at the
+//! start of its first token and closes at the end of its last one. The parser's other option — and
+//! the one it took before issue #68 — is to close at wherever the lookahead cursor happened to be,
+//! which on compact input is the same number and on spaced input is the next token's start. That
+//! is why a corpus cannot find this by being large: **on compact input every rule coincides**, so
+//! only trivia deliberately injected at a junction can tell a correct span from an artifact.
+//!
+//! # Why the walk reads `Debug` rather than a visitor
+//!
+//! The check has to see **every** span, and the only total projection of these ASTs that exists is
+//! the derived [`Debug`]. A hand-written visitor is precisely the thing that can fall one node
+//! behind the AST and go on reporting success about the nodes it still knows; `#[derive(Debug)]`
+//! renders every field of every node, so a node type added tomorrow enters this sweep without
+//! anybody remembering to add it. The cost is a string walk over a pretty-printed tree, which is
+//! paid once per padded parse and is not on any hot path.
+//!
+//! The walk's assumption about the rendering — a `span: SimpleSpan { start: N, end: M }` block
+//! nested inside its owner's frame — is not taken on faith: each dialect's gate pins it with a
+//! positive control over a hand-built rendering, and [`check`] is proved able to answer "no" by
+//! the same controls.
+//!
+//! # The invariant, in four parts
+//!
+//! [`check`] applies all four to every span it is given, against the token extents of the same
+//! bytes as reported by the **lexer** — never by the tree under test, which is the artifact being
+//! asserted about.
+//!
+//! - `inverted` — `end` before `start`. Structural; no span may be unusable as a range.
+//! - `start-not-token-start` / `end-not-token-end` — a **non-empty** node's endpoints are token
+//!   endpoints of the matching kind. This is the pair that #68 is about, and between them they
+//!   name every production that closed on a peek or opened on a cold cache.
+//! - `empty-off-boundary` — an **empty** node (an absent optional collection carries a zero-width
+//!   span as its position marker) sits on a token boundary rather than inside the ignorable bytes
+//!   between two tokens. Weaker than the non-empty rule on purpose: a zero-width span records a
+//!   *position*, and the two candidate positions on either side of a run of trivia are both
+//!   defensible, so pinning it tighter than "not in the middle of the whitespace" would be pinning
+//!   a choice rather than a fact.
+//! - `not-contained` — a node's span lies inside its parent's. Free from the walk's nesting, and
+//!   the check that catches an endpoint that ran past the construct it belongs to.
+//!
+//! # The liveness floor
+//!
+//! [`discriminating`] answers the question a silent sweep cannot: **was this span at a position
+//! where the two rules disagree at all?** A span whose end is followed immediately by another
+//! token, and whose start is preceded immediately by one, is a span the buggy rule and the correct
+//! rule agree about — checking it proves nothing. Each gate asserts every node type it observed
+//! was observed at least once at a discriminating site, so a sweep that padded nothing, or padded
+//! only the edges, fails loudly instead of reporting a green wall of vacuous checks.
+
+use std::collections::BTreeSet;
+
+/// The eight ignorable forms, one variant of each corpus entry per form.
+///
+/// The same eight `is_trivia` admits, in the same order as the lossless trivia gates' alphabet —
+/// `tests/support/graphqlx_padding.rs` owns that copy and the GraphQLx gate here asserts the two
+/// agree element for element, so the pinning is by assertion rather than by hoping.
+///
+/// The comment carries its own line terminator: a comment runs to the end of the line, so `"# c"`
+/// alone would swallow the token after it and the variant would stop being an injection.
+pub const ALPHABET: &[(&str, &str)] = &[
+  ("space", " "),
+  ("tab", "\t"),
+  ("newline", "\n"),
+  ("carriage-return", "\r"),
+  ("crlf", "\r\n"),
+  ("comment", "# c\n"),
+  ("comma", ","),
+  ("bom", "\u{FEFF}"),
+];
+
+/// One span found in a pretty-printed `Debug` rendering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FoundSpan {
+  /// The node type that owns it — the nearest enclosing named frame in the rendering.
+  pub owner: String,
+  /// The index in the same vector of the span of the nearest enclosing *node*, when there is one.
+  pub parent: Option<usize>,
+  /// The start offset.
+  pub start: usize,
+  /// The end offset.
+  pub end: usize,
+}
+
+/// Every `SimpleSpan` in a `{:#?}` rendering, attributed to its owning node type and its parent
+/// node's span.
+///
+/// The walk is a brace/paren/bracket stack over the pretty-printed lines. A line that ends in an
+/// opener pushes a frame named after its type — `Foo {`, `field: Foo {`, `Some(` all name their
+/// last identifier — and a line that begins with a closer pops one. When the frame being pushed is
+/// a `SimpleSpan`, the owner is the nearest enclosing named frame and the parent is the nearest
+/// enclosing frame that has already published a span index.
+///
+/// A `Debug`-rendered string never contains a raw newline (they are escaped) and never ends a line
+/// with a bare opener, so no string literal in the source can be mistaken for a frame.
+pub fn spans_of(dump: &str) -> Vec<FoundSpan> {
+  /// One open frame in the rendering: its type name, and the index of the span it owns once that
+  /// span has been read.
+  struct Frame {
+    name: String,
+    span: Option<usize>,
+  }
+
+  /// The `SimpleSpan { .. }` block currently being read.
+  struct Pending {
+    owner: String,
+    parent: Option<usize>,
+    start: Option<usize>,
+    end: Option<usize>,
+  }
+
+  let mut stack: Vec<Frame> = Vec::new();
+  let mut out: Vec<FoundSpan> = Vec::new();
+  let mut pending: Option<Pending> = None;
+
+  for raw in dump.lines() {
+    let line = raw.trim();
+    if line.is_empty() {
+      continue;
+    }
+
+    if let Some(rest) = line.strip_prefix("start: ")
+      && let Some(number) = rest.strip_suffix(',')
+      && let Some(slot) = pending.as_mut()
+      && let Ok(value) = number.parse::<usize>()
+    {
+      slot.start = Some(value);
+      continue;
+    }
+    if let Some(rest) = line.strip_prefix("end: ")
+      && let Some(number) = rest.strip_suffix(',')
+      && let Some(slot) = pending.as_mut()
+      && let Ok(value) = number.parse::<usize>()
+    {
+      slot.end = Some(value);
+      continue;
+    }
+
+    if line.ends_with('{') || line.ends_with('(') || line.ends_with('[') {
+      let label = line[..line.len() - 1].trim();
+      let name = label
+        .rsplit_once(": ")
+        .map_or(label, |(_, ty)| ty)
+        .to_string();
+      if name == "SimpleSpan" {
+        let owner = stack
+          .iter()
+          .rev()
+          .find(|frame| !frame.name.is_empty())
+          .map_or_else(|| "<root>".to_string(), |frame| frame.name.clone());
+        let parent = stack.iter().rev().find_map(|frame| frame.span);
+        pending = Some(Pending {
+          owner,
+          parent,
+          start: None,
+          end: None,
+        });
+      }
+      stack.push(Frame { name, span: None });
+      continue;
+    }
+
+    if line.starts_with('}') || line.starts_with(')') || line.starts_with(']') {
+      let popped = stack.pop();
+      if popped.as_ref().map(|frame| frame.name.as_str()) == Some("SimpleSpan")
+        && let Some(Pending {
+          owner,
+          parent,
+          start: Some(start),
+          end: Some(end),
+        }) = pending.take()
+      {
+        let index = out.len();
+        out.push(FoundSpan {
+          owner,
+          parent,
+          start,
+          end,
+        });
+        // The frame that owns this span can now be somebody else's parent.
+        if let Some(frame) = stack.iter_mut().rev().find(|frame| !frame.name.is_empty()) {
+          frame.span = Some(index);
+        }
+      }
+      continue;
+    }
+  }
+  out
+}
+
+/// One failed part of the invariant, named so a red gate says which node and which rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Violation {
+  /// The node type whose span is wrong.
+  pub owner: String,
+  /// Which part of the invariant it broke — see the module docs.
+  pub rule: &'static str,
+  /// The span and what the source says about it.
+  pub detail: String,
+}
+
+/// The token extents of a source: every token's start, and every token's end.
+#[derive(Debug, Clone, Default)]
+pub struct Extents {
+  /// Every offset a token begins at.
+  pub starts: BTreeSet<usize>,
+  /// Every offset a token ends at.
+  pub ends: BTreeSet<usize>,
+}
+
+/// Every way `spans` fails the extent invariant against `extents`.
+///
+/// An empty result is the pass. `src` is used only to quote the offending bytes in the message.
+pub fn check(src: &str, spans: &[FoundSpan], extents: &Extents) -> Vec<Violation> {
+  let mut out = Vec::new();
+  let mut note = |owner: &str, rule: &'static str, detail: String| {
+    out.push(Violation {
+      owner: owner.to_string(),
+      rule,
+      detail,
+    });
+  };
+
+  for span in spans {
+    let quoted = if span.start <= span.end && span.end <= src.len() {
+      format!("{:?}", &src[span.start..span.end])
+    } else {
+      "<out of range>".to_string()
+    };
+    let where_ = format!("{}..{} {quoted}", span.start, span.end);
+
+    if span.end < span.start {
+      note(&span.owner, "inverted", where_);
+      continue;
+    }
+
+    if span.start < span.end {
+      if !extents.starts.contains(&span.start) {
+        note(
+          &span.owner,
+          "start-not-token-start",
+          format!("{where_} — opens inside the ignorable bytes before its first token"),
+        );
+      }
+      if !extents.ends.contains(&span.end) {
+        note(
+          &span.owner,
+          "end-not-token-end",
+          format!("{where_} — closes past its last token, in the ignorable bytes that follow"),
+        );
+      }
+    } else if !extents.starts.contains(&span.start) && !extents.ends.contains(&span.start) {
+      note(
+        &span.owner,
+        "empty-off-boundary",
+        format!("{where_} — a zero-width span parked inside a run of trivia"),
+      );
+    }
+
+    if let Some(parent) = span.parent.map(|index| &spans[index])
+      && (span.start < parent.start || span.end > parent.end)
+    {
+      note(
+        &span.owner,
+        "not-contained",
+        format!(
+          "{where_} — escapes its {} parent at {}..{}",
+          parent.owner, parent.start, parent.end
+        ),
+      );
+    }
+  }
+  out
+}
+
+/// Is this span at a position where the token-extent rule and the lookahead rule **disagree**?
+///
+/// True when an ignorable byte sits immediately after the span's end or immediately before its
+/// start — the only situation in which closing on a peek, or opening on a cold cache, produces a
+/// different number from closing and opening on the tokens. A span for which this is false was
+/// checked, but nothing about it could have failed, which is what the liveness floor exists to
+/// notice.
+///
+/// Derived from the lexer's extents rather than from a byte classifier: an offset that is a token
+/// end and not also a token start has ignorable bytes after it, by definition of "the tokens tile
+/// everything that is not trivia".
+pub fn discriminating(span: &FoundSpan, extents: &Extents, len: usize) -> bool {
+  let trivia_after =
+    span.end < len && extents.ends.contains(&span.end) && !extents.starts.contains(&span.end);
+  let trivia_before =
+    span.start > 0 && extents.starts.contains(&span.start) && !extents.ends.contains(&span.start);
+  trivia_after || trivia_before
+}
+
+/// `src` with `pad` inserted at every boundary in `boundaries`.
+pub fn inject(src: &str, boundaries: &[usize], pad: &str) -> String {
+  let mut out = String::with_capacity(src.len() + boundaries.len() * pad.len());
+  let mut cursor = 0usize;
+  for &boundary in boundaries {
+    out.push_str(&src[cursor..boundary]);
+    out.push_str(pad);
+    cursor = boundary;
+  }
+  out.push_str(&src[cursor..]);
+  out
+}
+
+/// The distinct node types among `spans`.
+pub fn owners(spans: &[FoundSpan]) -> BTreeSet<String> {
+  spans.iter().map(|span| span.owner.clone()).collect()
+}

--- a/smear-parser/tests/syntactic_span_extent.rs
+++ b/smear-parser/tests/syntactic_span_extent.rs
@@ -1,0 +1,497 @@
+#![cfg(feature = "graphql")]
+
+//! The syntactic span-extent gate for GraphQL: trivia injection, with a per-node-type
+//! discrimination counter.
+//!
+//! The invariant: **a composite node's span is the extent of the tokens it contains.** It opens at
+//! the start of its first token and closes at the end of its last one, and no ignorable byte on
+//! either side belongs to it.
+//!
+//! # Why the syntactic suite had no gate like this, and what it cost
+//!
+//! On compact input every span rule coincides. Closing a node at the end of its last token and
+//! closing it at wherever the parser's lookahead cursor landed are the same number until there is
+//! trivia between the two, so a corpus of tightly written GraphQL — which is what a parser suite
+//! naturally accumulates — cannot distinguish a span from a lookahead artifact. The lossless side
+//! learned this and answered it with `lossless_trivia.rs`; the syntactic side had no counterpart,
+//! and issue #68 is what grew in the gap: forty-four node types across the two dialects were
+//! carrying spans that ran into the whitespace after them, and every gate in the repository was
+//! green.
+//!
+//! [`the_issue_68_witness`] is that measurement, pinned to the byte.
+//!
+//! # The alphabet, the corpus, and what pins them
+//!
+//! Eight ignorable forms — [`extent::ALPHABET`] — at every token boundary of every `valid_` entry
+//! in `tests/corpus/`, the same corpus and the same eight forms `lossless_trivia.rs` pads. That
+//! shared corpus is deliberate and load-bearing in one direction: **its reach over the grammar is
+//! measured there, not here.** `lossless_trivia.rs`'s coverage counter asserts these entries open
+//! every node kind in the kind space, so a production nobody exercises is that gate's failure. Re-
+//! deriving the same claim here would make two gates fail for one defect while neither explained
+//! it. What this gate owns instead is the *syntactic* side's own reach, pinned two ways below: the
+//! padded owner set must equal the compact one, and it must not shrink below what it measures
+//! today.
+//!
+//! # The liveness floor
+//!
+//! A trivia-injection sweep that silently injects into nothing is the same defect one level up: it
+//! reports success over spans that never sat anywhere the rules disagree. So each span is
+//! classified by [`extent::discriminating`] — is there an ignorable byte immediately after its end,
+//! or immediately before its start? — and
+//! [`trivia_injection_leaves_every_span_on_its_own_tokens`] asserts **every node type it observed
+//! was observed at least once at such a site**. A form that stopped injecting, a boundary scan that
+//! returned nothing, or a corpus that lost its interior junctions all turn that assertion red
+//! rather than leaving a wall of vacuous passes.
+//!
+//! # Two positive controls, because a checker that cannot fail proves nothing
+//!
+//! [`the_span_walk_reads_the_debug_rendering_this_gate_assumes`] pins the one assumption the walk
+//! makes about `#[derive(Debug)]`'s output, and [`the_checker_can_answer_no`] feeds
+//! [`extent::check`] a span that is wrong in each of the four ways and requires it to say so. The
+//! sweep below is only as good as those two.
+
+use std::{collections::BTreeSet, path::PathBuf};
+
+use smear_lexer::graphql::syntactic::SyntacticLexer;
+use smear_parser::graphql::{
+  GraphQL,
+  ast::Document,
+  error::GraphqlErrors,
+  syntactic::{GraphqlLexer, document},
+};
+use tokora::{Lexer as _, Parse as _, Parser, SimpleSpan};
+
+#[path = "support/span_extent.rs"]
+mod extent;
+
+use extent::{ALPHABET, Extents, FoundSpan, Violation, check, discriminating, inject, spans_of};
+
+/// The smallest number of distinct span-carrying node types this corpus reaches.
+///
+/// A floor, not a pin: adding a corpus entry that reaches a sixty-ninth node type is not a
+/// regression, and losing one is. The value is the measurement, taken the day this gate was
+/// written.
+const OWNER_FLOOR: usize = 68;
+
+/// Parses one source through the syntactic GraphQL document root.
+fn parse(src: &str) -> Result<Document<&str>, GraphqlErrors<&str>> {
+  Parser::with_parser::<'_, GraphqlLexer<'_, str>, Document<&str>, GraphqlErrors<&str>, _, GraphQL>(
+    document,
+  )
+  .parse_str(src)
+}
+
+/// Every token's start and end, from the **lexer**.
+///
+/// Never from the tree under test: reading the extents off the parse would make the yardstick a
+/// function of the artifact being measured, and a production that lost a token would quietly stop
+/// being checked there.
+fn extents(src: &str) -> Extents {
+  let mut lexer = SyntacticLexer::<str>::new(src);
+  let mut out = Extents::default();
+  while let Some(result) = lexer.lex() {
+    result.unwrap_or_else(|e| panic!("{src:?} must lex: {e:?}"));
+    out.starts.insert(lexer.span().start());
+    out.ends.insert(lexer.span().end());
+  }
+  out
+}
+
+/// Every token boundary in `src`: offset 0, then the end of each token.
+fn boundaries(src: &str) -> Vec<usize> {
+  let mut lexer = SyntacticLexer::<str>::new(src);
+  let mut out = vec![0usize];
+  while let Some(result) = lexer.lex() {
+    result.unwrap_or_else(|e| panic!("a valid corpus entry must lex: {e:?}"));
+    out.push(lexer.span().end());
+  }
+  out.dedup();
+  out
+}
+
+/// The `valid_` half of the shared GraphQL corpus, in a deterministic order.
+fn valid_corpus() -> Vec<(String, String)> {
+  let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    .join("tests")
+    .join("corpus");
+  let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+    .unwrap_or_else(|e| panic!("the shared corpus at {} is unreadable: {e}", dir.display()))
+    .map(|entry| entry.expect("a corpus directory entry").path())
+    .filter(|path| path.extension().is_some_and(|ext| ext == "graphql"))
+    .filter(|path| {
+      path
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy().starts_with("valid_"))
+    })
+    .collect();
+  files.sort();
+  files
+    .into_iter()
+    .map(|path| {
+      let name = path
+        .file_name()
+        .expect("a corpus entry has a file name")
+        .to_string_lossy()
+        .to_string();
+      let src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{} is unreadable: {e}", path.display()));
+      (name, src)
+    })
+    .collect()
+}
+
+/// The one assumption the span walk makes about `#[derive(Debug)]`, measured rather than trusted.
+///
+/// If `SimpleSpan` ever renders as a tuple struct, or the pretty printer stops nesting a field's
+/// value under its owner, the walk would find no spans at all — and a sweep that checks zero spans
+/// is the most convincing green wall there is. So the shape is pinned twice: against a rendering
+/// this test builds by hand, and against a real parse whose spans are known.
+#[test]
+fn the_span_walk_reads_the_debug_rendering_this_gate_assumes() {
+  assert_eq!(
+    format!("{:#?}", SimpleSpan::new(3usize, 7usize)),
+    "SimpleSpan {\n    start: 3,\n    end: 7,\n}",
+    "`SimpleSpan`'s pretty `Debug` is the shape `spans_of` walks; it changed"
+  );
+
+  let doc = parse("type T{f:Int}").expect("the control source parses");
+  let found = spans_of(&format!("{doc:#?}"));
+  assert!(
+    found.len() >= 8,
+    "the walk found only {} spans in a document with a type, a field and a named type — it is \
+     reading the rendering wrong",
+    found.len()
+  );
+
+  // Owner attribution and nesting, on nodes whose extents are unambiguous in compact source.
+  let named = found
+    .iter()
+    .find(|span| span.owner == "NamedType")
+    .expect("the walk must attribute the `Int` node to `NamedType`");
+  assert_eq!((named.start, named.end), (9, 12), "`Int` is at 9..12");
+  let parent = named
+    .parent
+    .map(|index| &found[index])
+    .expect("`NamedType` is nested inside a field, so the walk must give it a parent");
+  assert!(
+    parent.start <= named.start && named.end <= parent.end,
+    "the walk's parent link must be an enclosing node, and {}..{} is not",
+    parent.start,
+    parent.end
+  );
+}
+
+/// [`extent::check`] must be able to say "no", or every green run below means nothing.
+///
+/// One span wrong in each of the four ways the invariant names, over a two-token source whose
+/// extents are known: `a b` lexes as `a@0..1` and `b@2..3`, so 1 is a token end and not a start, 2
+/// is a start and not an end, and 4 is neither.
+#[test]
+fn the_checker_can_answer_no() {
+  let src = "a b";
+  let ext = extents(src);
+  assert_eq!(ext.starts, BTreeSet::from([0, 2]));
+  assert_eq!(ext.ends, BTreeSet::from([1, 3]));
+
+  let rules = |spans: &[FoundSpan]| -> Vec<&'static str> {
+    check(src, spans, &ext)
+      .iter()
+      .map(|violation: &Violation| violation.rule)
+      .collect()
+  };
+
+  // The control: the honest span of the whole thing, and the honest span of its first token.
+  let good = vec![
+    FoundSpan {
+      owner: "Whole".into(),
+      parent: None,
+      start: 0,
+      end: 3,
+    },
+    FoundSpan {
+      owner: "First".into(),
+      parent: Some(0),
+      start: 0,
+      end: 1,
+    },
+  ];
+  assert!(
+    rules(&good).is_empty(),
+    "the checker rejected a correct tree: {:?}",
+    check(src, &good, &ext)
+  );
+
+  // #68 proper: a node closed at the next token's start.
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Spilled".into(),
+      parent: None,
+      start: 0,
+      end: 2
+    }]),
+    ["end-not-token-end"]
+  );
+  // #68's other half: a node opened at the previous token's end.
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Early".into(),
+      parent: None,
+      start: 1,
+      end: 3
+    }]),
+    ["start-not-token-start"]
+  );
+  // A zero-width position marker parked in the whitespace between the tokens.
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Absent".into(),
+      parent: None,
+      start: 4,
+      end: 4
+    }]),
+    ["empty-off-boundary"]
+  );
+  // A child that outruns its parent.
+  assert_eq!(
+    rules(&[
+      FoundSpan {
+        owner: "Parent".into(),
+        parent: None,
+        start: 0,
+        end: 1
+      },
+      FoundSpan {
+        owner: "Child".into(),
+        parent: Some(0),
+        start: 2,
+        end: 3
+      },
+    ]),
+    ["not-contained"]
+  );
+  // An inverted span reports once and stops, rather than cascading into the endpoint rules.
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Backwards".into(),
+      parent: None,
+      start: 3,
+      end: 1
+    }]),
+    ["inverted"]
+  );
+
+  // And the liveness classifier must also be able to say "no": in `a b` the first token's span is
+  // followed by trivia and so is discriminating, while the whole-source span is flanked by nothing.
+  assert!(discriminating(&good[1], &ext, src.len()));
+  assert!(!discriminating(&good[0], &ext, src.len()));
+}
+
+/// The gate proper: every span in every padded parse is the extent of its own tokens, and every
+/// node type reached was reached somewhere the two span rules disagree.
+#[test]
+fn trivia_injection_leaves_every_span_on_its_own_tokens() {
+  let entries = valid_corpus();
+  assert!(
+    entries.len() >= 20,
+    "only {} valid corpus entries; the sweep is too thin to mean anything",
+    entries.len()
+  );
+
+  let mut padded_parses = 0usize;
+  let mut injected_bytes = 0usize;
+  let mut violations: Vec<(String, String, Violation)> = Vec::new();
+  let mut compact_owners: BTreeSet<String> = BTreeSet::new();
+  let mut padded_owners: BTreeSet<String> = BTreeSet::new();
+  let mut discriminated: BTreeSet<String> = BTreeSet::new();
+  let mut discriminating_spans = 0usize;
+  let mut total_spans = 0usize;
+
+  for (name, src) in &entries {
+    let marks = boundaries(src);
+    assert!(
+      marks.len() >= 3,
+      "{name}: {} token boundaries — a one-token entry cannot exercise an interior junction",
+      marks.len()
+    );
+
+    // The compact control. It must pass — a span that is wrong even without injection is a defect
+    // this gate should still name — and its owner set is the yardstick the padded set is held to.
+    let compact = parse(src).unwrap_or_else(|e| {
+      panic!(
+        "{name}: the unpadded entry does not parse — a corpus fault, not an injection one: {e:?}"
+      )
+    });
+    let compact_spans = spans_of(&format!("{compact:#?}"));
+    let compact_extents = extents(src);
+    for violation in check(src, &compact_spans, &compact_extents) {
+      violations.push((name.clone(), "compact".to_string(), violation));
+    }
+    compact_owners.extend(extent::owners(&compact_spans));
+
+    for (form, pad) in ALPHABET {
+      let padded_src = inject(src, &marks, pad);
+      assert_eq!(
+        padded_src.len(),
+        src.len() + marks.len() * pad.len(),
+        "{name} padded with {form}: the injection did not land at every boundary"
+      );
+      injected_bytes += marks.len() * pad.len();
+
+      let padded = parse(&padded_src).unwrap_or_else(|e| {
+        panic!(
+          "{name} padded with {form}: the padded entry does not parse, so some decision point \
+           looked at the head without committing the trivia in front of it: {e:?}"
+        )
+      });
+      padded_parses += 1;
+
+      let spans = spans_of(&format!("{padded:#?}"));
+      assert!(
+        !spans.is_empty(),
+        "{name} padded with {form}: the walk found no spans at all, so this variant was checked \
+         for nothing"
+      );
+      let padded_extents = extents(&padded_src);
+      for violation in check(&padded_src, &spans, &padded_extents) {
+        violations.push((name.clone(), (*form).to_string(), violation));
+      }
+      padded_owners.extend(extent::owners(&spans));
+
+      total_spans += spans.len();
+      for span in &spans {
+        if discriminating(span, &padded_extents, padded_src.len()) {
+          discriminating_spans += 1;
+          discriminated.insert(span.owner.clone());
+        }
+      }
+    }
+  }
+
+  assert_eq!(
+    padded_parses,
+    entries.len() * ALPHABET.len(),
+    "the sweep did not run every form over every entry"
+  );
+  assert!(
+    injected_bytes > 0,
+    "the sweep injected nothing, so every check above was made against the compact bytes"
+  );
+
+  if !violations.is_empty() {
+    let mut report: Vec<String> = violations
+      .iter()
+      .map(|(name, form, violation)| {
+        format!(
+          "  {name} [{form}] {} — {} — {}",
+          violation.owner, violation.rule, violation.detail
+        )
+      })
+      .collect();
+    report.sort();
+    report.dedup();
+    let owners: BTreeSet<&str> = violations
+      .iter()
+      .map(|(_, _, violation)| violation.owner.as_str())
+      .collect();
+    panic!(
+      "{} span-extent violations over {} node types — their spans are lookahead positions, not \
+       token extents:\n{}\nnode types: {owners:?}",
+      violations.len(),
+      owners.len(),
+      report.join("\n")
+    );
+  }
+
+  // Reach, pinned two ways. Padding may not lose a node type — a form that changed the tree would
+  // show up here even if every surviving span were tight — and the set may not silently shrink
+  // below what it measures today.
+  assert_eq!(
+    padded_owners, compact_owners,
+    "the padded sweep and the compact corpus disagree about which node types exist"
+  );
+  assert!(
+    padded_owners.len() >= OWNER_FLOOR,
+    "the sweep reached {} span-carrying node types, below the floor of {OWNER_FLOOR}: {padded_owners:?}",
+    padded_owners.len()
+  );
+
+  // The liveness floor. Every node type must have been observed at least once where the two span
+  // rules give different answers, or this gate is asserting about it without testing it.
+  let undiscriminated: Vec<&String> = padded_owners.difference(&discriminated).collect();
+  assert!(
+    undiscriminated.is_empty(),
+    "{} of the {} node types were never observed next to injected trivia, so nothing about their \
+     spans was actually at stake: {undiscriminated:?}",
+    undiscriminated.len(),
+    padded_owners.len()
+  );
+  assert!(
+    discriminating_spans * 2 >= total_spans,
+    "only {discriminating_spans} of {total_spans} spans sat at a junction where the two rules \
+     differ; padding at every boundary should put most of them there, so the injection has \
+     stopped reaching the interior"
+  );
+
+  println!(
+    "gate: {} entries x {} forms = {padded_parses} padded parses, {total_spans} spans, \
+     {discriminating_spans} at a discriminating junction, {} node types",
+    entries.len(),
+    ALPHABET.len(),
+    padded_owners.len()
+  );
+}
+
+/// Issue #68's own measurement, pinned to the byte.
+///
+/// `"  type T  { f : Int }  "`, whose tokens are `type@2..6 T@7..8 {@10..11 f@12..13 :@14..15
+/// Int@16..19 }@20..21`. Before the fix the parser answered `NamedType` 16..20, `FieldDefinition`
+/// 12..20 and `Document` 0..21: two nodes closed at the *next* token's start, and the document
+/// opened at input position 0, in front of its own leading trivia, so its two endpoints followed
+/// different rules.
+///
+/// Kept beside the sweep rather than folded into it because a named witness is what a reader of a
+/// future regression needs, and because the document's start is the one endpoint the sweep's other
+/// entries reach only incidentally.
+#[test]
+fn the_issue_68_witness() {
+  let src = "  type T  { f : Int }  ";
+  assert_eq!(src.len(), 23);
+
+  let ext = extents(src);
+  assert_eq!(
+    ext.starts,
+    BTreeSet::from([2, 7, 10, 12, 14, 16, 20]),
+    "the witness's token starts"
+  );
+  assert_eq!(
+    ext.ends,
+    BTreeSet::from([6, 8, 11, 13, 15, 19, 21]),
+    "the witness's token ends"
+  );
+
+  let doc = parse(src).expect("the witness parses");
+  let spans = spans_of(&format!("{doc:#?}"));
+  let of = |owner: &str| -> (usize, usize) {
+    let found: Vec<&FoundSpan> = spans.iter().filter(|span| span.owner == owner).collect();
+    assert_eq!(found.len(), 1, "{owner} appears {} times", found.len());
+    (found[0].start, found[0].end)
+  };
+
+  assert_eq!(of("NamedType"), (16, 19), "was 16..20 — `Int` plus a space");
+  assert_eq!(
+    of("FieldDefinition"),
+    (12, 19),
+    "was 12..20 — the field plus the space before `}}`"
+  );
+  assert_eq!(
+    of("Document"),
+    (2, 21),
+    "was 0..21 — the document plus its own leading trivia"
+  );
+
+  assert!(
+    check(src, &spans, &ext).is_empty(),
+    "the witness still violates the extent invariant: {:?}",
+    check(src, &spans, &ext)
+  );
+}

--- a/smear-parser/tests/syntactic_x_span_extent.rs
+++ b/smear-parser/tests/syntactic_x_span_extent.rs
@@ -1,0 +1,418 @@
+#![cfg(feature = "graphqlx")]
+
+//! The syntactic span-extent gate for GraphQLx — the twin of `syntactic_span_extent.rs`.
+//!
+//! The invariant, the alphabet, the walk and the liveness floor are that file's; it carries the
+//! reasoning and this one carries the dialect. What is worth saying separately is why the dialect
+//! needed its own run rather than inheriting the GraphQL result: **issue #68 was three times the
+//! size here.** Eleven GraphQL node types closed a span on a lookahead position; thirty-three
+//! GraphQLx ones did, because every construct the dialect adds — the generic argument lists, the
+//! `where` clauses, the namespaced type paths, the set and map literals — is a production that
+//! peeks past its own tail to decide whether the tail is there. [`the_generics_witness`] pins one
+//! of them.
+//!
+//! Both dialects' gates share `tests/support/span_extent.rs`, which is where the eight-form
+//! alphabet, the `Debug` span walk, the four-part check and the discrimination classifier live.
+//! The lossless trivia gates keep their own copy of the alphabet in
+//! `tests/support/graphqlx_padding.rs`; the two are deliberately not merged, because that module's
+//! boundary scan is defined over the **lossless** lexer and this gate's is defined over the
+//! syntactic one, and a gate about syntactic spans should measure syntactic tokens.
+
+use std::{collections::BTreeSet, path::PathBuf};
+
+use smear_lexer::graphqlx::syntactic::SyntacticLexer;
+use smear_parser::graphqlx::{
+  GraphQLx,
+  ast::Document,
+  error::GraphqlxErrors,
+  syntactic::{GraphqlxLexer, document},
+};
+use tokora::{Lexer as _, Parse as _, Parser};
+
+#[path = "support/span_extent.rs"]
+mod extent;
+
+use extent::{ALPHABET, Extents, FoundSpan, Violation, check, discriminating, inject, spans_of};
+
+/// The smallest number of distinct span-carrying node types this corpus reaches.
+///
+/// A floor, not a pin — see the GraphQL twin. Ninety-three against GraphQL's sixty-eight, which is
+/// the dialect's extra surface showing up as extra node types rather than as extra entries.
+const OWNER_FLOOR: usize = 93;
+
+/// Parses one source through the syntactic GraphQLx document root.
+fn parse(src: &str) -> Result<Document<&str>, GraphqlxErrors<&str>> {
+  Parser::with_parser::<
+    '_,
+    GraphqlxLexer<'_, str>,
+    Document<&str>,
+    GraphqlxErrors<&str>,
+    _,
+    GraphQLx,
+  >(document)
+  .parse_str(src)
+}
+
+/// Every token's start and end, from the **lexer** rather than from the tree under test.
+fn extents(src: &str) -> Extents {
+  let mut lexer = SyntacticLexer::<str>::new(src);
+  let mut out = Extents::default();
+  while let Some(result) = lexer.lex() {
+    result.unwrap_or_else(|e| panic!("{src:?} must lex: {e:?}"));
+    out.starts.insert(lexer.span().start());
+    out.ends.insert(lexer.span().end());
+  }
+  out
+}
+
+/// Every token boundary in `src`: offset 0, then the end of each token.
+fn boundaries(src: &str) -> Vec<usize> {
+  let mut lexer = SyntacticLexer::<str>::new(src);
+  let mut out = vec![0usize];
+  while let Some(result) = lexer.lex() {
+    result.unwrap_or_else(|e| panic!("a valid corpus entry must lex: {e:?}"));
+    out.push(lexer.span().end());
+  }
+  out.dedup();
+  out
+}
+
+/// The `valid_` half of the GraphQLx corpus, in a deterministic order.
+fn valid_corpus() -> Vec<(String, String)> {
+  let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    .join("tests")
+    .join("corpusx");
+  let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+    .unwrap_or_else(|e| {
+      panic!(
+        "the GraphQLx corpus at {} is unreadable: {e}",
+        dir.display()
+      )
+    })
+    .map(|entry| entry.expect("a corpus directory entry").path())
+    .filter(|path| path.extension().is_some_and(|ext| ext == "graphqlx"))
+    .filter(|path| {
+      path
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy().starts_with("valid_"))
+    })
+    .collect();
+  files.sort();
+  files
+    .into_iter()
+    .map(|path| {
+      let name = path
+        .file_name()
+        .expect("a corpus entry has a file name")
+        .to_string_lossy()
+        .to_string();
+      let src = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("{} is unreadable: {e}", path.display()));
+      (name, src)
+    })
+    .collect()
+}
+
+/// The walk's assumption about `#[derive(Debug)]`, re-measured against the GraphQLx AST.
+///
+/// Not inherited from the GraphQL gate: the two dialects derive their node types independently,
+/// and a GraphQLx node that rendered its span differently would leave this whole file checking
+/// nothing while the other one stayed green.
+#[test]
+fn the_span_walk_reads_the_debug_rendering_this_gate_assumes() {
+  let doc = parse("type T<A>{f:set<A>}").expect("the control source parses");
+  let found = spans_of(&format!("{doc:#?}"));
+  assert!(
+    found.len() >= 10,
+    "the walk found only {} spans in a generic type with a set-typed field — it is reading the \
+     rendering wrong",
+    found.len()
+  );
+  assert!(
+    found.iter().any(|span| span.owner == "TypeGenerics"),
+    "the walk must attribute the `<A>` on the field's type to `TypeGenerics` — the GraphQLx-only \
+     node this control exists for; it saw {:?}",
+    extent::owners(&found)
+  );
+  assert!(
+    found.iter().any(|span| span.parent.is_some()),
+    "the walk produced no nesting at all, so `not-contained` can never fire"
+  );
+}
+
+/// [`extent::check`] must be able to say "no" over GraphQLx tokens too.
+///
+/// The same five probes the GraphQL twin makes, over `a b`, which lexes identically in both
+/// dialects. Repeated rather than shared because the checker is fed this dialect's extents in the
+/// sweep below, and a shared assertion in the other binary cannot speak about this one.
+#[test]
+fn the_checker_can_answer_no() {
+  let src = "a b";
+  let ext = extents(src);
+  assert_eq!(ext.starts, BTreeSet::from([0, 2]));
+  assert_eq!(ext.ends, BTreeSet::from([1, 3]));
+
+  let rules = |spans: &[FoundSpan]| -> Vec<&'static str> {
+    check(src, spans, &ext)
+      .iter()
+      .map(|violation: &Violation| violation.rule)
+      .collect()
+  };
+
+  let good = vec![
+    FoundSpan {
+      owner: "Whole".into(),
+      parent: None,
+      start: 0,
+      end: 3,
+    },
+    FoundSpan {
+      owner: "First".into(),
+      parent: Some(0),
+      start: 0,
+      end: 1,
+    },
+  ];
+  assert!(
+    rules(&good).is_empty(),
+    "the checker rejected a correct tree"
+  );
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Spilled".into(),
+      parent: None,
+      start: 0,
+      end: 2
+    }]),
+    ["end-not-token-end"]
+  );
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Early".into(),
+      parent: None,
+      start: 1,
+      end: 3
+    }]),
+    ["start-not-token-start"]
+  );
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Absent".into(),
+      parent: None,
+      start: 4,
+      end: 4
+    }]),
+    ["empty-off-boundary"]
+  );
+  assert_eq!(
+    rules(&[
+      FoundSpan {
+        owner: "Parent".into(),
+        parent: None,
+        start: 0,
+        end: 1
+      },
+      FoundSpan {
+        owner: "Child".into(),
+        parent: Some(0),
+        start: 2,
+        end: 3
+      },
+    ]),
+    ["not-contained"]
+  );
+  assert_eq!(
+    rules(&[FoundSpan {
+      owner: "Backwards".into(),
+      parent: None,
+      start: 3,
+      end: 1
+    }]),
+    ["inverted"]
+  );
+
+  assert!(discriminating(&good[1], &ext, src.len()));
+  assert!(!discriminating(&good[0], &ext, src.len()));
+}
+
+/// The gate proper: every span in every padded parse is the extent of its own tokens, and every
+/// node type reached was reached somewhere the two span rules disagree.
+#[test]
+fn trivia_injection_leaves_every_span_on_its_own_tokens() {
+  let entries = valid_corpus();
+  assert!(
+    entries.len() >= 20,
+    "only {} valid corpus entries; the sweep is too thin to mean anything",
+    entries.len()
+  );
+
+  let mut padded_parses = 0usize;
+  let mut injected_bytes = 0usize;
+  let mut violations: Vec<(String, String, Violation)> = Vec::new();
+  let mut compact_owners: BTreeSet<String> = BTreeSet::new();
+  let mut padded_owners: BTreeSet<String> = BTreeSet::new();
+  let mut discriminated: BTreeSet<String> = BTreeSet::new();
+  let mut discriminating_spans = 0usize;
+  let mut total_spans = 0usize;
+
+  for (name, src) in &entries {
+    let marks = boundaries(src);
+    assert!(
+      marks.len() >= 3,
+      "{name}: {} token boundaries — a one-token entry cannot exercise an interior junction",
+      marks.len()
+    );
+
+    let compact = parse(src).unwrap_or_else(|e| {
+      panic!(
+        "{name}: the unpadded entry does not parse — a corpus fault, not an injection one: {e:?}"
+      )
+    });
+    let compact_spans = spans_of(&format!("{compact:#?}"));
+    let compact_extents = extents(src);
+    for violation in check(src, &compact_spans, &compact_extents) {
+      violations.push((name.clone(), "compact".to_string(), violation));
+    }
+    compact_owners.extend(extent::owners(&compact_spans));
+
+    for (form, pad) in ALPHABET {
+      let padded_src = inject(src, &marks, pad);
+      assert_eq!(
+        padded_src.len(),
+        src.len() + marks.len() * pad.len(),
+        "{name} padded with {form}: the injection did not land at every boundary"
+      );
+      injected_bytes += marks.len() * pad.len();
+
+      let padded = parse(&padded_src).unwrap_or_else(|e| {
+        panic!(
+          "{name} padded with {form}: the padded entry does not parse, so some decision point \
+           looked at the head without committing the trivia in front of it: {e:?}"
+        )
+      });
+      padded_parses += 1;
+
+      let spans = spans_of(&format!("{padded:#?}"));
+      assert!(
+        !spans.is_empty(),
+        "{name} padded with {form}: the walk found no spans at all, so this variant was checked \
+         for nothing"
+      );
+      let padded_extents = extents(&padded_src);
+      for violation in check(&padded_src, &spans, &padded_extents) {
+        violations.push((name.clone(), (*form).to_string(), violation));
+      }
+      padded_owners.extend(extent::owners(&spans));
+
+      total_spans += spans.len();
+      for span in &spans {
+        if discriminating(span, &padded_extents, padded_src.len()) {
+          discriminating_spans += 1;
+          discriminated.insert(span.owner.clone());
+        }
+      }
+    }
+  }
+
+  assert_eq!(
+    padded_parses,
+    entries.len() * ALPHABET.len(),
+    "the sweep did not run every form over every entry"
+  );
+  assert!(
+    injected_bytes > 0,
+    "the sweep injected nothing, so every check above was made against the compact bytes"
+  );
+
+  if !violations.is_empty() {
+    let mut report: Vec<String> = violations
+      .iter()
+      .map(|(name, form, violation)| {
+        format!(
+          "  {name} [{form}] {} — {} — {}",
+          violation.owner, violation.rule, violation.detail
+        )
+      })
+      .collect();
+    report.sort();
+    report.dedup();
+    let owners: BTreeSet<&str> = violations
+      .iter()
+      .map(|(_, _, violation)| violation.owner.as_str())
+      .collect();
+    panic!(
+      "{} span-extent violations over {} node types — their spans are lookahead positions, not \
+       token extents:\n{}\nnode types: {owners:?}",
+      violations.len(),
+      owners.len(),
+      report.join("\n")
+    );
+  }
+
+  assert_eq!(
+    padded_owners, compact_owners,
+    "the padded sweep and the compact corpus disagree about which node types exist"
+  );
+  assert!(
+    padded_owners.len() >= OWNER_FLOOR,
+    "the sweep reached {} span-carrying node types, below the floor of {OWNER_FLOOR}: {padded_owners:?}",
+    padded_owners.len()
+  );
+
+  let undiscriminated: Vec<&String> = padded_owners.difference(&discriminated).collect();
+  assert!(
+    undiscriminated.is_empty(),
+    "{} of the {} node types were never observed next to injected trivia, so nothing about their \
+     spans was actually at stake: {undiscriminated:?}",
+    undiscriminated.len(),
+    padded_owners.len()
+  );
+  assert!(
+    discriminating_spans * 2 >= total_spans,
+    "only {discriminating_spans} of {total_spans} spans sat at a junction where the two rules \
+     differ; padding at every boundary should put most of them there, so the injection has \
+     stopped reaching the interior"
+  );
+
+  println!(
+    "gate: {} entries x {} forms = {padded_parses} padded parses, {total_spans} spans, \
+     {discriminating_spans} at a discriminating junction, {} node types",
+    entries.len(),
+    ALPHABET.len(),
+    padded_owners.len()
+  );
+}
+
+/// The GraphQLx witness: a generic head and a `where` clause, the two junctions the dialect adds.
+///
+/// `"  type T <A> where A : Node { f : Int }  "`. Both are optional tails decided on the token
+/// after the one before them, so before the fix `TypePath`, `DefinitionTypeGenerics`,
+/// `WherePredicate` and `WhereClause` all closed at the following token's start — the largest
+/// single group in the thirty-three this dialect had.
+#[test]
+fn the_generics_witness() {
+  let src = "  type T <A> where A : Node { f : Int }  ";
+  let ext = extents(src);
+  let doc = parse(src).expect("the witness parses");
+  let spans = spans_of(&format!("{doc:#?}"));
+
+  let of = |owner: &str| -> (usize, usize) {
+    let found: Vec<&FoundSpan> = spans.iter().filter(|span| span.owner == owner).collect();
+    assert_eq!(found.len(), 1, "{owner} appears {} times", found.len());
+    (found[0].start, found[0].end)
+  };
+
+  // `<A>` closes on `>`, not on `where`.
+  assert_eq!(of("DefinitionTypeGenerics"), (9, 12));
+  // `A : Node` closes on `Node`, not on `{`.
+  assert_eq!(of("WherePredicate"), (19, 27));
+  assert_eq!(of("WhereClause"), (13, 27));
+  // And the document opens on `type`, not at input position 0.
+  assert_eq!(of("Document"), (2, 39));
+
+  assert!(
+    check(src, &spans, &ext).is_empty(),
+    "the witness still violates the extent invariant: {:?}",
+    check(src, &spans, &ext)
+  );
+}


### PR DESCRIPTION
Closes #68.