### PR TITLE
docs: declare [package.metadata.docs.rs], and gate the config that expands doc(cfg)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,26 @@ jobs:
   # a comment. Both are needed, and neither subsumes the other: the two links this
   # job was added for failed under `--all-features`, while the two in `smear`'s
   # facade were invisible there and only the single-dialect legs saw them.
+  #
+  # A third leg joined them in #65, on the same principle and for a different class:
+  # `--cfg docsrs`, which is the only configuration that expands a `doc(cfg(...))` at
+  # all. Read the steps for the reasoning; the short version is that both legs above
+  # compile every `#[cfg_attr(docsrs, doc(cfg(...)))]` in the workspace away to nothing
+  # and therefore cannot tell a correct one from a misapplied one, while docs.rs builds
+  # WITH the cfg. Its two steps also gate the two halves of that mechanism separately —
+  # the attributes being right, and the manifests telling docs.rs to pass the cfg — for
+  # the reason recorded on the second one.
+  #
+  # WHY ALL OF THIS IS IN `ci.yml`. The same test `byte-identity` above applies:
+  # `macos.yml` and `miri.yml` exist to hold legs that are queue-bound or set their own clock, so
+  # that this workflow can reach a conclusion. A `cargo doc --no-deps` run is neither —
+  # it is a couple of minutes of compilation whose verdict is a property of the source,
+  # not of the host, and rustdoc's output does not vary by platform. A second OS row
+  # would buy no information, and putting the leg behind the macOS queue would surface a
+  # broken badge hours after the pull request that broke it. It also belongs in this
+  # *job* rather than a new one: the three legs are one gate family that differ only in
+  # the rustdoc configuration under test, and they share a checkout and a warm target
+  # directory.
   docs:
     name: docs
     runs-on: ubuntu-latest
@@ -329,6 +349,128 @@ jobs:
 
           echo "::endgroup::"
         done
