### PR TITLE
ci(miri): pin the Miri selection to `smear`, and state what rowan makes uncoverable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,7 +339,24 @@ jobs:
         cargo hack build -p smear --each-feature --features parser \
           --exclude-features rowan,lossless-coverage,default \
           --exclude-no-default-features --exclude-all-features
-  
+        # Pass 3 — the four criterion benches, which NOTHING ELSE IN CI COMPILES.
+        #
+        # Measured on this tree: `cargo test`'s default target selection is lib + bins + tests +
+        # examples; a `[[bench]]` target is not in it, and neither `cargo build --workspace
+        # --all-features` (the `msrv` job) nor `cargo hack build --each-feature` above builds
+        # one. So while the benches lived in `smear/benches/` they were compiled by no gate at
+        # all — `#73`'s family exactly, a target that exists and that nothing ever proves builds.
+        #
+        # That was survivable when the benches sat beside the fixtures they `include_str!`. It
+        # is not now: `smear-benches` reaches across a member boundary for all 29 of them
+        # (`../../smear/tests/fixtures/...`), so a fixture rename would break four bench targets
+        # and every other job would stay green. `--benches` names a target KIND on a package
+        # that has nothing else, so there is no filter here that can match zero targets and
+        # exit 0.
+        #
+        # Build, not run: criterion sampling is minutes per target and this is a compile gate.
+        cargo build -p smear-benches --benches
+
   test:
     name: test
     strategy:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -30,37 +30,50 @@ name: Miri
 # to `.github/workflows/macos.yml` instead — a third lane, not this one, because a macOS
 # formatting failure and a Miri UB report are different findings and should be readable apart.
 #
-# This is a SCHEDULING change, not a coverage change. Every job, matrix cell and step below runs
-# what `.github/workflows/ci.yml` ran before, unchanged — the same 10 cells, the same two
-# aliasing models, the same `ci/miri_tb.sh` / `ci/miri_sb.sh`. The one step dropped in the move
-# was `cargo install cargo-hack`, which neither script invokes: both run `cargo miri setup` and
+# The SPLIT (#69/#71) was a scheduling change and not a coverage change: it moved the same 10
+# cells, the same two aliasing models and the same `ci/miri_tb.sh` / `ci/miri_sb.sh` out of
+# `.github/workflows/ci.yml` unchanged. The one step dropped in the move was
+# `cargo install cargo-hack`, which neither script invokes: both run `cargo miri setup` and
 # `cargo miri test` and nothing else, so it compiled a tool no cell used, on every cell.
 #
-# What this does NOT do is make Miri faster. It cannot: the macOS queue is a runner-concurrency
-# constraint this repository does not own. What the split buys is that `CI`'s answer no longer
-# waits behind it.
+# TWO THINGS ABOVE ARE NOW OUT OF DATE, and are kept because they are the measurement that
+# justified the split rather than a description of the file. #77 changed both:
+#
+#   * "the macOS queue is a runner-concurrency constraint this repository does not own" — still
+#     true of the account, and still true of `.github/workflows/macos.yml`'s four legs, but no
+#     longer true HERE: every cell in this file runs on `ubuntu-latest`. The next section says
+#     why that became possible. What is left of this lane's cost is wall clock alone.
+#   * "not a coverage change" — that was the split. #77 IS a coverage change, deliberately and
+#     in one direction: the scripts now pass `-p smear`, which drops the lossless CST tower.
+#     See "WHAT THIS MATRIX DOES NOT COVER" below; it is not optional and it is not a saving.
 
-# ── WHY THE APPLE CELLS STILL RUN ON A macOS HOST ───────────────────────────────────────────
+# ── WHY THE APPLE CELLS NO LONGER RUN ON A macOS HOST ───────────────────────────────────────
 #
-# Miri interprets a TARGET, so the host ought to be irrelevant, and if it were, these 4 cells
-# would become ubuntu ones and the queue that forced this split would stop mattering here.
-# Measured rather than assumed, and the answer is the same one tokora reached: `cargo build` is
-# the obstacle, not Miri.
+# Every cell below runs on `ubuntu-latest`, the two apple targets included, and this repository
+# now asks this workflow for no macOS runner at all. Miri interprets a TARGET, so the host was
+# always supposed to be irrelevant; until #77 it was not, and the reason had nothing to do with
+# Miri.
 #
-# `criterion 0.8.2` is an UNCONDITIONAL dev-dependency of `smear`,
-# and it depends on `alloca 0.4.0`, whose build script is a `cc::Build` that compiles `alloca.c`.
-# `cargo check --workspace --tests` on this tree produces
-# `target/debug/build/alloca/*/out/libcalloca.a`, so the C file is built for the target selected
-# by `--tests` — which is exactly the selection `ci/miri_tb.sh` and `ci/miri_sb.sh` make. On a
-# Linux host targeting `*-apple-darwin`, cc-rs invokes the host `cc` with `-arch x86_64` /
-# `-arch arm64` and `-mmacosx-version-min=...`; a Linux `cc` rejects those, and compiling them
-# needs Apple clang and the macOS SDK.
+# `criterion 0.8.2` was an unconditional dev-dependency of `smear` and it depends on
+# `alloca 0.4.0`, whose build script is a `cc::Build` that compiles `alloca.c`. Cargo resolves
+# dev-dependencies per PACKAGE and not per target, so the `--tests` selection these scripts make
+# built `alloca` for whatever target was named; on a Linux host targeting `*-apple-darwin`, cc-rs
+# invokes the host `cc` with `-arch x86_64` / `-arch arm64` and `-mmacosx-version-min=...`, which
+# a Linux `cc` rejects. Four cells were therefore pinned to `macos-latest` by one C file in one
+# transitive dependency of a benchmark harness.
 #
-# So `macos-latest` here is load-bearing for a reason that has nothing to do with Miri, and it is
-# not a leftover. Moving these cells means getting criterion out of the dev-dependency graph
-# first — cargo has no optional dev-dependencies, so that means the benches moving to their own
-# workspace member — or putting an osxcross toolchain on the runner, which trades a runner queue
-# for an unmanaged SDK. Neither is a CI edit.
+# The previous revision of this comment named the way out and called it "not a CI edit": get
+# criterion out of the dev-dependency graph, which — since cargo has no optional
+# dev-dependency — means the benches moving to their own workspace member. That is what
+# `smear-benches` is (see its manifest header), and it is the same move tokora made in its #216.
+# Measured on this tree afterwards: `cargo miri test -p smear --tests --lib` resolves to 32
+# packages where it previously resolved 95, and not one of the remaining build scripts compiles
+# C — `alloca`, `cc`, `criterion` and the three comparison parsers are all gone from the graph.
+# `apollo-parser` went with them, which also takes `rowan` out of `smear`'s dev graph entirely.
+#
+# Do not reintroduce a `criterion` — or anything else with a `cc` build script — into `smear`'s
+# `[dev-dependencies]`. It will not fail here; it will silently make these four cells
+# unschedulable on Linux again, and the symptom will look like a compiler error in C.
 #
 # WHAT THE TARGET AXIS BUYS, separately from the host. This workspace contains no `target_arch`,
 # `target_os`, `target_vendor`, `target_pointer_width` or `target_endian` cfg anywhere, so every
@@ -68,11 +81,26 @@ name: Miri
 # order and layout. On that axis `i686-unknown-linux-gnu` (32-bit) and
 # `powerpc64-unknown-linux-gnu` (big-endian) are each unique, and `x86_64-unknown-linux-gnu`,
 # `x86_64-apple-darwin` and `aarch64-apple-darwin` are all 64-bit little-endian. The two apple
-# cells are therefore the weakest of the five, and `x86_64-apple-darwin` is the weakest of those
-# — it shares its word size and byte order with the linux x86_64 cell and its OS with the other
-# apple cell. They are kept because dropping coverage is a different decision from moving it,
-# and because they cost `CI` nothing from here; if the macOS budget ever has to shrink,
-# `x86_64-apple-darwin` is the cell to spend first.
+# cells are therefore the weakest of the five. They are kept because dropping coverage is a
+# different decision from moving it, and the reason to spend them first is now weaker than it
+# was: they no longer cost a macOS runner, only wall clock on the same host class as every
+# other cell.
+
+# ── WHAT THIS MATRIX DOES NOT COVER, AND WHY IT IS STATED HERE ──────────────────────────────
+#
+# The 33 `#![cfg(feature = "rowan")]` integration targets in `smear/tests/` — the entire lossless
+# CST tower — are NOT interpreted by any cell in this file, on any target, under either aliasing
+# model. `rowan` itself has undefined behaviour reachable from its ordinary public API, live in
+# every published version including `0.17.0` (2026-08-02), reported upstream since 2021 and
+# unfixed; `ci/miri_sb.sh` and `ci/miri_tb.sh` carry the two sites, the reproduction and the
+# upstream references, and #77 carries the decision.
+#
+# This is an exclusion, not a silence. `ci/miri_scope.py` runs at the end of every cell, prints
+# the excluded set with its reason, and FAILS the cell in either direction: if a target that is
+# not `rowan`-gated ran zero tests (#73's mechanism — a built, linked, passing, empty harness),
+# or if a `rowan`-gated one ran any test at all (#77's mechanism — a new workspace member
+# unifying `smear/rowan` back into the resolve). The matrix is therefore allowed to be narrower
+# than the test tree, and not allowed to be narrower than it says.
 
 # `push`/`pull_request` triggers and `paths-ignore` are deliberately identical to
 # `.github/workflows/ci.yml` and `.github/workflows/macos.yml`; read the comment there for why the
