### PR TITLE
test(parser): the span gates run the invalid corpora, under a recovering emitter

### DIFF
--- a/smear-parser/tests/support/span_extent.rs
+++ b/smear-parser/tests/support/span_extent.rs
@@ -38,7 +38,9 @@
 //!   between two tokens. Weaker than the non-empty rule on purpose: a zero-width span records a
 //!   *position*, and the two candidate positions on either side of a run of trivia are both
 //!   defensible, so pinning it tighter than "not in the middle of the whitespace" would be pinning
-//!   a choice rather than a fact.
+//!   a choice rather than a fact. A source the lexer yields **no token at all** for — an empty
+//!   file, a comment-only one, one the lexer rejects on its first byte — has no boundaries for the
+//!   rule to name, and there the two input edges are the only positions there are; see [`check`].
 //! - `not-contained` — a node's span lies inside its parent's. Free from the walk's nesting, and
 //!   the check that catches an endpoint that ran past the construct it belongs to.
 //!
@@ -214,7 +216,19 @@ pub struct Extents {
 /// Every way `spans` fails the extent invariant against `extents`.
 ///
 /// An empty result is the pass. `src` is used only to quote the offending bytes in the message.
+///
+/// # The tokenless source
+///
+/// `empty-off-boundary` asks whether a zero-width span sits on a token boundary, and a source the
+/// lexer yields **no** token for has none: an empty file, a comment-only one, a byte the lexer
+/// refuses outright. The invalid corpora contain all three, and a parse of one under a recovering
+/// emitter still produces a document node — a zero-width one, because there is nothing for it to
+/// contain. The only two positions such a node can carry are the input's own edges, so both are
+/// accepted **and only when the token set is empty**: with even one token in the source the
+/// ordinary rule applies at offset 0 like anywhere else, so an optional-collection marker parked in
+/// front of a leading run of trivia is still named. `the_checker_can_answer_no` pins both halves.
 pub fn check(src: &str, spans: &[FoundSpan], extents: &Extents) -> Vec<Violation> {
+  let tokenless = extents.starts.is_empty() && extents.ends.is_empty();
   let mut out = Vec::new();
   let mut note = |owner: &str, rule: &'static str, detail: String| {
     out.push(Violation {
@@ -252,7 +266,10 @@ pub fn check(src: &str, spans: &[FoundSpan], extents: &Extents) -> Vec<Violation
           format!("{where_} — closes past its last token, in the ignorable bytes that follow"),
         );
       }
-    } else if !extents.starts.contains(&span.start) && !extents.ends.contains(&span.start) {
+    } else if !extents.starts.contains(&span.start)
+      && !extents.ends.contains(&span.start)
+      && !(tokenless && (span.start == 0 || span.start == src.len()))
+    {
       note(
         &span.owner,
         "empty-off-boundary",

--- a/smear-parser/tests/syntactic_span_extent.rs
+++ b/smear-parser/tests/syntactic_span_extent.rs
@@ -49,6 +49,30 @@
 //! makes about `#[derive(Debug)]`'s output, and [`the_checker_can_answer_no`] feeds
 //! [`extent::check`] a span that is wrong in each of the four ways and requires it to say so. The
 //! sweep below is only as good as those two.
+//!
+//! # The other half of the corpus, and the emitter it needs — issue #75
+//!
+//! Everything above runs the `valid_` entries, which parse to completion, so **no recovery path is
+//! exercised anywhere in it**. The `invalid_` entries are the other half of the same corpus and the
+//! gate was silent about them, which is what made #75 — "does the span wrapper shorten a recovered
+//! delimited node?" — unanswerable by running the suite.
+//!
+//! Answering it needs an emitter that recovers. The shipped syntactic entry points pin
+//! [`Fatal`](tokora::emitter::Fatal), under which the first close-miss becomes an `Err` and no tree
+//! exists to measure; but every production in this dialect is generic over its context, so a
+//! recording emitter is one type alias away and is what a consumer wanting partial trees will
+//! reach for. [`RecoveringCtx`] is that alias, and
+//! [`recovered_spans_are_token_extents_over_the_invalid_corpus`] runs the same four-part check and
+//! the same liveness floor over the `invalid_` half under it.
+//!
+//! [`a_recovered_group_ends_at_its_last_token_not_at_the_recovery_cursor`] is #75's own
+//! measurement. tokora's delimited shapes span a recovered construct with
+//! [`span_since`](tokora::InputRef::span_since) — cursor to cursor — so a group closed by
+//! recovery ends at the **live lookahead cursor**, which at a wrong closer is that token's start.
+//! `token_spanned` overrides it with the token extent, and the two differ by exactly the trivia in
+//! between. The witness pins which of the two readings is right *in the lexer's terms*: the
+//! recovery cursor is an offset the lexer reports as a token **start** and not a token **end**, so
+//! the cursor reading is `end-not-token-end` — the #68 defect — and the checker is made to say so.
 
 use std::{collections::BTreeSet, path::PathBuf};
 
@@ -59,7 +83,9 @@ use smear_parser::graphql::{
   error::GraphqlErrors,
   syntactic::{GraphqlLexer, document},
 };
-use tokora::{Lexer as _, Parse as _, Parser, SimpleSpan};
+use tokora::{
+  Lexer as _, Parse as _, Parser, ParserContext, SimpleSpan, cache::DefaultCache, emitter::Verbose,
+};
 
 #[path = "support/span_extent.rs"]
 mod extent;
@@ -73,12 +99,86 @@ use extent::{ALPHABET, Extents, FoundSpan, Violation, check, discriminating, inj
 /// written.
 const OWNER_FLOOR: usize = 68;
 
-/// Parses one source through the syntactic GraphQL document root.
+/// The smallest number of `invalid_` entries the shared corpus is allowed to hold.
+///
+/// The measurement on the day the invalid sweep was written, as a floor. Deleting an invalid entry
+/// shrinks the only corpus that reaches a recovery path.
+const INVALID_ENTRY_FLOOR: usize = 31;
+
+/// The smallest number of `invalid_` entries the **lexer** accepts.
+///
+/// The rest are the `invalid_lex_*` class, which has no token extents to be measured against. A
+/// grammar-level invalid entry turning into a lexer-level one would silently shrink the sweep.
+const LEXABLE_INVALID_FLOOR: usize = 27;
+
+/// The smallest number of invalid variants (compact plus padded) that must **recover** into a tree.
+///
+/// The liveness floor for the recovery dimension: with no recovered parse the invalid sweep checks
+/// nothing at all and every assertion in it passes vacuously.
+const RECOVERED_VARIANT_FLOOR: usize = 45;
+
+/// The smallest number of distinct span-carrying node types the recovered invalid parses reach.
+const RECOVERED_OWNER_FLOOR: usize = 8;
+
+/// Parses one source through the syntactic GraphQL document root, fail-fast — the shipped wiring.
 fn parse(src: &str) -> Result<Document<&str>, GraphqlErrors<&str>> {
   Parser::with_parser::<'_, GraphqlLexer<'_, str>, Document<&str>, GraphqlErrors<&str>, _, GraphQL>(
     document,
   )
   .parse_str(src)
+}
+
+/// The recording emitter the invalid-corpus sweep runs under: the same one the lossless tower
+/// pins, over this dialect's syntactic error container.
+///
+/// `Verbose`'s third parameter is the grammar brand, and `Emitter<'inp, L, Lang>` is implemented
+/// only where it matches — a bare `Verbose::default()` leaves it at `()` and the context then
+/// fails to be a `ParseContext<…, GraphQL>`.
+type RecoveringEmitter<'inp> = Verbose<GraphqlErrors<&'inp str>, SimpleSpan, GraphQL>;
+
+/// The context [`parse_recovering`] drives: this dialect's syntactic productions with the
+/// close-miss diagnostics *recorded* rather than raised.
+///
+/// Not a shipped configuration — the entry points pin `Fatal` — but a reachable one, because the
+/// productions are public and generic over `Ctx`. It is also the only configuration in which a
+/// recovery span exists at all, so it is what #75 has to be answered in.
+type RecoveringCtx<'inp> = ParserContext<
+  'inp,
+  GraphqlLexer<'inp, str>,
+  RecoveringEmitter<'inp>,
+  DefaultCache<'inp, GraphqlLexer<'inp, str>>,
+  GraphQL,
+>;
+
+/// Parses one source through the same document root with a **recovering** emitter.
+///
+/// An `Ok` here over a source [`parse`] rejects is the definition of a recovered parse: the two
+/// wirings differ in nothing but whether an emitted diagnostic becomes an `Err`.
+fn parse_recovering(src: &str) -> Result<Document<&str>, GraphqlErrors<&str>> {
+  Parser::with_parser_and_context::<
+    '_,
+    GraphqlLexer<'_, str>,
+    Document<&str>,
+    RecoveringCtx<'_>,
+    _,
+    GraphQL,
+  >(document, ParserContext::of(RecoveringEmitter::default()))
+  .parse_str(src)
+}
+
+/// Does the **lexer** accept `src` end to end?
+///
+/// The `invalid_lex_*` class does not, and for those there are no token extents to measure a span
+/// against — the yardstick itself is missing. The sweep classifies them out rather than guessing;
+/// `lossless_parity.rs` is where that class is held.
+fn lexes(src: &str) -> bool {
+  let mut lexer = SyntacticLexer::<str>::new(src);
+  while let Some(result) = lexer.lex() {
+    if result.is_err() {
+      return false;
+    }
+  }
+  true
 }
 
 /// Every token's start and end, from the **lexer**.
@@ -102,15 +202,15 @@ fn boundaries(src: &str) -> Vec<usize> {
   let mut lexer = SyntacticLexer::<str>::new(src);
   let mut out = vec![0usize];
   while let Some(result) = lexer.lex() {
-    result.unwrap_or_else(|e| panic!("a valid corpus entry must lex: {e:?}"));
+    result.unwrap_or_else(|e| panic!("a corpus entry the sweep pads must lex: {e:?}"));
     out.push(lexer.span().end());
   }
   out.dedup();
   out
 }
 
-/// The `valid_` half of the shared GraphQL corpus, in a deterministic order.
-fn valid_corpus() -> Vec<(String, String)> {
+/// One half of the shared GraphQL corpus, selected by file-name prefix, in a deterministic order.
+fn corpus(prefix: &str) -> Vec<(String, String)> {
   let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
     .join("tests")
     .join("corpus");
@@ -121,7 +221,7 @@ fn valid_corpus() -> Vec<(String, String)> {
     .filter(|path| {
       path
         .file_name()
-        .is_some_and(|name| name.to_string_lossy().starts_with("valid_"))
+        .is_some_and(|name| name.to_string_lossy().starts_with(prefix))
     })
     .collect();
   files.sort();
@@ -138,6 +238,16 @@ fn valid_corpus() -> Vec<(String, String)> {
       (name, src)
     })
     .collect()
+}
+
+/// The `valid_` half of the shared GraphQL corpus.
+fn valid_corpus() -> Vec<(String, String)> {
+  corpus("valid_")
+}
+
+/// The `invalid_` half — the entries the shipped parser rejects and the sweep above never touches.
+fn invalid_corpus() -> Vec<(String, String)> {
+  corpus("invalid_")
 }
 
 /// The one assumption the span walk makes about `#[derive(Debug)]`, measured rather than trusted.
@@ -284,6 +394,58 @@ fn the_checker_can_answer_no() {
   // followed by trivia and so is discriminating, while the whole-source span is flanked by nothing.
   assert!(discriminating(&good[1], &ext, src.len()));
   assert!(!discriminating(&good[0], &ext, src.len()));
+
+  // The tokenless carve-out, both halves. A comment-only source has no token boundaries at all, so
+  // the empty document node the recovering parse produces there can only sit on an input edge —
+  // both of which are accepted. Anywhere else in the same source is still named, so the carve-out
+  // cannot be mistaken for "zero-width spans are unchecked".
+  let bare = "# c\n";
+  let bare_ext = extents(bare);
+  assert!(
+    bare_ext.starts.is_empty() && bare_ext.ends.is_empty(),
+    "a comment-only source must lex to no tokens for this control to be about anything"
+  );
+  let at = |offset: usize| -> Vec<&'static str> {
+    check(
+      bare,
+      &[FoundSpan {
+        owner: "Empty".into(),
+        parent: None,
+        start: offset,
+        end: offset,
+      }],
+      &bare_ext,
+    )
+    .iter()
+    .map(|violation: &Violation| violation.rule)
+    .collect()
+  };
+  assert!(at(0).is_empty(), "offset 0 is an input edge");
+  assert!(at(bare.len()).is_empty(), "the end is the other edge");
+  assert_eq!(
+    at(2),
+    ["empty-off-boundary"],
+    "an interior offset is still inside the trivia, tokens or no tokens"
+  );
+  // And the carve-out is scoped to the tokenless case: with a token in the source, offset 0 in
+  // front of a leading run of trivia is named exactly as before.
+  let leading = extents(" a");
+  assert_eq!(
+    check(
+      " a",
+      &[FoundSpan {
+        owner: "Empty".into(),
+        parent: None,
+        start: 0,
+        end: 0
+      }],
+      &leading
+    )
+    .iter()
+    .map(|violation: &Violation| violation.rule)
+    .collect::<Vec<_>>(),
+    ["empty-off-boundary"],
+  );
 }
 
 /// The gate proper: every span in every padded parse is the extent of its own tokens, and every
@@ -439,6 +601,306 @@ fn trivia_injection_leaves_every_span_on_its_own_tokens() {
     ALPHABET.len(),
     padded_owners.len()
   );
+}
+
+/// The `invalid_` half, under a recovering emitter: every span a **recovered** parse produces is
+/// still the extent of its own tokens, and every node type reached was reached where the two span
+/// rules disagree.
+///
+/// The sweep the `valid_` half cannot do. Those entries parse to completion, so nothing in them
+/// enters a recovery path; these do nothing else. What comes out is not one tree per entry —
+/// smear's own productions raise most of their diagnostics as `Err` rather than through the
+/// emitter, so a recovering context rescues only the parses whose miss is a *tokora-owned*
+/// close-miss — and the counters below say how many, so a change that quietly stops recovering
+/// turns this red instead of leaving a smaller green number.
+#[test]
+fn recovered_spans_are_token_extents_over_the_invalid_corpus() {
+  let entries = invalid_corpus();
+  assert!(
+    entries.len() >= INVALID_ENTRY_FLOOR,
+    "only {} invalid corpus entries, below the floor of {INVALID_ENTRY_FLOOR}",
+    entries.len()
+  );
+
+  let mut lexable = 0usize;
+  let mut lexer_rejected = 0usize;
+  let mut padded_variants = 0usize;
+  let mut recovered = 0usize;
+  let mut compact_recovered = 0usize;
+  let mut violations: Vec<(String, String, Violation)> = Vec::new();
+  let mut compact_owners: BTreeSet<String> = BTreeSet::new();
+  let mut padded_owners: BTreeSet<String> = BTreeSet::new();
+  let mut discriminated: BTreeSet<String> = BTreeSet::new();
+  let mut discriminating_spans = 0usize;
+  let mut total_spans = 0usize;
+
+  let mut measure = |name: &String,
+                     form: &str,
+                     variant: &str,
+                     owners: &mut BTreeSet<String>,
+                     violations: &mut Vec<(String, String, Violation)>|
+   -> bool {
+    let Ok(doc) = parse_recovering(variant) else {
+      return false;
+    };
+    let spans = spans_of(&format!("{doc:#?}"));
+    assert!(
+      !spans.is_empty(),
+      "{name} [{form}]: the parse recovered but the walk found no spans, so this variant was \
+       checked for nothing"
+    );
+    let ext = extents(variant);
+    for violation in check(variant, &spans, &ext) {
+      violations.push((name.clone(), form.to_string(), violation));
+    }
+    owners.extend(extent::owners(&spans));
+    if form != "compact" {
+      total_spans += spans.len();
+      for span in &spans {
+        if discriminating(span, &ext, variant.len()) {
+          discriminating_spans += 1;
+          discriminated.insert(span.owner.clone());
+        }
+      }
+    }
+    true
+  };
+
+  for (name, src) in &entries {
+    // The corpus's own claim about itself. An `invalid_` entry the shipped fail-fast parser
+    // accepts is a corpus fault, and it would also make every "recovered" count below a lie.
+    assert!(
+      parse(src).is_err(),
+      "{name}: the shipped fail-fast parser accepts it, so it is not an `invalid_` entry"
+    );
+
+    // The `invalid_lex_*` class: the lexer refuses these, so there are no token extents to hold a
+    // span against — the yardstick itself is absent, and guessing one would be the circularity
+    // this gate exists to avoid.
+    if !lexes(src) {
+      lexer_rejected += 1;
+      continue;
+    }
+    lexable += 1;
+
+    if measure(name, "compact", src, &mut compact_owners, &mut violations) {
+      compact_recovered += 1;
+      recovered += 1;
+    }
+
+    let marks = boundaries(src);
+    for (form, pad) in ALPHABET {
+      let padded_src = inject(src, &marks, pad);
+      assert_eq!(
+        padded_src.len(),
+        src.len() + marks.len() * pad.len(),
+        "{name} padded with {form}: the injection did not land at every boundary"
+      );
+      assert!(
+        lexes(&padded_src),
+        "{name} padded with {form}: injecting at a token boundary made the source unlexable"
+      );
+      padded_variants += 1;
+      if measure(name, form, &padded_src, &mut padded_owners, &mut violations) {
+        recovered += 1;
+      }
+    }
+  }
+
+  if !violations.is_empty() {
+    let mut report: Vec<String> = violations
+      .iter()
+      .map(|(name, form, violation)| {
+        format!(
+          "  {name} [{form}] {} — {} — {}",
+          violation.owner, violation.rule, violation.detail
+        )
+      })
+      .collect();
+    report.sort();
+    report.dedup();
+    let owners: BTreeSet<&str> = violations
+      .iter()
+      .map(|(_, _, violation)| violation.owner.as_str())
+      .collect();
+    panic!(
+      "{} span-extent violations over {} node types in recovered parses — a recovered node's span \
+       is still the extent of the tokens it holds, not the position recovery stopped at:\n{}\nnode \
+       types: {owners:?}",
+      violations.len(),
+      owners.len(),
+      report.join("\n")
+    );
+  }
+
+  // The recovery floor. Nothing above fires if no parse ever recovers — the sweep would report
+  // success over an empty set — so the number of recovered variants is pinned, as is the fact
+  // that some of them recovered without any padding at all.
+  assert!(
+    recovered >= RECOVERED_VARIANT_FLOOR,
+    "only {recovered} of {} variants recovered into a tree, below the floor of \
+     {RECOVERED_VARIANT_FLOOR}; the sweep has stopped reaching the recovery paths",
+    padded_variants + lexable
+  );
+  assert!(
+    compact_recovered > 0,
+    "no unpadded invalid entry recovered, so every recovery below depends on the injection"
+  );
+  assert_eq!(
+    lexable + lexer_rejected,
+    entries.len(),
+    "every invalid entry is either lexable or lexer-rejected"
+  );
+  assert!(
+    lexable >= LEXABLE_INVALID_FLOOR,
+    "only {lexable} invalid entries lex, below the floor of {LEXABLE_INVALID_FLOOR}"
+  );
+
+  // Reach, and the liveness floor — the same two the `valid_` sweep carries. The padded set is
+  // held to a floor rather than to the compact set: padding can change whether an entry recovers
+  // at all, which is the one way this half differs from the other.
+  assert!(
+    padded_owners.len() >= RECOVERED_OWNER_FLOOR,
+    "the recovered sweep reached {} span-carrying node types, below the floor of \
+     {RECOVERED_OWNER_FLOOR}: {padded_owners:?}",
+    padded_owners.len()
+  );
+  assert!(
+    compact_owners.is_subset(&padded_owners),
+    "padding lost a node type the unpadded invalid entries reach: {:?}",
+    compact_owners
+      .difference(&padded_owners)
+      .collect::<Vec<_>>()
+  );
+  let undiscriminated: Vec<&String> = padded_owners.difference(&discriminated).collect();
+  assert!(
+    undiscriminated.is_empty(),
+    "{} of the {} node types in recovered parses were never observed next to injected trivia, so \
+     nothing about their spans was actually at stake: {undiscriminated:?}",
+    undiscriminated.len(),
+    padded_owners.len()
+  );
+  assert!(
+    discriminating_spans * 2 >= total_spans,
+    "only {discriminating_spans} of {total_spans} spans sat at a junction where the two rules \
+     differ; padding at every boundary should put most of them there"
+  );
+
+  println!(
+    "gate: {} invalid entries ({lexable} lexable, {lexer_rejected} lexer-rejected) x {} forms = \
+     {padded_variants} padded variants, {recovered} recovered ({compact_recovered} unpadded), \
+     {total_spans} spans, {discriminating_spans} at a discriminating junction, {} node types",
+    entries.len(),
+    ALPHABET.len(),
+    padded_owners.len()
+  );
+}
+
+/// Issue #75's own measurement: where a **recovered** delimited node ends, pinned to the byte and
+/// adjudicated in the lexer's terms.
+///
+/// Two shapes, both a bracket group closed by a `)` with a space in front of it — the value list
+/// inside an argument list, and the list *type* inside a variables definition. tokora reports the
+/// wrong token through the emitter and recovers with a `]` synthesized at the live cursor, spanning
+/// the group with [`span_since`](tokora::InputRef::span_since) — cursor to cursor — so its own
+/// answer ends at the `)`'s start. `token_spanned` overrides that with the token extent, one token
+/// short.
+///
+/// #75 read the override as a shortening bug. It is the opposite, and the **lexer** settles it
+/// without anyone asking the parser: the recovery cursor is an offset the lexer reports as a token
+/// *start* and never as a token *end*, so a node closing there closes in the ignorable byte before
+/// its neighbour — `end-not-token-end`, which is issue #68 exactly. Each case makes
+/// [`extent::check`] say so about the cursor reading, and say nothing about the extent reading.
+///
+/// Why these two and not an object or a selection set, which #75 also names: in this dialect they
+/// cannot be driven into a surviving wrong-closer recovery at all. `decide_object_field_head` and
+/// the selection-head dispatcher raise their rejection as an `Err` rather than through the emitter,
+/// so the parse dies before tokora's close-miss law runs. Only a group whose wrong closer is the
+/// *enclosing* construct's real closer survives, which is what both cases below are.
+#[test]
+fn a_recovered_group_ends_at_its_last_token_not_at_the_recovery_cursor() {
+  /// `src`, the node the recovery lands on, its token extent, and the recovery cursor the other
+  /// reading would have closed at.
+  fn witness(src: &str, owner: &str, extent: (usize, usize), cursor: usize) {
+    let ext = extents(src);
+
+    // It has to be a recovery, or the case is about nothing: the shipped wiring rejects it and
+    // the recording one returns a tree.
+    assert!(
+      parse(src).is_err(),
+      "{src:?}: the fail-fast parser must reject the witness, or no recovery happens in it"
+    );
+    let doc = parse_recovering(src).unwrap_or_else(|e| panic!("{src:?}: no recovered tree: {e:?}"));
+
+    let spans = spans_of(&format!("{doc:#?}"));
+    let found: Vec<&FoundSpan> = spans.iter().filter(|span| span.owner == owner).collect();
+    assert_eq!(
+      found.len(),
+      1,
+      "{src:?}: {owner} appears {} times",
+      found.len()
+    );
+    assert_eq!(
+      (found[0].start, found[0].end),
+      extent,
+      "{src:?}: the recovered {owner} must end at its last token, not at the closer it recovered \
+       against"
+    );
+
+    // The other reading, adjudicated by the lexer rather than by the parser.
+    assert!(
+      ext.starts.contains(&cursor) && !ext.ends.contains(&cursor),
+      "{src:?}: {cursor} must be a token start and not a token end for this witness to \
+       discriminate at all"
+    );
+    assert_eq!(
+      check(
+        src,
+        &[FoundSpan {
+          owner: owner.to_string(),
+          parent: None,
+          start: extent.0,
+          end: cursor,
+        }],
+        &ext,
+      )
+      .iter()
+      .map(|violation: &Violation| violation.rule)
+      .collect::<Vec<_>>(),
+      ["end-not-token-end"],
+      "{src:?}: ending a recovered group at the recovery cursor is #68's defect wearing a \
+       different hat"
+    );
+
+    // And the tree as parsed says nothing.
+    assert!(
+      check(src, &spans, &ext).is_empty(),
+      "{src:?}: the recovered witness violates the extent invariant: {:?}",
+      check(src, &spans, &ext)
+    );
+  }
+
+  // A list value: `[1 , 2` closes on the `2` it holds, not on the `)` at 14. Its enclosing argument
+  // list did *not* recover — that `)` is its real closer — so the recovery sits strictly inside a
+  // well-closed parent, and `not-contained` has something to be right about.
+  witness("{ f(a: [1 , 2 ) }", "List", (7, 13), 14);
+  let doc = parse_recovering("{ f(a: [1 , 2 ) }").expect("the witness recovers");
+  let spans = spans_of(&format!("{doc:#?}"));
+  let of = |owner: &str| -> (usize, usize) {
+    let found: Vec<&FoundSpan> = spans.iter().filter(|span| span.owner == owner).collect();
+    assert_eq!(found.len(), 1, "{owner} appears {} times", found.len());
+    (found[0].start, found[0].end)
+  };
+  assert_eq!(
+    of("ArgumentList"),
+    (3, 15),
+    "the parent closed on its real `)`"
+  );
+  assert_eq!(of("Argument"), (4, 13));
+
+  // A list *type*, a different production family reaching the same close-miss law: `[Int` closes
+  // on `Int`, not on the `)` at 17.
+  witness("query Q($v: [Int ) { f }", "ListType", (12, 16), 17);
 }
 
 /// Issue #68's own measurement, pinned to the byte.

--- a/smear-parser/tests/syntactic_x_span_extent.rs
+++ b/smear-parser/tests/syntactic_x_span_extent.rs
@@ -17,6 +17,19 @@
 //! `tests/support/graphqlx_padding.rs`; the two are deliberately not merged, because that module's
 //! boundary scan is defined over the **lossless** lexer and this gate's is defined over the
 //! syntactic one, and a gate about syntactic spans should measure syntactic tokens.
+//!
+//! # The `invalid_` half and the recovering emitter — issue #75
+//!
+//! The GraphQL twin's module docs carry the reasoning; the short of it is that the `valid_` sweep
+//! parses to completion and so exercises no recovery path at all, which is what made #75
+//! unanswerable by running the suite. [`RecoveringCtx`] is the recording context that gives the
+//! `invalid_` entries a tree to measure, and
+//! [`recovered_spans_are_token_extents_over_the_invalid_corpus`] holds them to the same four-part
+//! check and the same liveness floor.
+//!
+//! [`a_recovered_group_ends_at_its_last_token_not_at_the_recovery_cursor`] is this dialect's
+//! measurement of the question itself: a group closed by recovery ends at the token extent, not at
+//! the live cursor, and the lexer is what says so.
 
 use std::{collections::BTreeSet, path::PathBuf};
 
@@ -27,7 +40,9 @@ use smear_parser::graphqlx::{
   error::GraphqlxErrors,
   syntactic::{GraphqlxLexer, document},
 };
-use tokora::{Lexer as _, Parse as _, Parser};
+use tokora::{
+  Lexer as _, Parse as _, Parser, ParserContext, SimpleSpan, cache::DefaultCache, emitter::Verbose,
+};
 
 #[path = "support/span_extent.rs"]
 mod extent;
@@ -40,7 +55,16 @@ use extent::{ALPHABET, Extents, FoundSpan, Violation, check, discriminating, inj
 /// the dialect's extra surface showing up as extra node types rather than as extra entries.
 const OWNER_FLOOR: usize = 93;
 
-/// Parses one source through the syntactic GraphQLx document root.
+/// The floors the `invalid_` sweep carries — the GraphQL twin documents what each one is for.
+const INVALID_ENTRY_FLOOR: usize = 45;
+/// The smallest number of `invalid_` entries the **lexer** accepts.
+const LEXABLE_INVALID_FLOOR: usize = 41;
+/// The smallest number of invalid variants (compact plus padded) that must **recover** into a tree.
+const RECOVERED_VARIANT_FLOOR: usize = 81;
+/// The smallest number of distinct span-carrying node types the recovered invalid parses reach.
+const RECOVERED_OWNER_FLOOR: usize = 16;
+
+/// Parses one source through the syntactic GraphQLx document root, fail-fast — the shipped wiring.
 fn parse(src: &str) -> Result<Document<&str>, GraphqlxErrors<&str>> {
   Parser::with_parser::<
     '_,
@@ -51,6 +75,53 @@ fn parse(src: &str) -> Result<Document<&str>, GraphqlxErrors<&str>> {
     GraphQLx,
   >(document)
   .parse_str(src)
+}
+
+/// The recording emitter the invalid-corpus sweep runs under — the GraphQL twin explains the three
+/// type parameters and why the grammar brand has to be spelled.
+type RecoveringEmitter<'inp> = Verbose<GraphqlxErrors<&'inp str>, SimpleSpan, GraphQLx>;
+
+/// The context [`parse_recovering`] drives: this dialect's syntactic productions with the
+/// close-miss diagnostics *recorded* rather than raised.
+///
+/// Not a shipped configuration — the entry points pin `Fatal` — but a reachable one, because the
+/// productions are public and generic over `Ctx`, and the only one in which a recovery span exists.
+type RecoveringCtx<'inp> = ParserContext<
+  'inp,
+  GraphqlxLexer<'inp, str>,
+  RecoveringEmitter<'inp>,
+  DefaultCache<'inp, GraphqlxLexer<'inp, str>>,
+  GraphQLx,
+>;
+
+/// Parses one source through the same document root with a **recovering** emitter.
+///
+/// An `Ok` here over a source [`parse`] rejects is the definition of a recovered parse: the two
+/// wirings differ in nothing but whether an emitted diagnostic becomes an `Err`.
+fn parse_recovering(src: &str) -> Result<Document<&str>, GraphqlxErrors<&str>> {
+  Parser::with_parser_and_context::<
+    '_,
+    GraphqlxLexer<'_, str>,
+    Document<&str>,
+    RecoveringCtx<'_>,
+    _,
+    GraphQLx,
+  >(document, ParserContext::of(RecoveringEmitter::default()))
+  .parse_str(src)
+}
+
+/// Does the **lexer** accept `src` end to end?
+///
+/// The `invalid_lex_*` class does not, and for those there are no token extents to measure a span
+/// against — the yardstick itself is missing.
+fn lexes(src: &str) -> bool {
+  let mut lexer = SyntacticLexer::<str>::new(src);
+  while let Some(result) = lexer.lex() {
+    if result.is_err() {
+      return false;
+    }
+  }
+  true
 }
 
 /// Every token's start and end, from the **lexer** rather than from the tree under test.
@@ -70,15 +141,15 @@ fn boundaries(src: &str) -> Vec<usize> {
   let mut lexer = SyntacticLexer::<str>::new(src);
   let mut out = vec![0usize];
   while let Some(result) = lexer.lex() {
-    result.unwrap_or_else(|e| panic!("a valid corpus entry must lex: {e:?}"));
+    result.unwrap_or_else(|e| panic!("a corpus entry the sweep pads must lex: {e:?}"));
     out.push(lexer.span().end());
   }
   out.dedup();
   out
 }
 
-/// The `valid_` half of the GraphQLx corpus, in a deterministic order.
-fn valid_corpus() -> Vec<(String, String)> {
+/// One half of the GraphQLx corpus, selected by file-name prefix, in a deterministic order.
+fn corpus(prefix: &str) -> Vec<(String, String)> {
   let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
     .join("tests")
     .join("corpusx");
@@ -94,7 +165,7 @@ fn valid_corpus() -> Vec<(String, String)> {
     .filter(|path| {
       path
         .file_name()
-        .is_some_and(|name| name.to_string_lossy().starts_with("valid_"))
+        .is_some_and(|name| name.to_string_lossy().starts_with(prefix))
     })
     .collect();
   files.sort();
@@ -111,6 +182,16 @@ fn valid_corpus() -> Vec<(String, String)> {
       (name, src)
     })
     .collect()
+}
+
+/// The `valid_` half of the GraphQLx corpus.
+fn valid_corpus() -> Vec<(String, String)> {
+  corpus("valid_")
+}
+
+/// The `invalid_` half — the entries the shipped parser rejects and the sweep above never touches.
+fn invalid_corpus() -> Vec<(String, String)> {
+  corpus("invalid_")
 }
 
 /// The walk's assumption about `#[derive(Debug)]`, re-measured against the GraphQLx AST.
@@ -233,6 +314,55 @@ fn the_checker_can_answer_no() {
 
   assert!(discriminating(&good[1], &ext, src.len()));
   assert!(!discriminating(&good[0], &ext, src.len()));
+
+  // The tokenless carve-out, both halves — see the GraphQL twin. A comment-only source has no
+  // token boundaries, so only its two input edges can carry the empty document node a recovering
+  // parse produces there; anywhere else in it is still named, and a source with tokens is
+  // unaffected at offset 0.
+  let bare = "# c\n";
+  let bare_ext = extents(bare);
+  assert!(
+    bare_ext.starts.is_empty() && bare_ext.ends.is_empty(),
+    "a comment-only source must lex to no tokens for this control to be about anything"
+  );
+  let at = |offset: usize| -> Vec<&'static str> {
+    check(
+      bare,
+      &[FoundSpan {
+        owner: "Empty".into(),
+        parent: None,
+        start: offset,
+        end: offset,
+      }],
+      &bare_ext,
+    )
+    .iter()
+    .map(|violation: &Violation| violation.rule)
+    .collect()
+  };
+  assert!(at(0).is_empty(), "offset 0 is an input edge");
+  assert!(at(bare.len()).is_empty(), "the end is the other edge");
+  assert_eq!(
+    at(2),
+    ["empty-off-boundary"],
+    "an interior offset is still inside the trivia, tokens or no tokens"
+  );
+  assert_eq!(
+    check(
+      " a",
+      &[FoundSpan {
+        owner: "Empty".into(),
+        parent: None,
+        start: 0,
+        end: 0
+      }],
+      &extents(" a")
+    )
+    .iter()
+    .map(|violation: &Violation| violation.rule)
+    .collect::<Vec<_>>(),
+    ["empty-off-boundary"],
+  );
 }
 
 /// The gate proper: every span in every padded parse is the extent of its own tokens, and every
@@ -381,6 +511,252 @@ fn trivia_injection_leaves_every_span_on_its_own_tokens() {
     ALPHABET.len(),
     padded_owners.len()
   );
+}
+
+/// The `invalid_` half, under a recovering emitter: every span a **recovered** parse produces is
+/// still the extent of its own tokens, and every node type reached was reached where the two span
+/// rules disagree.
+///
+/// The GraphQL twin carries the reasoning. What differs here is only the size of the corpus and
+/// how far a recovering context gets through it, both of which the counters below pin.
+#[test]
+fn recovered_spans_are_token_extents_over_the_invalid_corpus() {
+  let entries = invalid_corpus();
+  assert!(
+    entries.len() >= INVALID_ENTRY_FLOOR,
+    "only {} invalid corpus entries, below the floor of {INVALID_ENTRY_FLOOR}",
+    entries.len()
+  );
+
+  let mut lexable = 0usize;
+  let mut lexer_rejected = 0usize;
+  let mut padded_variants = 0usize;
+  let mut recovered = 0usize;
+  let mut compact_recovered = 0usize;
+  let mut violations: Vec<(String, String, Violation)> = Vec::new();
+  let mut compact_owners: BTreeSet<String> = BTreeSet::new();
+  let mut padded_owners: BTreeSet<String> = BTreeSet::new();
+  let mut discriminated: BTreeSet<String> = BTreeSet::new();
+  let mut discriminating_spans = 0usize;
+  let mut total_spans = 0usize;
+
+  let mut measure = |name: &String,
+                     form: &str,
+                     variant: &str,
+                     owners: &mut BTreeSet<String>,
+                     violations: &mut Vec<(String, String, Violation)>|
+   -> bool {
+    let Ok(doc) = parse_recovering(variant) else {
+      return false;
+    };
+    let spans = spans_of(&format!("{doc:#?}"));
+    assert!(
+      !spans.is_empty(),
+      "{name} [{form}]: the parse recovered but the walk found no spans, so this variant was \
+       checked for nothing"
+    );
+    let ext = extents(variant);
+    for violation in check(variant, &spans, &ext) {
+      violations.push((name.clone(), form.to_string(), violation));
+    }
+    owners.extend(extent::owners(&spans));
+    if form != "compact" {
+      total_spans += spans.len();
+      for span in &spans {
+        if discriminating(span, &ext, variant.len()) {
+          discriminating_spans += 1;
+          discriminated.insert(span.owner.clone());
+        }
+      }
+    }
+    true
+  };
+
+  for (name, src) in &entries {
+    assert!(
+      parse(src).is_err(),
+      "{name}: the shipped fail-fast parser accepts it, so it is not an `invalid_` entry"
+    );
+
+    if !lexes(src) {
+      lexer_rejected += 1;
+      continue;
+    }
+    lexable += 1;
+
+    if measure(name, "compact", src, &mut compact_owners, &mut violations) {
+      compact_recovered += 1;
+      recovered += 1;
+    }
+
+    let marks = boundaries(src);
+    for (form, pad) in ALPHABET {
+      let padded_src = inject(src, &marks, pad);
+      assert_eq!(
+        padded_src.len(),
+        src.len() + marks.len() * pad.len(),
+        "{name} padded with {form}: the injection did not land at every boundary"
+      );
+      assert!(
+        lexes(&padded_src),
+        "{name} padded with {form}: injecting at a token boundary made the source unlexable"
+      );
+      padded_variants += 1;
+      if measure(name, form, &padded_src, &mut padded_owners, &mut violations) {
+        recovered += 1;
+      }
+    }
+  }
+
+  if !violations.is_empty() {
+    let mut report: Vec<String> = violations
+      .iter()
+      .map(|(name, form, violation)| {
+        format!(
+          "  {name} [{form}] {} — {} — {}",
+          violation.owner, violation.rule, violation.detail
+        )
+      })
+      .collect();
+    report.sort();
+    report.dedup();
+    let owners: BTreeSet<&str> = violations
+      .iter()
+      .map(|(_, _, violation)| violation.owner.as_str())
+      .collect();
+    panic!(
+      "{} span-extent violations over {} node types in recovered parses — a recovered node's span \
+       is still the extent of the tokens it holds, not the position recovery stopped at:\n{}\nnode \
+       types: {owners:?}",
+      violations.len(),
+      owners.len(),
+      report.join("\n")
+    );
+  }
+
+  assert!(
+    recovered >= RECOVERED_VARIANT_FLOOR,
+    "only {recovered} of {} variants recovered into a tree, below the floor of \
+     {RECOVERED_VARIANT_FLOOR}; the sweep has stopped reaching the recovery paths",
+    padded_variants + lexable
+  );
+  assert!(
+    compact_recovered > 0,
+    "no unpadded invalid entry recovered, so every recovery below depends on the injection"
+  );
+  assert_eq!(
+    lexable + lexer_rejected,
+    entries.len(),
+    "every invalid entry is either lexable or lexer-rejected"
+  );
+  assert!(
+    lexable >= LEXABLE_INVALID_FLOOR,
+    "only {lexable} invalid entries lex, below the floor of {LEXABLE_INVALID_FLOOR}"
+  );
+
+  assert!(
+    padded_owners.len() >= RECOVERED_OWNER_FLOOR,
+    "the recovered sweep reached {} span-carrying node types, below the floor of \
+     {RECOVERED_OWNER_FLOOR}: {padded_owners:?}",
+    padded_owners.len()
+  );
+  assert!(
+    compact_owners.is_subset(&padded_owners),
+    "padding lost a node type the unpadded invalid entries reach: {:?}",
+    compact_owners
+      .difference(&padded_owners)
+      .collect::<Vec<_>>()
+  );
+  let undiscriminated: Vec<&String> = padded_owners.difference(&discriminated).collect();
+  assert!(
+    undiscriminated.is_empty(),
+    "{} of the {} node types in recovered parses were never observed next to injected trivia, so \
+     nothing about their spans was actually at stake: {undiscriminated:?}",
+    undiscriminated.len(),
+    padded_owners.len()
+  );
+  assert!(
+    discriminating_spans * 2 >= total_spans,
+    "only {discriminating_spans} of {total_spans} spans sat at a junction where the two rules \
+     differ; padding at every boundary should put most of them there"
+  );
+
+  println!(
+    "gate: {} invalid entries ({lexable} lexable, {lexer_rejected} lexer-rejected) x {} forms = \
+     {padded_variants} padded variants, {recovered} recovered ({compact_recovered} unpadded), \
+     {total_spans} spans, {discriminating_spans} at a discriminating junction, {} node types",
+    entries.len(),
+    ALPHABET.len(),
+    padded_owners.len()
+  );
+}
+
+/// Issue #75's own measurement in this dialect: where a **recovered** delimited node ends, pinned
+/// to the byte and adjudicated in the lexer's terms.
+///
+/// The GraphQL twin carries the argument. The recovery cursor is an offset the lexer reports as a
+/// token *start* and never as a token *end*, so closing a recovered group there is
+/// `end-not-token-end` — issue #68 — and the checker is made to say so about that reading and to
+/// say nothing about the token-extent one.
+#[test]
+fn a_recovered_group_ends_at_its_last_token_not_at_the_recovery_cursor() {
+  fn witness(src: &str, owner: &str, extent: (usize, usize), cursor: usize) {
+    let ext = extents(src);
+
+    assert!(
+      parse(src).is_err(),
+      "{src:?}: the fail-fast parser must reject the witness, or no recovery happens in it"
+    );
+    let doc = parse_recovering(src).unwrap_or_else(|e| panic!("{src:?}: no recovered tree: {e:?}"));
+
+    let spans = spans_of(&format!("{doc:#?}"));
+    let found: Vec<&FoundSpan> = spans.iter().filter(|span| span.owner == owner).collect();
+    assert_eq!(
+      found.len(),
+      1,
+      "{src:?}: {owner} appears {} times",
+      found.len()
+    );
+    assert_eq!(
+      (found[0].start, found[0].end),
+      extent,
+      "{src:?}: the recovered {owner} must end at its last token, not at the closer it recovered \
+       against"
+    );
+
+    assert!(
+      ext.starts.contains(&cursor) && !ext.ends.contains(&cursor),
+      "{src:?}: {cursor} must be a token start and not a token end for this witness to \
+       discriminate at all"
+    );
+    assert_eq!(
+      check(
+        src,
+        &[FoundSpan {
+          owner: owner.to_string(),
+          parent: None,
+          start: extent.0,
+          end: cursor,
+        }],
+        &ext,
+      )
+      .iter()
+      .map(|violation: &Violation| violation.rule)
+      .collect::<Vec<_>>(),
+      ["end-not-token-end"],
+      "{src:?}: ending a recovered group at the recovery cursor is #68's defect wearing a \
+       different hat"
+    );
+
+    assert!(
+      check(src, &spans, &ext).is_empty(),
+      "{src:?}: the recovered witness violates the extent invariant: {:?}",
+      check(src, &spans, &ext)
+    );
+  }
+
+  witness("{ f(a: [1 , 2 ) }", "List", (7, 13), 14);
+  witness("query Q($v: [Int ) { f }", "ListType", (12, 16), 17);
 }
 
 /// The GraphQLx witness: a generic head and a `where` clause, the two junctions the dialect adds.


### PR DESCRIPTION
Closes #75.