+
+    # ── The docs.rs configuration ──────────────────────────────────────────────
+    #
+    # The ONLY leg that expands `doc(cfg(...))`. `#[cfg_attr(docsrs, doc(cfg(...)))]`
+    # is inert without `--cfg docsrs`, so the two steps above compile every one of
+    # them away to nothing — a misapplied attribute and a correct one look identical
+    # to them. docs.rs builds WITH the cfg, which is the entire reason the idiom
+    # exists, so a fault only this leg can see is a real published-docs failure found
+    # after publication.
+    #
+    # tokora hit exactly that in its #195: ten attributes sat on block expressions
+    # rather than on items and took `cargo +nightly doc` to exit 101 while every other
+    # gate was green. smear's own instance was the mirror image (#65) — the attributes
+    # were correct and no manifest declared `[package.metadata.docs.rs]`, so docs.rs
+    # never passed the cfg and the badges had never rendered. Same silence, opposite
+    # mechanism; this step and the one after it are the two halves.
+    #
+    # Nightly, because `doc(cfg)` is a nightly feature and the crates gate it behind
+    # `#![cfg_attr(docsrs, feature(doc_cfg))]` — the same toolchain docs.rs uses.
+    #
+    # `--workspace --all-features` rather than the three published crates by name:
+    # `all-features = true` is what every publishable manifest declares, so this is
+    # literally the command docs.rs runs, and naming crates would leave the next one
+    # added uncovered until somebody remembered to extend a list.
+    - name: Install Rust (nightly, for the docs.rs configuration)
+      run: rustup toolchain install nightly --no-self-update
+    - name: RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features --no-deps
+      env:
+        RUSTDOCFLAGS: --cfg docsrs -D warnings
+      run: |
+        set -euo pipefail
+        TD="${CARGO_TARGET_DIR:-target}"
+        rm -rf "$TD/doc"
+        cargo +nightly doc --workspace --all-features --no-deps
+
+        for page in smear smear_lexer smear_parser; do
+          if [ ! -f "$TD/doc/$page/index.html" ]; then
+            echo "::error::cargo +nightly doc --cfg docsrs exited 0 but wrote no page for $page"
+            exit 1
+          fi
+        done
+
+        # The assertion that makes this leg self-verifying, and it is not decoration.
+        # Everything above still exits 0 if `--cfg docsrs` never reaches rustdoc — a
+        # typo in the env key, a `RUSTDOCFLAGS` overwritten by a later edit, the flag
+        # dropped in a refactor — and the result is a green leg that expands nothing,
+        # which is precisely the inert state #65 was about. The rendered badge is the
+        # only direct evidence the cfg was in effect.
+        #
+        # A floor of one, deliberately, not a per-attribute census. `--cfg docsrs` is
+        # all-or-nothing for an invocation, so one badge proves the mechanism for all
+        # of them; the per-attribute failure is a MISAPPLIED attribute, and that is a
+        # hard error above, not a missing badge. A pinned count would red on every
+        # honest edit and buy nothing this does not already have.
+        #
+        # `|| true` inside the group, not after the pipe: `set -o pipefail` is on, and
+        # grep exits 1 when it matches nothing — which is the case this check exists to
+        # report, so it has to reach the `if` rather than kill the step first.
+        badges=$( { grep -rl 'Available on crate feature' "$TD/doc/smear_lexer" "$TD/doc/smear_parser" || true; } | wc -l )
+        echo "pages carrying a rendered doc(cfg) badge: $badges"
+        if [ "$badges" -lt 1 ]; then
+          echo "::error::cargo +nightly doc exited 0 but rendered no doc(cfg) badge — --cfg docsrs did not reach rustdoc, so every cfg_attr(docsrs, ...) in the workspace was compiled away and this leg tested nothing"
+          exit 1
+        fi
+
+    # The other half, and the half that would actually have caught #65. The step above
+    # passes `--cfg docsrs` itself, so it proves the ATTRIBUTES are right while saying
+    # nothing about whether docs.rs will ever pass the cfg — that is a property of the
+    # manifests, and for the whole life of the repository no manifest had it. A gate on
+    # the attributes alone would have stayed green through the entire defect.
+    #
+    # Derived from `cargo metadata` over every workspace member rather than a list of
+    # three crate names, so a crate added later is covered the day it is added. Keyed on
+    # `publish`: cargo reports `[]` for `publish = false` and null otherwise, so
+    # `smear-apollo-bench` — a bench harness docs.rs will never build — is skipped
+    # without being named.
+    - name: every publishable crate declares [package.metadata.docs.rs]
+      run: |
+        set -euo pipefail
+        META="${RUNNER_TEMP:-/tmp}/cargo-metadata.json"
+        cargo metadata --no-deps --format-version 1 > "$META"
+
+        # A quoted heredoc delimiter, so the shell expands nothing between here and
+        # `PY` and the script can use whichever quotes read best. `python3 -c '...'`
+        # cannot: the body would sit inside shell single quotes, and every quote in it
+        # would need escaping.
+        python3 - "$META" <<'PY'
+        import json, sys
+
+        with open(sys.argv[1]) as handle:
+            packages = json.load(handle)["packages"]
+
+        checked, missing = [], []
+        for pkg in packages:
+            # cargo reports `[]` for `publish = false` and null for a publishable crate.
+            if pkg.get("publish") == []:
+                continue
+            docsrs = (pkg.get("metadata") or {}).get("docs", {}).get("rs")
+            if docsrs is None:
+                missing.append(f'{pkg["name"]}: no [package.metadata.docs.rs] table')
+                continue
+            args = docsrs.get("rustdoc-args", [])
+            if "--cfg" not in args or "docsrs" not in args:
+                missing.append(f'{pkg["name"]}: rustdoc-args does not pass --cfg docsrs (got {args!r})')
+            else:
+                checked.append(pkg["name"])
+
+        for name in sorted(checked):
+            print(f'ok: {name} declares rustdoc-args = ["--cfg", "docsrs"]')
+
+        # A filter that matches everything leaves nothing to check and still exits 0,
+        # which is the shape of green this whole issue is about.
+        if not checked and not missing:
+            print("::error::no publishable workspace member was checked, so this gate proved nothing")
+            sys.exit(1)
+
+        for problem in missing:
+            print(f"::error::{problem}")
+        if missing:
+            print("::error::without that table docs.rs does not pass --cfg docsrs, so every cfg_attr(docsrs, doc(cfg(...))) in the crate is inert ON DOCS.RS, not merely in CI — see #65")
+            sys.exit(1)
+        PY
 
   # Build with exactly the MSRV declared in Cargo.toml's `rust-version`, so
   # a floor that silently drifts above the declared value is caught here

--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ shall be dual licensed as above, without any additional terms or conditions.
 [CI-url]: https://github.com/al8n/smear/actions/workflows/ci.yml
 [codecov-url]: https://app.codecov.io/gh/al8n/smear
 [doc-url]: https://docs.rs/smear
-[crates-url]: https://crates.io/smear
+[crates-url]: https://crates.io/crates/smear

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -14,7 +14,7 @@
 //! * the correctness gate itself — error-free parse, byte-exact round-trip, non-trivial node
 //!   counts — which decides which entries are eligible to be timed at all.
 //!
-//! Nothing here is timed. [`benches/apollo_comparison.rs`] does the timing and calls into this.
+//! Nothing here is timed. `benches/apollo_comparison.rs` does the timing and calls into this.
 
 use core::hint::black_box;
 

--- a/smear-lexer/Cargo.toml
+++ b/smear-lexer/Cargo.toml
@@ -69,3 +69,17 @@ required-features = ["std", "graphql"]
 
 [lints]
 workspace = true