@@ -137,10 +165,12 @@ concurrency:
 # Every `run:` here is bash — the same block `ci.yml` and `macos.yml` carry, and `ci.yml`'s has
 # the full account of what it is for. The construct at risk in this file is the
 # `case ... esac` in both `Install cross C toolchain` steps, which PowerShell cannot parse at
-# all. It is safe today only because that step's `if: runner.os == 'Linux'` skips it on the two
-# apple cells, so the ONLY host that ever executes it is the one whose default shell is already
-# bash — a guard written for a different purpose holding up a dialect assumption by accident.
-# Stated here so the assumption is the file's, not the matrix's.
+# all. Before #86 it was safe only because that step's `if: runner.os == 'Linux'` skipped it on
+# the two apple cells — a guard written for a different purpose holding up a dialect assumption
+# by accident. It is now safe twice over and for the stated reason: this block, and the fact
+# that since #77 every cell in this file runs on `ubuntu-latest`. Both stay. "Every host happens
+# to be Linux" is a property of the matrix, which can change in one line; declaring the shell is
+# a property of the file.
 defaults:
   run:
     shell: bash
@@ -164,31 +194,18 @@ jobs:
       # cancel the other, unrelated cells in this matrix.
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        # ONE dimension. Until #77 there was an `os` dimension too, with five `exclude:` entries
+        # pairing each target to the only host that could build it — a 2 x 5 product carved back
+        # down to 5. The two apple targets needed `macos-latest` because `criterion` put a C
+        # build script in `smear`'s dev graph; `smear-benches` took it out, so every target now
+        # builds on the same host and the product is the list. See the header.
         target:
           - x86_64-unknown-linux-gnu
           - i686-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - x86_64-apple-darwin
           - aarch64-apple-darwin
-        # Exclude invalid combinations. All five entries below are live: each
-        # names an `os` and a `target` that both appear in the lists above, so
-        # each removes a cell that the product would otherwise create. 2 x 5
-        # minus 5 leaves the 5 cells this matrix runs.
-        exclude:
-          - os: ubuntu-latest
-            target: x86_64-apple-darwin
-          - os: ubuntu-latest
-            target: aarch64-apple-darwin
-          - os: macos-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: i686-unknown-linux-gnu
-          - os: macos-latest
-            target: powerpc64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Cache cargo build and registry
@@ -202,10 +219,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-miri-
       - name: Install cross C toolchain for ${{ matrix.target }}
-        # x86_64-unknown-linux-gnu and the macOS targets build with the
-        # runner's native toolchain; only the two Linux cross targets need
-        # an extra package, so install exactly the one each needs.
-        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
+        # Named targets rather than a negation. The guard used to read
+        # `runner.os == 'Linux' && matrix.target != 'x86_64-apple-darwin'`-shaped, which was
+        # true for exactly the two targets the `case` below has branches for — but only by
+        # coincidence, and since #77 every host IS Linux, so the `runner.os` half is now a
+        # condition that can never be false. Naming the two keeps the guard and the `case`
+        # arms in agreement where a reader can see it, and makes adding a third target a
+        # deliberate edit in two visible places rather than a silent fall-through to a `case`
+        # with no matching branch.
+        if: matrix.target == 'i686-unknown-linux-gnu' || matrix.target == 'powerpc64-unknown-linux-gnu'
         run: |
           case "${{ matrix.target }}" in
             i686-unknown-linux-gnu)
@@ -229,31 +251,18 @@ jobs:
       # cancel the other, unrelated cells in this matrix.
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        # ONE dimension. Until #77 there was an `os` dimension too, with five `exclude:` entries
+        # pairing each target to the only host that could build it — a 2 x 5 product carved back
+        # down to 5. The two apple targets needed `macos-latest` because `criterion` put a C
+        # build script in `smear`'s dev graph; `smear-benches` took it out, so every target now
+        # builds on the same host and the product is the list. See the header.
         target:
           - x86_64-unknown-linux-gnu
           - i686-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
           - x86_64-apple-darwin
           - aarch64-apple-darwin
-        # Exclude invalid combinations. All five entries below are live: each
-        # names an `os` and a `target` that both appear in the lists above, so
-        # each removes a cell that the product would otherwise create. 2 x 5
-        # minus 5 leaves the 5 cells this matrix runs.
-        exclude:
-          - os: ubuntu-latest
-            target: x86_64-apple-darwin
-          - os: ubuntu-latest
-            target: aarch64-apple-darwin
-          - os: macos-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: i686-unknown-linux-gnu
-          - os: macos-latest
-            target: powerpc64-unknown-linux-gnu
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Cache cargo build and registry
@@ -267,10 +276,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-miri-
       - name: Install cross C toolchain for ${{ matrix.target }}
-        # x86_64-unknown-linux-gnu and the macOS targets build with the
-        # runner's native toolchain; only the two Linux cross targets need
-        # an extra package, so install exactly the one each needs.
-        if: runner.os == 'Linux' && matrix.target != 'x86_64-unknown-linux-gnu'
+        # Named targets rather than a negation. The guard used to read
+        # `runner.os == 'Linux' && matrix.target != 'x86_64-apple-darwin'`-shaped, which was
+        # true for exactly the two targets the `case` below has branches for — but only by
+        # coincidence, and since #77 every host IS Linux, so the `runner.os` half is now a
+        # condition that can never be false. Naming the two keeps the guard and the `case`
+        # arms in agreement where a reader can see it, and makes adding a third target a
+        # deliberate edit in two visible places rather than a silent fall-through to a `case`
+        # with no matching branch.
+        if: matrix.target == 'i686-unknown-linux-gnu' || matrix.target == 'powerpc64-unknown-linux-gnu'
         run: |
           case "${{ matrix.target }}" in
             i686-unknown-linux-gnu)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,30 @@
 members = [
   "benchmarks",
   "smear",
+  "smear-benches",
   "smear-smoke",
 ]