+
+# See `smear/Cargo.toml` for why this block exists at all (#65).
+#
+# `all-features = true`, and this is the crate where that setting is load-bearing rather than
+# merely harmless: the workspace's only two `doc(cfg)` attributes outside `smear-parser` sit on
+# the `graphql` and `graphqlx` modules here, and a build that leaves a dialect out does not
+# compile the module its badge is attached to. Documenting one dialect would therefore render one
+# badge and silently drop the other — the same "the attribute is there and the page disagrees"
+# shape #65 is about. Everything else this crate declares is a consumer-facing source-type
+# backing (`bytes`, `bstr`, `hipstr`, `smol-bytes`) or an allocation tier; nothing here is
+# test-only.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/smear-parser/Cargo.toml
+++ b/smear-parser/Cargo.toml
@@ -100,3 +100,33 @@ name = "graphqlx"
 path = "benches/graphqlx.rs"
 harness = false
 required-features = ["graphqlx"]
+
+# See `smear/Cargo.toml` for why this block exists at all (#65). This is the crate where
+# `all-features` was genuinely in question, so the decision is recorded rather than assumed.
+#
+# The two dialects are not the tension they look like. `graphql` and `graphqlx` are BOTH in
+# `default`, so a page carrying both is the surface a reader gets from `cargo add smear-parser`,
+# not an exotic union nobody compiles. `rowan` has to be on for an unrelated reason: it gates the
+# whole lossless CST tower, a headline consumer feature that would otherwise be absent from the
+# page entirely.
+#
+# `test-support` is the entry that looks wrong and is not. Leaving it out would stop
+# `lossless::test_support` being compiled, and that module is documented ON PURPOSE — its own
+# header argues the case, `KindSpace` being a public unsealed extension point whose invariants are
+# stated in prose and enforced nowhere else — and it carries
+# `#[cfg_attr(docsrs, doc(cfg(feature = "test-support")))]`, a badge that renders only in a build
+# that enables the feature. Excluding it here would leave that attribute inert on docs.rs, which
+# is #65's own defect reproduced one level down inside its fix. It does not drag the 68
+# per-production drivers onto the page either: every `test_support` under a *dialect* is
+# `#[doc(hidden)]`, so the feature adds exactly one documented item.
+#
+# `lossless-coverage` is the one awkward inclusion — it exports six instrumentation items nobody
+# ships. The answer to that is the `doc(cfg)` badge now on them in `src/lossless/coverage.rs`,
+# NOT a hand-written `features = [...]`. A literal list documents the features somebody
+# remembered on the day they wrote it, and the next feature added to this manifest would be
+# missing from docs.rs with nothing anywhere reporting it — the same silence as #65, one release
+# later. Keeping `all-features` also keeps the CI leg and the published build the same command,
+# so the gate tests the configuration docs.rs actually runs.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/smear-parser/src/lib.rs
+++ b/smear-parser/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, allow(unused_attributes))]
 #![allow(clippy::type_complexity)]
 #![deny(missing_docs)]
 

--- a/smear-parser/src/lossless/coverage.rs
+++ b/smear-parser/src/lossless/coverage.rs
@@ -54,10 +54,17 @@
 //! gate rows; the alternative — a wrapper compiled always and neutered by a `cfg` inside — puts a
 //! type the shipped parser does not need into the shipped parser's monomorphization for no gain.
 
+// Badged for the same reason `lossless::test_support` is. This module is `pub mod`
+// unconditionally while every item in it is behind the feature, so on a docs.rs page built with
+// `all-features = true` these six read as ordinary public API. The badge is the only thing that
+// says otherwise — and it renders only under `--cfg docsrs`, which is what
+// `[package.metadata.docs.rs]` in this crate's manifest makes docs.rs pass.
 #[cfg(feature = "lossless-coverage")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lossless-coverage")))]
 pub use counter::{hits, hits_of, reset};
 
 #[cfg(feature = "lossless-coverage")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lossless-coverage")))]
 pub use instrumented::{Counted, node, node_at};
 
 /// The thread-local tally, one lane per kind space.

--- a/smear/Cargo.toml
+++ b/smear/Cargo.toml
@@ -30,3 +30,19 @@ smallvec = ["smear-lexer/smallvec", "smear-parser/smallvec"]
 tokora.workspace = true
 smear-lexer.workspace = true
 smear-parser.workspace = true
+
+# Without this block docs.rs does not pass `--cfg docsrs`, so every
+# `#[cfg_attr(docsrs, doc(cfg(...)))]` in the workspace expands to nothing — on docs.rs ITSELF,
+# not merely in CI. That was the state until #65: the attributes were written correctly and the
+# badges they exist to render had never once appeared. `rustdoc-args` is the half that makes them
+# expand; `all-features` is the half that decides the surface they are expanded over, and it is a
+# per-crate decision rather than a paste — see `smear-parser/Cargo.toml` for the one that was
+# actually in question.
+#
+# Here there is nothing to weigh. Every feature this facade declares is consumer-facing — the two
+# dialects (both already in `default`), the allocation tiers, and the source-type backings — and
+# it declares no test-only feature at all, so there is no subset that documents less and loses
+# nothing.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Closes #65.