+
+# ── THREE OF THE FOUR MEMBERS PULL `smear` PAST ITS DEFAULT FEATURE SET ──────────────────────
+#
+# `benchmarks` and `smear-smoke` both enable `smear/rowan`; `smear-smoke` also enables
+# `lossless-coverage` and `test-support`. Cargo unifies features across the SELECTED packages,
+# so a bare workspace-wide command resolves `smear` with every feature it declares turned on.
+#
+# That arithmetic is how the entire lossless CST tower entered the Miri selection without anyone
+# choosing it. #70 added `benchmarks`, #84 added `smear-smoke`, and each time the Miri scripts —
+# which name no `-p` and no `--features` — got wider by resolution rather than by decision. The
+# first time real lossless code reached Miri it reported undefined behaviour inside `rowan`
+# (#77), which is the sharpest available statement of what an unchosen selection costs.
+#
+# There is deliberately NO `default-members` narrowing that away. It would pin the Miri
+# selection at the price of silently narrowing every OTHER bare command in the repository:
+# `cargo test --all-features` in `.github/workflows/ci.yml` is meant to cover all four members
+# and would quietly have stopped, with no exit code saying so — the same defect class, one turn
+# later. The selection is pinned where it is READ instead: `ci/miri_sb.sh` and `ci/miri_tb.sh`
+# pass `-p smear`, and `ci/miri_scope.py` fails the run if what got interpreted is not what
+# those scripts claim.
+#
 # Reference-only: the superseded parser/scaffold crates and the old `smear`
 # benches and integration suite that drove them. Kept for history and parity
 # lookups, deliberately outside the build. Cargo errors on a nested package

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ published, so nothing on crates.io moved; this affects path and git dependents o
 
 All benchmarks compare **smear** against [`apollo-parser`](https://crates.io/crates/apollo-parser), [`graphql-parser`](https://crates.io/crates/graphql-parser), [`async-graphql-parser`](https://crates.io/crates/async-graphql-parser), and [`cynic-parser`](https://crates.io/crates/cynic-parser). Lower is better.
 
-Run with: `cargo bench --package smear --bench <name> -- --quick`
+Run with: `cargo bench --package smear-benches --bench <name> -- --quick`
 
 ### Schema Parsing
 

--- a/ci/miri_sb.sh
+++ b/ci/miri_sb.sh
@@ -9,6 +9,13 @@ fi
 
 TARGET=$1
 
+# Prove the scope guard can fail, BEFORE `rustup`, before `cargo miri setup`, before anything
+# that costs minutes. `ci/miri_scope.py` is what makes this cell's coverage claim checkable
+# rather than asserted, and a guard that has quietly stopped checking is worse than no guard —
+# it is the exact shape of #73. Sub-second, and it reads the real `smear/tests/` partition, so
+# it also fails if that tree stops having both gated and un-gated targets to distinguish.
+python3 ci/miri_scope.py --selftest
+
 rustup toolchain install nightly --component miri
 rustup override set nightly
 cargo miri setup
@@ -34,20 +41,102 @@ MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-ali
 # So i686 alone drops `--tests` and runs the lib unit tests only. This is a
 # deliberate, scoped reduction, not a silent one: i686's unique value in
 # this matrix is 32-bit pointer width on a SIMD byte-level lexer, and the
-# lib tests (115 lexer unit tests at last measurement, sharing one binary
-# with the parser's since the crates merged) exercise exactly that, under
-# both aliasing models. What is given up is "integration-suite coverage at
-# 32-bit", not "32-bit coverage" — tests/oracle.rs and
-# tests/tokora_conformance.rs still run under Miri on x86_64 and
-# powerpc64-unknown-linux-gnu, so the scenarios themselves stay covered,
-# just not at this pointer width.
+# lib tests exercise exactly that, under both aliasing models. Measured
+# 2026-08-07 under the `-p smear` selection below: 473 lib unit tests, the
+# lexer's and the parser's in one binary since the crates merged. What is
+# given up is "integration-suite coverage at 32-bit", not "32-bit
+# coverage" — tests/oracle.rs and tests/tokora_conformance.rs still run
+# under Miri on x86_64 and powerpc64-unknown-linux-gnu, so the scenarios
+# themselves stay covered, just not at this pointer width.
+
+# ── A WALL-CLOCK RISK THIS SELECTION CARRIES, STATED BEFORE IT BITES ────────────────────────
+#
+# `tests/syntactic_span_extent.rs` and `tests/syntactic_x_span_extent.rs` are in this cell and
+# have almost certainly never completed in one. They arrived in #72 and grew in #80; they are
+# not `rowan`-gated, so they were always SELECTED — but cargo runs test binaries in name order,
+# `lossless_*` sorts before `syntactic_*`, and since #70 every Miri cell aborted inside the
+# lossless tower before reaching them. `miri.yml` has no `success` conclusion in its last 40
+# runs either, so nothing has covered them.
+#
+# They are also the most expensive thing here by a wide margin. Measured 2026-08-07 on one
+# aarch64-apple-darwin core, this model, nothing else on that core: ONE of the six tests in
+# `syntactic_span_extent.rs` — `trivia_injection_leaves_every_span_on_its_own_tokens` — had NOT
+# finished after 36 minutes. Its sibling sweeps 90 corpus entries where that one sweeps 56. For scale,
+# the whole lib suite is 183s and `tests/oracle.rs` is 180s.
+#
+# The number that matters and is NOT measurable from here is the GitHub runner's. `miri.yml`'s
+# header records 4h20m for the slowest cell of run 30963710061 — created before #72, so without
+# these two targets. A GitHub job is killed at 6 hours. If a cell starts timing out, this is the
+# reason, and the remedy is the one the i686 block above already demonstrates: reduce the
+# selection deliberately, in writing, naming what is given up. `--test`-level exclusion of these
+# two is the obvious first cut, and it costs less than it looks — Miri finds UB in code PATHS,
+# and these sweeps vary the INPUT over paths the lib tests, `oracle.rs` and
+# `tokora_conformance.rs` already interpret.
+#
+# It is not cut pre-emptively, because dropping coverage on an estimate is the mistake in the
+# other direction, and nothing here has a CI measurement yet.
 if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
   MIRIFLAGS="$MIRIFLAGS -Zmiri-address-reuse-rate=1.0"
   TEST_ARGS=""
+  TESTS_SELECTED=0
 else
   TEST_ARGS="--tests"
+  TESTS_SELECTED=1
 fi
 
 export MIRIFLAGS
 
-cargo miri test $TEST_ARGS --target $TARGET --lib
+# ── WHY `-p smear`, AND WHAT IT COSTS ───────────────────────────────────────────────────────
+#
+# This line said `cargo miri test $TEST_ARGS --target $TARGET --lib` until #77 — no `-p`, so it
+# selected every workspace member, and cargo unified their features. `smear` does NOT default to
+# `rowan`, but `benchmarks` and `smear-smoke` both enable it, so the resolve turned it on and the
+# whole lossless CST tower entered this cell. Nobody widened the scope; #70 and then #84 added a
+# member and the arithmetic did it. See the note in the root `Cargo.toml`.
+#
+# The widening was not survivable, and that is the finding rather than an inconvenience.
+# `rowan 0.16.1` has undefined behaviour reachable from its ordinary public API, under BOTH
+# aliasing models and in two independent places:
+#
+#   * Stacked Borrows — `src/arc.rs:260`, `<HeaderSlice<H, [T; 0]> as Deref>::deref` forges a
+#     `&HeaderSlice<H, [T]>` covering the whole slice out of a `&self` whose retag covers only
+#     the header. Reached from `GreenNodeBuilder::finish_node`, i.e. from building ANY tree.
+#   * Tree Borrows — `src/cursor.rs:219`, `rowan::cursor::free` deallocating a
+#     `Box<NodeData>` through a tag an ancestor's `Cell` still holds frozen. Reached from
+#     dropping any red-tree `SyntaxNode`, including out of `parse_document(..).syntax()`.
+#
+# Both were reproduced on 2026-08-07 by two standalone programs that name nothing but rowan's
+# public API, against `0.15.19`, `0.16.1`, `0.16.2` (yanked) and `0.17.0` — the newest release,
+# published 2026-08-02. The construct is byte-identical in all four, so THERE IS NO VERSION TO
+# BUMP TO. Upstream has had it reported since 2021 (rust-analyzer/rowan#108, and #163, #192);
+# the only fix attempt, PR #211, is a conflicting draft whose own description says the immutable
+# path still fails under Stacked Borrows.
+#
+# So `-p smear` is not a cost/benefit trade about minutes. The lossless tower CANNOT be
+# interpreted, at any price, until rowan is fixed — and the 33 `#![cfg(feature = "rowan")]`
+# targets in `smear/tests/` are therefore excluded here rather than left to fail. `-p smear` is
+# the mechanism because it is the one that a future workspace member cannot undo: feature
+# unification is over the SELECTED packages, and this selects one.
+#
+# What that leaves covered is the half where this project's own `unsafe` lives — the SIMD lexer
+# and the syntactic parser, through `tokora`'s substrate — and `ci/miri_scope.py` below asserts
+# that the covered/excluded split is exactly the one written here, in both directions. Read its
+# header before changing any of this.
+LOG="$(mktemp)"
+set +e
+cargo miri test -p smear $TEST_ARGS --target "$TARGET" --lib 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+set -e
+
+# Always run the scope guard, including after a failed run: the excluded set it prints is the
+# statement of what this cell does not cover, and that is worth reading either way. Its own
+# verdict is folded in below rather than allowed to mask Miri's.
+SCOPE=0
+python3 ci/miri_scope.py --log "$LOG" --tests-selected "$TESTS_SELECTED" \
+  --miri-status "$STATUS" || SCOPE=$?
+rm -f "$LOG"
+
+if [ "$STATUS" -ne 0 ]; then
+  exit "$STATUS"
+fi
+exit "$SCOPE"

--- a/ci/miri_scope.py
+++ b/ci/miri_scope.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Assert that a Miri run interpreted exactly the targets it was supposed to.
+
+Run from `ci/miri_sb.sh` and `ci/miri_tb.sh` against the log those scripts tee, immediately
+after `cargo miri test`. It exists because of two defects that both cost this repository real
+time and both presented as a GREEN cell:
+
+  #73  Miri built 39 test binaries and meaningfully ran five. Every lossless integration test
+       opens with `#![cfg(feature = "rowan")]` and the scripts passed no `--features`, so 33 of
+       them compiled to EMPTY harnesses: the targets were built, they linked, they ran, they
+       printed `running 0 tests`, and they passed. Nothing warned, because from cargo's point of
+       view nothing was wrong. A silent bound reads as full coverage.
+
+  #77  The inverse. `smear` does not default to `rowan`, but three of the four workspace members
+       enable it, and cargo unifies features across the SELECTED packages — so the moment #70
+       added a member the bare workspace-wide command in those scripts started resolving `smear`
+       with `rowan` ON. The lossless tower reached Miri for the first time by arithmetic, and
+       reported undefined behaviour inside `rowan` itself. Nobody chose the widening and nobody
+       could see it had happened.
+
+So the two failure directions are symmetric and this checks both:
+
+  * a target that is NOT `rowan`-gated and ran zero tests  -> #73's silence, and
+  * a target that IS `rowan`-gated and ran ANY test        -> #77's unchosen widening.
+
+The `rowan`-gated set is DERIVED, by reading the `#![cfg(...)]` header of every file in
+`smear/tests/`, and never written down here. A hand-maintained list would be a third thing that
+agrees with the source on the day it is written, which is the shape of both defects above.
+
+Exit 0 on agreement, 1 on any disagreement. The excluded set is printed on every run, pass or
+fail, because "what this matrix does not cover" belongs in the log rather than in a reader's
+assumption.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import pathlib
+import re
+import shutil
+import sys
+import tempfile
+
+# `.github/workflows/miri.yml` sets `CARGO_TERM_COLOR: always`, so cargo emits SGR escapes even
+# though nothing here is a tty: `\x1b[1m\x1b[32m     Running\x1b[0m tests/oracle.rs (...)`. Every
+# line is stripped before it is matched. Without this the two patterns below match nothing at all,
+# and the guard would report a perfectly good run as having interpreted no targets — a check
+# defeated by the format of its own input.
+ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+# `     Running tests/oracle.rs (/path/to/binary)` and
+# `     Running unittests src/lib.rs (/path/to/binary)`.
+RUNNING = re.compile(r"^\s+Running (?:unittests )?(\S+)")
+COUNT = re.compile(r"^running (\d+) tests?$")
+# A test file's crate-level `#![cfg(...)]`. Anchored to column 0 with `^`, which is what makes
+# this a CRATE-level attribute rather than any inner attribute: a `mod x { #![cfg(...)] }` is
+# indented and must not be read as gating the whole target. Non-greedy up to the closing `)]` so
+# a nested `all(...)` / `any(...)` is captured whole, and `re.S` so it may span lines.
+INNER_CFG = re.compile(r"^#!\[cfg\((.*?)\)\]", re.S | re.M)
+
+# The one reason a target is allowed to be excluded, and the issue that records it.
+EXCLUSION_REASON = (
+    "gated on `rowan`, which cannot be interpreted: rowan 0.16.1 has undefined behaviour under "
+    "Stacked Borrows in `src/arc.rs` and under Tree Borrows in `src/cursor.rs`, live in every "
+    "published version through 0.17.0 (al8n/smear#77, rust-analyzer/rowan#108 and #192)"
+)
+
+
+def gated_targets(tests_dir: pathlib.Path) -> tuple[set[str], set[str]]:
+    """Partition `smear/tests/*.rs` into (rowan-gated, not-rowan-gated) target names."""
+    gated: set[str] = set()
+    plain: set[str] = set()
+    for path in sorted(tests_dir.glob("*.rs")):
+        # Whole file, not a prefix window: several of these open with a module doc comment long
+        # enough that a fixed window would miss the attribute below it, and misclassifying a
+        # gated target as un-gated would fail the cell with the wrong explanation.
+        match = INNER_CFG.search(path.read_text(encoding="utf-8"))
+        (gated if match and "rowan" in match.group(1) else plain).add(path.stem)
+    return gated, plain
+
+
+def ran_counts(log: pathlib.Path) -> tuple[dict[str, int], list[tuple[str, int]]]:
+    """Read the log into (integration targets -> test count, lib binaries in order).
+
+    The two are kept apart because cargo spells every package's unit-test binary
+    `Running unittests src/lib.rs (<path>)` — the same text for all of them, distinguished only
+    by the path in parentheses. Collapsing them onto one key silently keeps whichever ran first,
+    and on a workspace-wide selection that is a coin toss between packages: the CI log of run
+    31073592771 has two, `smear`'s and `smear-apollo-bench`'s, both empty. So they are returned
+    as a LIST and the caller requires exactly one, which is both the truth under `-p smear` and
+    a direct check that the selection is still one package.
+    """
+    counts: dict[str, int] = {}
+    libs: list[tuple[str, int]] = []
+    current: str | None = None
+    current_path: str = ""
+    for raw in log.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = ANSI.sub("", raw)
+        running = RUNNING.match(line)
+        if running:
+            target = running.group(1)
+            current = "<lib>" if target.endswith("lib.rs") else pathlib.Path(target).stem
+            tail = line.split("(", 1)
+            current_path = tail[1].rstrip(") ") if len(tail) == 2 else "<unknown path>"
+            continue
+        count = COUNT.match(line.strip())
+        if count and current is not None:
+            n = int(count.group(1))
+            if current == "<lib>":
+                libs.append((current_path, n))
+            else:
+                # A binary reports `running N tests` once; keep the first, so a `--no-capture`
+                # re-run appended to the same log cannot overwrite it.
+                counts.setdefault(current, n)
+            current = None
+    return counts, libs
+
+
+def selftest(tests_dir: pathlib.Path) -> int:
+    """Prove every branch of `check` can fail, against the REAL test tree.
+
+    A guard that cannot fail is the defect this guard exists to catch, so this runs first in
+    `ci/miri_sb.sh` and `ci/miri_tb.sh` — before `rustup`, before `cargo miri setup`, before
+    anything that costs minutes. The logs below are synthesised, but the gated/plain partition
+    is read from `smear/tests/` exactly as a real run reads it: a case is stated in terms of
+    "some gated target" and "some plain target", so it keeps meaning when a test file is added.
+    """
+    gated, plain = gated_targets(tests_dir)
+    if not gated or not plain:
+        print("::error::miri_scope selftest: the test tree has no gated targets, or no "
+              f"un-gated ones ({len(gated)} / {len(plain)}), so the cases below would not "
+              "exercise what they name")
+        return 1
+    a_gated, a_plain = sorted(gated)[0], sorted(plain)[0]
+
+    def log(entries: list[tuple[str, int | None]]) -> str:
+        out = []
+        for i, (name, count) in enumerate(entries):
+            path = "unittests src/lib.rs" if name == "<lib>" else f"tests/{name}.rs"
+            out.append(f"     Running {path} (/tmp/build/pkg{i}/{name}-deadbeef)")
+            if count is not None:
+                out.append(f"running {count} tests")
+                out.append(f"test result: ok. {count} passed; 0 failed")
+        return "\n".join(out) + "\n"
+
+    clean = [("<lib>", 400)] + [(n, 0) for n in sorted(gated)] + [(n, 7) for n in sorted(plain)]
+    cases: list[tuple[str, str, bool, int, int]] = [
+        # (name, log text, tests_selected, miri_status, expected exit)
+        ("a correct run passes", log(clean), True, 0, 0),
+        ("a plain target that ran zero tests fails (#73)",
+         log([(n, 0 if n == a_plain else c) for n, c in clean]), True, 0, 1),
+        ("a gated target that ran any test fails (#77)",
+         log([(n, 3 if n == a_gated else c) for n, c in clean]), True, 0, 1),
+        ("a plain target absent from a run that SUCCEEDED fails",
+         log([e for e in clean if e[0] != a_plain]), True, 0, 1),
+        ("a plain target absent from a run that ABORTED is truncation, not a finding",
+         log([e for e in clean if e[0] != a_plain]), True, 1, 0),
+        ("the lib binary reporting zero tests fails",
+         log([("<lib>", 0)] + clean[1:]), True, 0, 1),
+        ("the lib binary never running fails",
+         log(clean[1:]), True, 0, 1),
+        ("`--lib` alone does not require the integration targets to appear",
+         log([("<lib>", 400)]), False, 0, 0),
+        # `CARGO_TERM_COLOR: always` in the workflow means the log this guard reads is full of
+        # SGR escapes. Pinned as a case rather than trusted, because the failure mode is silent
+        # in the wrong direction: unstripped, `RUNNING` matches nothing, every target looks
+        # absent, and on a SUCCESSFUL run the guard would fail the cell for the whole suite.
+        # The shape the CI log of run 31073592771 actually has: `smear`'s lib binary and
+        # `smear-apollo-bench`'s, both spelled `Running unittests src/lib.rs`, distinguished only
+        # by the path. Two of them means the selection is not one package.
+        ("a second package's lib unit tests running fails (#77, from the other end)",
+         log([("<lib>", 400), ("<lib>", 0)] + clean[1:]), True, 0, 1),
+        ("a colourised log parses the same as a plain one",
+         log(clean).replace("     Running", "\x1b[1m\x1b[32m     Running\x1b[0m"), True, 0, 0),
+    ]
+
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="miri-scope-selftest-"))
+    bad = 0
+    try:
+        for i, (name, text, sel, status, want) in enumerate(cases):
+            path = tmp / f"case{i}.log"
+            path.write_text(text, encoding="utf-8")
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                got = check(tests_dir, path, tests_selected=sel, miri_status=status)
+            mark = "ok  " if got == want else "FAIL"
+            if got != want:
+                bad += 1
+            print(f"  {mark} [{got} vs want {want}] {name}")
+            if got != want:
+                print("       ---- guard output ----")
+                for line in buf.getvalue().splitlines():
+                    print(f"       {line}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if bad:
+        print(f"::error::miri_scope selftest: {bad} of {len(cases)} cases did not behave as "
+              "written — this guard does not check what its header claims")
+        return 1
+    print(f"miri_scope selftest OK: {len(cases)} cases, "
+          f"{len(gated)} gated / {len(plain)} un-gated targets in {tests_dir}")
+    return 0
+
+
+def check(
+    tests_dir: pathlib.Path,
+    log: pathlib.Path,
+    *,
+    tests_selected: bool,
+    miri_status: int,
+) -> int:
+    """Print the covered/excluded split, then return 0 if the run matched it and 1 if it did not."""
+    gated, plain = gated_targets(tests_dir)
+    if not gated and not plain:
+        print(f"::error::miri_scope: {tests_dir} holds no test targets — this guard would "
+              "pass by having nothing to check, which is the defect it exists to catch")
+        return 1
+
+    counts, libs = ran_counts(log)
+
+    print()
+    print("── Miri scope ──────────────────────────────────────────────────────────────────")
+    print(f"NOT COVERED by this cell: {len(gated)} of {len(gated) + len(plain)} integration "
+          f"targets in {tests_dir}")
+    print(f"  reason: {EXCLUSION_REASON}")
+    for name in sorted(gated):
+        print(f"    - {name}")
+    print(f"COVERED: the lib unit tests plus {len(plain)} integration targets"
+          + ("" if tests_selected else " (this cell runs `--lib` only; see the script header)"))
+    for name in sorted(plain):
+        print(f"    + {name}")
+    print("────────────────────────────────────────────────────────────────────────────────")
+    print()
+
+    aborted = miri_status != 0
+    failures: list[str] = []
+    notes: list[str] = []
+
+    lib = libs[0][1] if libs else None
+    if not libs:
+        (notes if aborted else failures).append(
+            "the lib unit-test binary never ran; every cell must interpret it"
+        )
+    elif len(libs) > 1:
+        failures.append(
+            f"{len(libs)} lib unit-test binaries ran, and `-p smear` selects ONE package — so "
+            "the selection is wider than these scripts pass. That is #77's mechanism seen from "
+            "the other end; the extra packages were: "
+            + ", ".join(path for path, _ in libs[1:])
+        )
+    elif lib == 0:
+        failures.append("the lib unit-test binary reported `running 0 tests`")
+
+    for name in sorted(plain):
+        got = counts.get(name)
+        if got is None:
+            if not tests_selected:
+                continue
+            if aborted:
+                notes.append(f"{name}: not reached — the run aborted before it")
+            else:
+                failures.append(
+                    f"{name}: `--tests` was passed and this target is not `rowan`-gated, but the "
+                    "run never reached it — it is no longer being built, and the cell is "
+                    "narrower than it claims (#73)"
+                )
+        elif got == 0:
+            failures.append(
+                f"{name}: ran and reported `running 0 tests`. A target that compiles to an empty "
+                "harness passes without testing anything — that is #73's exact mechanism. Either "
+                "it acquired a `cfg` the Miri feature set does not satisfy, or its tests were "
+                "removed"
+            )
+
+    for name in sorted(gated):
+        got = counts.get(name)
+        if got:
+            failures.append(
+                f"{name}: `rowan`-gated and yet ran {got} tests, so `rowan` is ON in this "
+                "selection. Something widened it — a new workspace member enabling "
+                "`smear/rowan` and unifying into the resolve is how #70 and #84 both did it. "
+                "The tower cannot be interpreted while rowan is UB (#77); pin the selection "
+                "rather than let it be resolved"
+            )
+
+    if notes:
+        print(f"miri_scope: `cargo miri test` exited {miri_status}, so the run stopped early "
+              "and the following are truncation, not scope:")
+        for line in notes:
+            print(f"  . {line}")
+
+    if failures:
+        print("::error::miri_scope: the run did not interpret what this cell claims to cover")
+        for line in failures:
+            print(f"  - {line}")
+        return 1
+
+    covered = sorted(n for n in plain if n in counts)
+    where = "so far" if aborted else "interpreted"
+    print(f"miri_scope OK: lib ({lib if lib is not None else 'not reached'}) + {len(covered)} "
+          f"integration targets {where}; {len(gated)} excluded for the recorded reason and none "
+          "of them ran")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--log", type=pathlib.Path)
+    ap.add_argument("--tests-dir", default=pathlib.Path("smear/tests"), type=pathlib.Path)
+    ap.add_argument(
+        "--selftest",
+        action="store_true",
+        help="Prove every branch of the guard can fail, against synthesised logs, and exit. "
+        "Takes no --log, --tests-selected or --miri-status.",
+    )
+    ap.add_argument(
+        "--tests-selected",
+        choices=("0", "1"),
+        help="1 when the run passed `--tests`, so every non-gated target is expected to appear; "
+        "0 for the i686 cell, which runs `--lib` alone and can only be checked on what it ran.",
+    )
+    ap.add_argument(
+        "--miri-status",
+        type=int,
+        help="`cargo miri test`'s own exit status. A run that ABORTED never reaches the targets "
+        "after the one that killed it, so on a non-zero status an absent target is reported and "
+        "not failed — the cell is already red for the real reason, and blaming the truncation on "
+        "a missing target would bury it. Every other check here still applies: a target that DID "
+        "run and reported zero tests, or a `rowan`-gated one that ran at all, is a finding no "
+        "matter how the run ended.",
+    )
+    args = ap.parse_args()
+
+    if not args.tests_dir.is_dir():
+        print(f"::error::miri_scope: no such directory: {args.tests_dir}", file=sys.stderr)
+        return 1
+
+    if args.selftest:
+        return selftest(args.tests_dir)
+
+    missing = [
+        flag
+        for flag, value in (("--log", args.log),
+                            ("--tests-selected", args.tests_selected),
+                            ("--miri-status", args.miri_status))
+        if value is None
+    ]
+    if missing:
+        ap.error("required without --selftest: " + ", ".join(missing))
+    if not args.log.is_file():
+        print(f"::error::miri_scope: no such log: {args.log}", file=sys.stderr)
+        return 1
+
+    return check(
+        args.tests_dir,
+        args.log,
+        tests_selected=args.tests_selected == "1",
+        miri_status=args.miri_status,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/miri_tb.sh
+++ b/ci/miri_tb.sh
@@ -9,6 +9,13 @@ fi
 
 TARGET=$1
 
+# Prove the scope guard can fail, BEFORE `rustup`, before `cargo miri setup`, before anything
+# that costs minutes. `ci/miri_scope.py` is what makes this cell's coverage claim checkable
+# rather than asserted, and a guard that has quietly stopped checking is worse than no guard —
+# it is the exact shape of #73. Sub-second, and it reads the real `smear/tests/` partition, so
+# it also fails if that tree stops having both gated and un-gated targets to distinguish.
+python3 ci/miri_scope.py --selftest
+
 rustup toolchain install nightly --component miri
 rustup override set nightly
 cargo miri setup
@@ -35,21 +42,106 @@ MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-disable-isolation -Zmiri-symbolic-ali
 # So i686 alone drops `--tests` and runs the lib unit tests only. This is a
 # deliberate, scoped reduction, not a silent one: i686's unique value in
 # this matrix is 32-bit pointer width on a SIMD byte-level lexer, and the
-# lib tests (115 lexer unit tests at last measurement, sharing one binary
-# with the parser's since the crates merged) exercise exactly that, under
-# both aliasing models. What is given up is "integration-suite coverage at
-# 32-bit", not "32-bit coverage" — tests/oracle.rs and
-# tests/tokora_conformance.rs still run under Miri on x86_64 and
-# powerpc64-unknown-linux-gnu, so the scenarios themselves stay covered,
-# just not at this pointer width.
+# lib tests exercise exactly that, under both aliasing models. Measured
+# 2026-08-07 under the `-p smear` selection below: 473 lib unit tests, the
+# lexer's and the parser's in one binary since the crates merged. What is
+# given up is "integration-suite coverage at 32-bit", not "32-bit
+# coverage" — tests/oracle.rs and tests/tokora_conformance.rs still run
+# under Miri on x86_64 and powerpc64-unknown-linux-gnu, so the scenarios
+# themselves stay covered, just not at this pointer width.
+
+# ── A WALL-CLOCK RISK THIS SELECTION CARRIES, STATED BEFORE IT BITES ────────────────────────
+#
+# `tests/syntactic_span_extent.rs` and `tests/syntactic_x_span_extent.rs` are in this cell and
+# have almost certainly never completed in one. They arrived in #72 and grew in #80; they are
+# not `rowan`-gated, so they were always SELECTED — but cargo runs test binaries in name order,
+# `lossless_*` sorts before `syntactic_*`, and since #70 every Miri cell aborted inside the
+# lossless tower before reaching them. `miri.yml` has no `success` conclusion in its last 40
+# runs either, so nothing has covered them.
+#
+# They are also the most expensive thing here by a wide margin. Measured 2026-08-07 on one
+# aarch64-apple-darwin core, this model, nothing else on that core: ONE of the six tests in
+# `syntactic_span_extent.rs` — `trivia_injection_leaves_every_span_on_its_own_tokens` — had NOT
+# finished after 36 minutes. Its sibling sweeps 90 corpus entries where that one sweeps 56. For scale,
+# the whole lib suite is 183s and `tests/oracle.rs` is 180s.
+#
+# The number that matters and is NOT measurable from here is the GitHub runner's. `miri.yml`'s
+# header records 4h20m for the slowest cell of run 30963710061 — created before #72, so without
+# these two targets. A GitHub job is killed at 6 hours. If a cell starts timing out, this is the
+# reason, and the remedy is the one the i686 block above already demonstrates: reduce the
+# selection deliberately, in writing, naming what is given up. `--test`-level exclusion of these
+# two is the obvious first cut, and it costs less than it looks — Miri finds UB in code PATHS,
+# and these sweeps vary the INPUT over paths the lib tests, `oracle.rs` and
+# `tokora_conformance.rs` already interpret.
+#
+# It is not cut pre-emptively, because dropping coverage on an estimate is the mistake in the
+# other direction, and nothing here has a CI measurement yet.
 if [ "$TARGET" = "i686-unknown-linux-gnu" ]; then
   MIRIFLAGS="$MIRIFLAGS -Zmiri-address-reuse-rate=1.0"
   TEST_ARGS=""
+  TESTS_SELECTED=0
 else
   TEST_ARGS="--tests"
+  TESTS_SELECTED=1
 fi
 
 export MIRIFLAGS
 
-cargo miri test $TEST_ARGS --target $TARGET --lib
+# ── WHY `-p smear`, AND WHAT IT COSTS ───────────────────────────────────────────────────────
+#
+# This line said `cargo miri test $TEST_ARGS --target $TARGET --lib` until #77 — no `-p`, so it
+# selected every workspace member, and cargo unified their features. `smear` does NOT default to
+# `rowan`, but `benchmarks` and `smear-smoke` both enable it, so the resolve turned it on and the
+# whole lossless CST tower entered this cell. Nobody widened the scope; #70 and then #84 added a
+# member and the arithmetic did it. See the note in the root `Cargo.toml`.
+#
+# The widening was not survivable, and that is the finding rather than an inconvenience.
+# `rowan 0.16.1` has undefined behaviour reachable from its ordinary public API, under BOTH
+# aliasing models and in two independent places:
+#
+#   * Tree Borrows — THIS model — `src/cursor.rs:219`, `rowan::cursor::free` deallocating a
+#     `Box<NodeData>` through a tag an ancestor's `Cell` still holds frozen. Reached from
+#     dropping any red-tree `SyntaxNode`; `smear/tests/lossless_roundtrip.rs` trips it on
+#     `parse_document(src).syntax().text().to_string()`, which is as ordinary as this API gets.
+#   * Stacked Borrows — `src/arc.rs:260`, a `&HeaderSlice<H, [T]>` forged over the whole slice
+#     out of a `&self` whose retag covers only the header. Reached from
+#     `GreenNodeBuilder::finish_node`, i.e. from building ANY tree. Tree Borrows accepts that
+#     one — upstream's position is that Stacked Borrows does not support the pattern rowan
+#     needs — which is why the two models fail in different places rather than the same one.
+#
+# Both were reproduced on 2026-08-07 by two standalone programs that name nothing but rowan's
+# public API, against `0.15.19`, `0.16.1`, `0.16.2` (yanked) and `0.17.0` — the newest release,
+# published 2026-08-02. The construct is byte-identical in all four, so THERE IS NO VERSION TO
+# BUMP TO. Upstream has had it reported since 2021 (rust-analyzer/rowan#108, and #163, #192);
+# the only fix attempt, PR #211, is a conflicting draft whose own description says the mutable
+# path still fails under Tree Borrows.
+#
+# So `-p smear` is not a cost/benefit trade about minutes. The lossless tower CANNOT be
+# interpreted, at any price, until rowan is fixed — and the 33 `#![cfg(feature = "rowan")]`
+# targets in `smear/tests/` are therefore excluded here rather than left to fail. `-p smear` is
+# the mechanism because it is the one that a future workspace member cannot undo: feature
+# unification is over the SELECTED packages, and this selects one.
+#
+# What that leaves covered is the half where this project's own `unsafe` lives — the SIMD lexer
+# and the syntactic parser, through `tokora`'s substrate — and `ci/miri_scope.py` below asserts
+# that the covered/excluded split is exactly the one written here, in both directions. Read its
+# header before changing any of this.
+LOG="$(mktemp)"
+set +e
+cargo miri test -p smear $TEST_ARGS --target "$TARGET" --lib 2>&1 | tee "$LOG"
+STATUS=${PIPESTATUS[0]}
+set -e
+
+# Always run the scope guard, including after a failed run: the excluded set it prints is the
+# statement of what this cell does not cover, and that is worth reading either way. Its own
+# verdict is folded in below rather than allowed to mask Miri's.
+SCOPE=0
+python3 ci/miri_scope.py --log "$LOG" --tests-selected "$TESTS_SELECTED" \
+  --miri-status "$STATUS" || SCOPE=$?
+rm -f "$LOG"
+
+if [ "$STATUS" -ne 0 ]; then
+  exit "$STATUS"
+fi
+exit "$SCOPE"
 

--- a/smear-benches/Cargo.toml
+++ b/smear-benches/Cargo.toml
@@ -1,0 +1,110 @@
+[package]
+name = "smear-benches"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+description = "smear's criterion benchmarks. Not published; exists so `criterion` is not in `smear`'s own dependency graph."
+publish = false
+
+# ── WHY THE BENCHES LIVE IN THEIR OWN MEMBER ────────────────────────────────────────────────
+#
+# `criterion 0.8.2` depends on `alloca 0.4.0`, whose build script compiles `alloca.c` through
+# cc-rs. Cross-compiling to an apple target hands the HOST `cc` an `-arch x86_64` /
+# `-arch arm64` and an `-mmacosx-version-min=...`; a Linux `cc` rejects all three, and building
+# them needs Apple clang and the macOS SDK. Cargo resolves dev-dependencies per PACKAGE and not
+# per target, so while `criterion` sat in `smear`'s `[dev-dependencies]`, ANY selection that
+# built a `smear` test target for an apple target built `alloca` too — including
+# `cargo miri test --target x86_64-apple-darwin`, which died in a C compiler before Miri
+# interpreted a single instruction.
+#
+# That, and nothing about Miri, is why four Miri cells ran on `macos-latest`; the header of
+# `.github/workflows/miri.yml` carried the measurement and named this move as the way out.
+# Cargo has no optional dev-dependency, so a package boundary is the only mechanism: `criterion`
+# is a dev-dependency of THIS package, `smear` has nothing of the sort, and the four apple Miri
+# cells now run on `ubuntu-latest`. The same boundary also takes `apollo-parser` out of `smear`'s
+# dev graph — and with it `rowan`, which is the crate `#77` is about.
+#
+# ── AND WHY THESE BENCH TARGETS HAVE NO `required-features` ─────────────────────────────────
+#
+# In `smear/Cargo.toml` each `[[bench]]` carried one — `["std", "graphql", "graphqlx"]` for
+# `lex_baseline`, `["parser", <dialect>]` for the other three — because `smear`'s features can be
+# off and a bench naming a gated API would then fail to COMPILE. A bench whose required features
+# are unmet is SKIPPED, not failed: cargo compiles nothing, prints nothing and exits 0, which is
+# the same silence `#73` is about.
+#
+# Here there is nothing to skip on. The `smear` dependency below pins the feature point, so all
+# four benches compile in every configuration this package can be built in and a
+# `required-features` entry would be a tautology that could only ever go stale. The skip hazard
+# is removed by construction instead of guarded against.
+
+[dependencies]
+# The union of the four `required-features` sets these benches used to declare, plus `smallvec`.
+#
+# `default-features = false` with the set written out, so it is this list and not whatever
+# `default` happens to carry on the day — the shape `#81` was about. The list is nonetheless
+# element-for-element what `smear`'s `default` resolves to today, and deliberately so: a
+# benchmark has to measure the configuration a consumer gets from `cargo add smear`, and
+# `smallvec` is in that default and changes the collection backing on the measured paths. It is
+# in the list for that reason and not because a bench names it.
+#
+# `rowan` is deliberately ABSENT. None of the four benches touches the lossless CST tower —
+# `smear-apollo-bench` in `benchmarks/` is the member that measures it, against apollo-parser —
+# and enabling it here would compile the tower into four binaries that never enter it.
+#
+# ONE FEATURE IS LOST BY THE MOVE, and it is inert: `test-support`. Inside `smear` it was on for
+# every dev target, benches included, because that package dev-depends on itself to enable it.
+# From here there is no such edge. It changes nothing measured: everything it compiles lives
+# inside the `rowan`-gated tower, which is off in this set, so it was already compiling to
+# nothing in a bench build. Recorded because "the benches no longer resolve the same feature set"
+# is the kind of difference that would otherwise be discovered by a number moving.
+smear = { workspace = true, default-features = false, features = [
+  "std",
+  "graphql",
+  "graphqlx",
+  "parser",
+  "smallvec",
+] }
+# Named directly because all four benches spell `tokora::{Parse, Parser}` to drive a parse.
+# The workspace entry pins the same feature point `smear` resolves, so cargo links ONE copy and
+# the traits the benches name are the traits `smear`'s parsers implement.
+tokora.workspace = true
+
+[dev-dependencies]
+criterion = "0.8"
+
+# The three like-for-like comparison parsers `executables.rs` and `type_system.rs` measure
+# against. They moved here with the benches that are their only callers; no test, example or
+# source file in `smear` ever named one. `apollo-parser` is the load-bearing removal: it is the
+# only edge that put `rowan` — the crate whose UB `#77` records — into `smear`'s dependency
+# graph at all, once `smear`'s own `rowan` feature is off.
+apollo-parser = "0.8.6"
+graphql-parser = "0.4.1"
+async-graphql-parser = "7.2.1"
+cynic-parser = "=0.11.2"
+
+[lints]
+workspace = true
+
+# Disable the default libtest bench harness on all four; every bench goes through criterion.
+[[bench]]
+name = "lex_baseline"
+path = "benches/lex_baseline.rs"
+harness = false
+
+[[bench]]
+name = "executables"
+path = "benches/executables.rs"
+harness = false
+
+[[bench]]
+name = "type_system"
+path = "benches/type_system.rs"
+harness = false
+
+[[bench]]
+name = "graphqlx"
+path = "benches/graphqlx.rs"
+harness = false

--- a/smear-benches/bench.sh
+++ b/smear-benches/bench.sh
@@ -4,6 +4,11 @@
 #   ./bench.sh                  # runs syntactic + simd_phase1
 #   ./bench.sh lossless         # also includes the lossless group
 #   ./bench.sh all              # runs all three groups
+#
+# Lives beside the benches it drives. It was `smear/bench.sh` and `cd`d to its own directory, so
+# the bare `cargo bench --bench lex_baseline` below resolved against `smear`'s manifest; moving
+# the benches to this member without moving this file would have left a script that still ran
+# and still exited 0 while selecting a package with no `[[bench]]` target left in it.
 
 set -euo pipefail
 cd "$(dirname "$0")"

--- a/smear-benches/benches/executables.rs
+++ b/smear-benches/benches/executables.rs
@@ -14,43 +14,49 @@ struct Fixture {
 const FIXTURES: &[Fixture] = &[
   Fixture {
     name: "bench_01_tiny_simple",
-    source: include_str!("../tests/fixtures/executables/bench_01_tiny_simple.graphql"),
+    source: include_str!("../../smear/tests/fixtures/executables/bench_01_tiny_simple.graphql"),
   },
   Fixture {
     name: "bench_02_small_simple",
-    source: include_str!("../tests/fixtures/executables/bench_02_small_simple.graphql"),
+    source: include_str!("../../smear/tests/fixtures/executables/bench_02_small_simple.graphql"),
   },
   Fixture {
     name: "bench_03_small_variables",
-    source: include_str!("../tests/fixtures/executables/bench_03_small_variables.graphql"),
+    source: include_str!("../../smear/tests/fixtures/executables/bench_03_small_variables.graphql"),
   },
   Fixture {
     name: "bench_04_medium_nested",
-    source: include_str!("../tests/fixtures/executables/bench_04_medium_nested.graphql"),
+    source: include_str!("../../smear/tests/fixtures/executables/bench_04_medium_nested.graphql"),
   },
   Fixture {
     name: "bench_05_medium_fragments",
-    source: include_str!("../tests/fixtures/executables/bench_05_medium_fragments.graphql"),
+    source: include_str!(
+      "../../smear/tests/fixtures/executables/bench_05_medium_fragments.graphql"
+    ),
   },
   Fixture {
     name: "bench_06_large_complex",
-    source: include_str!("../tests/fixtures/executables/bench_06_large_complex.graphql"),
+    source: include_str!("../../smear/tests/fixtures/executables/bench_06_large_complex.graphql"),
   },
   Fixture {
     name: "bench_07_large_deep_nesting",
-    source: include_str!("../tests/fixtures/executables/bench_07_large_deep_nesting.graphql"),
+    source: include_str!(
+      "../../smear/tests/fixtures/executables/bench_07_large_deep_nesting.graphql"
+    ),
   },
   Fixture {
     name: "bench_08_many_fields",
-    source: include_str!("../tests/fixtures/executables/bench_08_many_fields.graphql"),
+    source: include_str!("../../smear/tests/fixtures/executables/bench_08_many_fields.graphql"),
   },
   Fixture {
     name: "bench_09_many_aliases",
-    source: include_str!("../tests/fixtures/executables/bench_09_many_aliases.graphql"),
+    source: include_str!("../../smear/tests/fixtures/executables/bench_09_many_aliases.graphql"),
   },
   Fixture {
     name: "bench_10_huge_comprehensive",
-    source: include_str!("../tests/fixtures/executables/bench_10_huge_comprehensive.graphql"),
+    source: include_str!(
+      "../../smear/tests/fixtures/executables/bench_10_huge_comprehensive.graphql"
+    ),
   },
 ];
 

--- a/smear-benches/benches/graphqlx.rs
+++ b/smear-benches/benches/graphqlx.rs
@@ -21,21 +21,27 @@ struct Fixture {
 const FIXTURES: &[Fixture] = &[
   Fixture {
     name: "graphqlx_01_imports_and_paths",
-    source: include_str!("../tests/fixtures/parser/graphqlx/ok/0013_complex_import.graphqlx"),
+    source: include_str!(
+      "../../smear/tests/fixtures/parser/graphqlx/ok/0013_complex_import.graphqlx"
+    ),
   },
   Fixture {
     name: "graphqlx_02_definitions_and_extensions",
-    source: include_str!("../tests/fixtures/parser/graphqlx/ok/0015_extend_with_generics.graphqlx"),
+    source: include_str!(
+      "../../smear/tests/fixtures/parser/graphqlx/ok/0015_extend_with_generics.graphqlx"
+    ),
   },
   Fixture {
     name: "graphqlx_03_operations_and_generics",
     source: include_str!(
-      "../tests/fixtures/parser/graphqlx/ok/0016_operation_with_generics.graphqlx"
+      "../../smear/tests/fixtures/parser/graphqlx/ok/0016_operation_with_generics.graphqlx"
     ),
   },
   Fixture {
     name: "graphqlx_04_complex_fragments",
-    source: include_str!("../tests/fixtures/parser/graphqlx/ok/0022_complex_fragments.graphqlx"),
+    source: include_str!(
+      "../../smear/tests/fixtures/parser/graphqlx/ok/0022_complex_fragments.graphqlx"
+    ),
   },
 ];
 

--- a/smear-benches/benches/lex_baseline.rs
+++ b/smear-benches/benches/lex_baseline.rs
@@ -36,30 +36,35 @@ use std::hint::black_box;
 //   * github schema — a large public SDL (~340 KB)
 //   * gitlab schema — an extreme stress test (~2.3 MB)
 //
-// All paths are workspace-relative; if the fixtures move these `include_str!`
-// calls will fail at compile time, which is the right failure mode.
+// Every path below is relative to THIS FILE, which is how `include_str!` resolves; the corpora
+// live in `smear`'s test tree and are reached across the member boundary. If a fixture moves,
+// these calls fail at compile time, which is the right failure mode — and
+// `.github/workflows/ci.yml`'s `build` job compiles this member's bench targets so that failure
+// is reachable from CI, which it was not while the benches lived inside `smear` (no gate builds
+// a `[[bench]]` target: `cargo test`'s default selection omits them).
 
-const FIXTURES_EXEC: &str = "tests/fixtures/executables";
-const FIXTURES_SCHEMA: &str = "tests/fixtures/schemas";
+const FIXTURES_EXEC: &str = "smear/tests/fixtures/executables";
+const FIXTURES_SCHEMA: &str = "smear/tests/fixtures/schemas";
 
 // Executable queries.
-const Q_TINY: &str = include_str!("../tests/fixtures/executables/bench_01_tiny_simple.graphql");
+const Q_TINY: &str =
+  include_str!("../../smear/tests/fixtures/executables/bench_01_tiny_simple.graphql");
 const Q_SMALL: &str =
-  include_str!("../tests/fixtures/executables/bench_03_small_variables.graphql");
+  include_str!("../../smear/tests/fixtures/executables/bench_03_small_variables.graphql");
 const Q_MED_FRAG: &str =
-  include_str!("../tests/fixtures/executables/bench_05_medium_fragments.graphql");
+  include_str!("../../smear/tests/fixtures/executables/bench_05_medium_fragments.graphql");
 const Q_LARGE_COMPLEX: &str =
-  include_str!("../tests/fixtures/executables/bench_06_large_complex.graphql");
+  include_str!("../../smear/tests/fixtures/executables/bench_06_large_complex.graphql");
 const Q_HUGE: &str =
-  include_str!("../tests/fixtures/executables/bench_10_huge_comprehensive.graphql");
+  include_str!("../../smear/tests/fixtures/executables/bench_10_huge_comprehensive.graphql");
 const Q_KITCHEN_SINK: &str =
-  include_str!("../tests/fixtures/executables/kitchen-sink_canonical.graphql");
+  include_str!("../../smear/tests/fixtures/executables/kitchen-sink_canonical.graphql");
 
 // Schemas — ascending in size.
-const S_MINIMAL: &str = include_str!("../tests/fixtures/schemas/minimal.graphql");
-const S_GMX: &str = include_str!("../tests/fixtures/schemas/gmx_schema.graphql");
-const S_GITHUB: &str = include_str!("../tests/fixtures/schemas/github_schema.graphql");
-const S_GITLAB: &str = include_str!("../tests/fixtures/schemas/gitlab_schema.graphql");
+const S_MINIMAL: &str = include_str!("../../smear/tests/fixtures/schemas/minimal.graphql");
+const S_GMX: &str = include_str!("../../smear/tests/fixtures/schemas/gmx_schema.graphql");
+const S_GITHUB: &str = include_str!("../../smear/tests/fixtures/schemas/github_schema.graphql");
+const S_GITLAB: &str = include_str!("../../smear/tests/fixtures/schemas/gitlab_schema.graphql");
 
 /// All inputs, paired with a short label for the bench id.
 const INPUTS: &[(&str, &str)] = &[
@@ -246,8 +251,14 @@ fn bench_graphqlx(c: &mut Criterion) {
 criterion_group!(benches, bench_lossless, bench_simd, bench_graphqlx);
 criterion_main!(benches);
 
-// Compile-time touch on the fixture roots so reorganising those dirs gives
-// a clear error pointing at this file instead of cryptic missing-file
-// errors from `include_str!`.
+// The two fixture roots every `include_str!` above reaches into, written once as
+// WORKSPACE-relative paths so a reader can find them without composing `../../` by hand.
+//
+// This is documentation, not a check, and the comment that used to sit here called it a
+// "compile-time touch on the fixture roots" — a `const &str` holding a path does not verify
+// that the path exists, so it caught nothing and never could. Naming it accurately matters
+// here specifically: a construct that reads as a gate and is not one is #73's whole subject.
+// The real gate is the `include_str!` calls themselves, and CI reaching them is what
+// `.github/workflows/ci.yml`'s `build` job now guarantees.
 #[allow(dead_code)]
-const _FIXTURE_PATHS: (&str, &str) = (FIXTURES_EXEC, FIXTURES_SCHEMA);
+const _FIXTURE_ROOTS: (&str, &str) = (FIXTURES_EXEC, FIXTURES_SCHEMA);

--- a/smear-benches/benches/type_system.rs
+++ b/smear-benches/benches/type_system.rs
@@ -14,23 +14,25 @@ struct Fixture {
 const FIXTURES: &[Fixture] = &[
   Fixture {
     name: "type_system_01_minimal",
-    source: include_str!("../tests/fixtures/schemas/minimal_type.graphql"),
+    source: include_str!("../../smear/tests/fixtures/schemas/minimal_type.graphql"),
   },
   Fixture {
     name: "type_system_02_descriptions",
-    source: include_str!("../tests/fixtures/schemas/directive_descriptions_canonical.graphql"),
+    source: include_str!(
+      "../../smear/tests/fixtures/schemas/directive_descriptions_canonical.graphql"
+    ),
   },
   Fixture {
     name: "type_system_03_descriptions_and_extensions",
-    source: include_str!("../tests/fixtures/schemas/kitchen-sink_canonical.graphql"),
+    source: include_str!("../../smear/tests/fixtures/schemas/kitchen-sink_canonical.graphql"),
   },
   Fixture {
     name: "type_system_04_medium_lending_schema",
-    source: include_str!("../tests/fixtures/schemas/schema-lending.graphql"),
+    source: include_str!("../../smear/tests/fixtures/schemas/schema-lending.graphql"),
   },
   Fixture {
     name: "type_system_05_large_apollo_studio_schema",
-    source: include_str!("../tests/fixtures/schemas/apollo-studio.graphql"),
+    source: include_str!("../../smear/tests/fixtures/schemas/apollo-studio.graphql"),
   },
 ];
 

--- a/smear/Cargo.toml
+++ b/smear/Cargo.toml
@@ -52,6 +52,18 @@ smol-bytes = ["dep:smol-bytes", "tokora/smol_bytes_0_1"]
 
 # The lossless CST tower. Reachable through the crate named `smear` for the first time here (#81).
 # `parser` because the tower lives in that module; `std` because the runner needs it.
+#
+# EVERYTHING THIS FEATURE COMPILES IS OUTSIDE MIRI'S REACH, and will stay outside it until
+# `rowan` is fixed upstream. `rowan 0.16.1` executes undefined behaviour on the ordinary path —
+# `src/arc.rs` under Stacked Borrows, from building any green tree, and `src/cursor.rs` under
+# Tree Borrows, from dropping any red one. Both are live in every published version through
+# `0.17.0`, both were reproduced against rowan alone with no smear code involved, and there is
+# no version to move to. #77 has the evidence; `ci/miri_sb.sh` has the decision; and
+# `ci/miri_scope.py` will fail the Miri matrix if this feature ever resolves ON inside it, so
+# turning it on there is not something that can happen by accident again.
+#
+# This says nothing against the feature — it is a headline capability and its 33 integration
+# targets run under `cargo test` like everything else. It is only that ONE tool cannot see it.
 rowan = ["dep:rowan", "tokora/rowan", "std", "parser"]
 
 # Instruments both dialects' lossless productions with a per-node-kind hit counter, so each
@@ -114,42 +126,38 @@ rowan = { version = "0.16", optional = true }
 # published manifest does not name a version of itself.
 smear = { path = ".", features = ["test-support"] }
 
-criterion = "0.8"
 # `tokora::conformance` is the lexer-contract test kit; it is test-only, so the
 # feature is pulled in here rather than in the normal dependency.
 tokora = { workspace = true, features = ["conformance"] }
-apollo-parser = "0.8.6"
-graphql-parser = "0.4.1"
-async-graphql-parser = "7.2.1"
-cynic-parser = "=0.11.2"
 
-# Disable the default libtest bench harness; all benches go through criterion.
+# ── WHAT IS DELIBERATELY NOT HERE ───────────────────────────────────────────────────────────
+#
+# `criterion`, and with it `apollo-parser`, `graphql-parser`, `async-graphql-parser` and
+# `cynic-parser`. All five were dev-dependencies of this package and all five were reached from
+# `benches/` and from nowhere else — no test, example or source file named one. They moved to
+# the `smear-benches` member along with the four `[[bench]]` sections that used them; that
+# manifest's header carries the reasoning in full.
+#
+# The short version, because putting any of them back has a cost that is not local. Cargo
+# resolves dev-dependencies per PACKAGE, not per target, so every entry in this block is built
+# for every test target of this package:
+#
+#   * `criterion` pulls `alloca`, whose build script compiles C through cc-rs. A Linux `cc`
+#     rejects the `-arch arm64` / `-mmacosx-version-min` that cc-rs hands it for an apple
+#     target, so this one edge is what forced four Miri cells onto a `macos-latest` runner —
+#     for a reason that has nothing to do with Miri.
+#   * `apollo-parser` pulls `rowan`, and with this package's own `rowan` feature off that edge
+#     was the ONLY thing putting rowan in the graph at all. rowan is the crate whose undefined
+#     behaviour is #77.
+#
+# A dev-dependency added here that drags either one back re-creates both conditions, and does it
+# silently — nothing in CI reports on the shape of this block.
+#
+# `[lib] bench = false` stays. This package declares no `[[bench]]` target any more, so nothing
+# here goes through criterion — but the setting is about the LIB, and without it cargo still
+# builds a libtest bench harness for `src/lib.rs`.
 [lib]
 bench = false
-
-[[bench]]
-name = "lex_baseline"
-path = "benches/lex_baseline.rs"
-harness = false
-required-features = ["std", "graphql", "graphqlx"]
-
-[[bench]]
-name = "executables"
-path = "benches/executables.rs"
-harness = false
-required-features = ["parser", "graphql"]
-
-[[bench]]
-name = "type_system"
-path = "benches/type_system.rs"
-harness = false
-required-features = ["parser", "graphql"]
-
-[[bench]]
-name = "graphqlx"
-path = "benches/graphqlx.rs"
-harness = false
-required-features = ["parser", "graphqlx"]
 
 # Both examples read files from argv and print to stdout, and they drive the
 # GraphQL lossless lexer, so they need `std` and `graphql`.


### PR DESCRIPTION
Closes #77. Settles #73.