### PR TITLE
feat(validator): the built-once Schema, with draft §3 running inside its build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,9 +231,9 @@ jobs:
         # together with exactly one other feature. This restores those pairs deliberately, and the
         # two that matter are `parser` x `bytes` (60 parser cfg sites) and `parser` x dialect.
         #
-        # `rowan` and `lossless-coverage` are excluded because they already imply `parser`, so
-        # their pass-1 cells ARE pairs; `default`, `--no-default-features` and `--all-features`
-        # are excluded because those three runs would duplicate pass-1 exactly.
+        # `rowan`, `lossless-coverage` and `validator` are excluded because they already imply
+        # `parser`, so their pass-1 cells ARE pairs; `default`, `--no-default-features` and
+        # `--all-features` are excluded because those three runs would duplicate pass-1 exactly.
         #
         # `parser` itself is NOT in the exclude list: cargo-hack rejects a feature named by both
         # `--features` and `--exclude-features` (verified against 0.6.43, "specified by both"),
@@ -241,7 +241,7 @@ jobs:
         # Nine cells, one per remaining feature, and a feature added to the manifest later joins
         # them without anyone editing this file.
         cargo hack clippy -p smear --each-feature --features parser \
-          --exclude-features rowan,lossless-coverage,default \
+          --exclude-features rowan,lossless-coverage,validator,default \
           --exclude-no-default-features --exclude-all-features
 
   # Run tests on some extra platforms
@@ -284,7 +284,53 @@ jobs:
       - name: cargo build --target ${{ matrix.target }}
         run: |
           rustup target add ${{ matrix.target }}
-          cargo build --target ${{ matrix.target }} 
+          cargo build --target ${{ matrix.target }}
+
+  # The validator's schema representation, on a core with no compare-and-swap.
+  #
+  # NOT a cell of the `cross` matrix above, and it cannot become one: that job builds the whole
+  # workspace, and `smear` does not build for `thumbv6m-none-eabi` — its syntactic AST offers an
+  # `Arc`-backed spelling of recursive list types, which needs `alloc::sync`. The claim under test
+  # is narrower and is the one the design rests on: `Schema` holds no `Arc`, no atomics and no
+  # interior mutability and depends on nothing but `core` and `alloc`, so an embedded core can
+  # hold one and the caller picks the pointer.
+  #
+  # `-p smear-noatomic` names the package rather than filtering, so a rename is a hard error here
+  # instead of a warn-and-exit-0. That member `#[path]`-includes `smear`'s own representation
+  # files, so this builds the shipped source and not a copy of it — verified to discriminate by
+  # adding an `Arc` to the representation, which fails with "cannot find `sync` in `std`".
+  noatomic:
+    name: noatomic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache cargo build and registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-noatomic-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-noatomic-
+      - name: Install Rust
+        run: rustup update stable && rustup default stable
+      - name: cargo build -p smear-noatomic --target thumbv6m-none-eabi
+        run: |
+          rustup target add thumbv6m-none-eabi
+          cargo build -p smear-noatomic --target thumbv6m-none-eabi
+      # An empty `[dependencies]` table is the other half of the claim, and a comment cannot
+      # enforce it. Read out of `cargo metadata` so a dependency added to the manifest fails here
+      # rather than quietly widening what the target build proves.
+      - name: the representation depends on nothing
+        run: |
+          DEPS="$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; p=[x for x in json.load(sys.stdin)["packages"] if x["name"]=="smear-noatomic"][0]; print(len(p["dependencies"]))')"
+          if [ "$DEPS" != "0" ]; then
+            echo "::error::smear-noatomic declares $DEPS dependencies; the whole point of the member is that it declares none"
+            exit 1
+          fi
 
   build:
     name: build
@@ -327,9 +373,9 @@ jobs:
         # together with exactly one other feature. This restores those pairs deliberately, and the
         # two that matter are `parser` x `bytes` (60 parser cfg sites) and `parser` x dialect.
         #
-        # `rowan` and `lossless-coverage` are excluded because they already imply `parser`, so
-        # their pass-1 cells ARE pairs; `default`, `--no-default-features` and `--all-features`
-        # are excluded because those three runs would duplicate pass-1 exactly.
+        # `rowan`, `lossless-coverage` and `validator` are excluded because they already imply
+        # `parser`, so their pass-1 cells ARE pairs; `default`, `--no-default-features` and
+        # `--all-features` are excluded because those three runs would duplicate pass-1 exactly.
         #
         # `parser` itself is NOT in the exclude list: cargo-hack rejects a feature named by both
         # `--features` and `--exclude-features` (verified against 0.6.43, "specified by both"),
@@ -337,7 +383,7 @@ jobs:
         # Nine cells, one per remaining feature, and a feature added to the manifest later joins
         # them without anyone editing this file.
         cargo hack build -p smear --each-feature --features parser \
-          --exclude-features rowan,lossless-coverage,default \
+          --exclude-features rowan,lossless-coverage,validator,default \
           --exclude-no-default-features --exclude-all-features
         # Pass 3 — the four criterion benches, which NOTHING ELSE IN CI COMPILES.
         #

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -138,9 +138,9 @@ jobs:
         # together with exactly one other feature. This restores those pairs deliberately, and the
         # two that matter are `parser` x `bytes` (60 parser cfg sites) and `parser` x dialect.
         #
-        # `rowan` and `lossless-coverage` are excluded because they already imply `parser`, so
-        # their pass-1 cells ARE pairs; `default`, `--no-default-features` and `--all-features`
-        # are excluded because those three runs would duplicate pass-1 exactly.
+        # `rowan`, `lossless-coverage` and `validator` are excluded because they already imply
+        # `parser`, so their pass-1 cells ARE pairs; `default`, `--no-default-features` and
+        # `--all-features` are excluded because those three runs would duplicate pass-1 exactly.
         #
         # `parser` itself is NOT in the exclude list: cargo-hack rejects a feature named by both
         # `--features` and `--exclude-features` (verified against 0.6.43, "specified by both"),
@@ -148,7 +148,7 @@ jobs:
         # Nine cells, one per remaining feature, and a feature added to the manifest later joins
         # them without anyone editing this file.
         cargo hack clippy -p smear --each-feature --features parser \
-          --exclude-features rowan,lossless-coverage,default \
+          --exclude-features rowan,lossless-coverage,validator,default \
           --exclude-no-default-features --exclude-all-features
 
   build:
@@ -188,9 +188,9 @@ jobs:
         # together with exactly one other feature. This restores those pairs deliberately, and the
         # two that matter are `parser` x `bytes` (60 parser cfg sites) and `parser` x dialect.
         #
-        # `rowan` and `lossless-coverage` are excluded because they already imply `parser`, so
-        # their pass-1 cells ARE pairs; `default`, `--no-default-features` and `--all-features`
-        # are excluded because those three runs would duplicate pass-1 exactly.
+        # `rowan`, `lossless-coverage` and `validator` are excluded because they already imply
+        # `parser`, so their pass-1 cells ARE pairs; `default`, `--no-default-features` and
+        # `--all-features` are excluded because those three runs would duplicate pass-1 exactly.
         #
         # `parser` itself is NOT in the exclude list: cargo-hack rejects a feature named by both
         # `--features` and `--exclude-features` (verified against 0.6.43, "specified by both"),
@@ -198,7 +198,7 @@ jobs:
         # Nine cells, one per remaining feature, and a feature added to the manifest later joins
         # them without anyone editing this file.
         cargo hack build -p smear --each-feature --features parser \
-          --exclude-features rowan,lossless-coverage,default \
+          --exclude-features rowan,lossless-coverage,validator,default \
           --exclude-no-default-features --exclude-all-features
 
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,21 @@ members = [
   "benchmarks",
   "smear",
   "smear-benches",
+  "smear-noatomic",
   "smear-smoke",
 ]
 
-# ── THREE OF THE FOUR MEMBERS PULL `smear` PAST ITS DEFAULT FEATURE SET ──────────────────────
+# ── THREE OF THE FIVE MEMBERS PULL `smear` PAST ITS DEFAULT FEATURE SET ──────────────────────
 #
 # `benchmarks` and `smear-smoke` both enable `smear/rowan`; `smear-smoke` also enables
 # `lossless-coverage` and `test-support`. Cargo unifies features across the SELECTED packages,
 # so a bare workspace-wide command resolves `smear` with every feature it declares turned on.
+#
+# `smear-noatomic` is the one member this arithmetic does not reach, and deliberately so: its
+# `[dependencies]` table is empty and CI asserts that out of `cargo metadata`, so it has no edge
+# to `smear` to unify a feature through. It reaches the representation by `#[path]`-including
+# those source files, which is what lets it build for a core with no compare-and-swap while
+# `smear` itself cannot.
 #
 # That arithmetic is how the entire lossless CST tower entered the Miri selection without anyone
 # choosing it. #70 added `benchmarks`, #84 added `smear-smoke`, and each time the Miri scripts —
@@ -20,7 +27,7 @@ members = [
 #
 # There is deliberately NO `default-members` narrowing that away. It would pin the Miri
 # selection at the price of silently narrowing every OTHER bare command in the repository:
-# `cargo test --all-features` in `.github/workflows/ci.yml` is meant to cover all four members
+# `cargo test --all-features` in `.github/workflows/ci.yml` is meant to cover all five members
 # and would quietly have stopped, with no exit code saying so — the same defect class, one turn
 # later. The selection is pinned where it is READ instead: `ci/miri_sb.sh` and `ci/miri_tb.sh`
 # pass `-p smear`, and `ci/miri_scope.py` fails the run if what got interpreted is not what

--- a/smear-noatomic/Cargo.toml
+++ b/smear-noatomic/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "smear-noatomic"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+description = "Compiles the validator's `Schema` representation for a core with no atomics, out of `smear`'s own source files"
+publish = false
+
+# The standing proof of one of the validator's load-bearing claims: the schema representation
+# needs no shared-ownership primitive, no interior mutability and no dependency, so it builds for
+# a target that has no compare-and-swap instruction at all.
+#
+# It does that by compiling `smear`'s own files — `#[path]`-included, not copied. A copy would
+# pass forever after the original drifted; this member fails to build the moment a `use` in
+# `smear/src/validator/schema/repr/` reaches outside `core` and `alloc`.
+#
+# The gate is `cargo build -p smear-noatomic --target thumbv6m-none-eabi`. `smear` itself cannot
+# build for that target and is not expected to: its syntactic AST offers an `Arc`-backed list-type
+# spelling (`parser::graphql::ast::ArcType`), which needs `alloc::sync` and therefore native
+# atomics. That is exactly why the claim is about the *schema*, which the caller wraps in whatever
+# pointer their platform has, and not about the crate.
+
+# Deliberately empty, and asserted by CI rather than by comment: the representation depends on
+# nothing.
+[dependencies]
+
+[lints]
+workspace = true

--- a/smear-noatomic/src/lib.rs
+++ b/smear-noatomic/src/lib.rs
@@ -1,0 +1,109 @@
+//! `smear`'s schema representation, compiled for a core without atomics.
+//!
+//! # What this member is for
+//!
+//! `smear::validator::schema` claims three things about [`repr::Schema`] that a reader
+//! has to take on trust unless something checks them:
+//!
+//! 1. it depends on nothing but `core` and `alloc`;
+//! 2. it contains no `Arc`, no atomics and no interior mutability, so it is `Send + Sync` by
+//!    construction and needs no shared-ownership primitive of its own;
+//! 3. it is therefore reachable from an embedded target — including one with no native
+//!    compare-and-swap.
+//!
+//! This crate turns all three into a build. It is `#![no_std]` over `alloc`, it has an empty
+//! `[dependencies]` table, and CI builds it for `thumbv6m-none-eabi` (Cortex-M0+), where
+//! `alloc::sync` does not exist and `core::sync::atomic`'s pointer-width types are absent. An
+//! `Arc`, a `Cell` or a stray `use` anywhere in the representation fails that build.
+//!
+//! # It compiles the originals, not a copy
+//!
+//! The module below is `#[path]`-included straight out of `smear/src/validator/schema/repr/`.
+//! Nothing is duplicated, so nothing can drift: this is the same source text `smear` ships, read
+//! through a second crate root that supplies a different `std`.
+//!
+//! # Why `smear` itself is not built for the target
+//!
+//! It cannot be. `smear::parser::graphql::ast` offers an `Arc`-backed spelling of recursive list
+//! types (`ArcType`), which needs `alloc::sync` and therefore native atomics, and the crate's
+//! `memspan` dependency is pulled in with `std`. The claim under test was never that the parser
+//! reaches an embedded core — it is that the *schema* does, because a build-once, read-many value
+//! is shared as `&Schema` and lets the caller pick the pointer: `alloc::sync::Arc` where there
+//! are atomics, `portable_atomic_util::Arc` where there are not.
+
+#![no_std]
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+// The same aliasing `smear` uses when its `std` feature is off, which is what lets the included
+// files spell their allocations `std::boxed::Box` in both crates.
+extern crate alloc as std;
+
+/// The schema representation, compiled from `smear`'s own files.
+#[path = "../../smear/src/validator/schema/repr/mod.rs"]
+pub mod repr;
+
+use repr::{
+  DirectiveDef, DirectiveLocations, FieldDef, InputValueDef, NameIndex, PackedType, Range32,
+  Schema, Sym, TypeDef, TypeId,
+};
+
+/// The claims, as compile-time assertions.
+///
+/// `Send + Sync` is the one the whole design rests on: validation takes `&Schema`, so a schema
+/// that were not both could not be shared, and the absence of interior mutability is what makes
+/// it both. The row types are asserted separately so a regression names the table it is in.
+const _: () = {
+  const fn send_sync<T: Send + Sync>() {}
+  let _ = send_sync::<Schema>;
+  let _ = send_sync::<NameIndex>;
+  let _ = send_sync::<TypeDef>;
+  let _ = send_sync::<FieldDef>;
+  let _ = send_sync::<InputValueDef>;
+  let _ = send_sync::<DirectiveDef>;
+
+  // Every row is a plain integer record, so the tables are `Box<[T]>` of `Copy` values with no
+  // interior pointers. `Copy` is the property that says so.
+  const fn plain<T: Copy>() {}
+  let _ = plain::<Sym>;
+  let _ = plain::<TypeId>;
+  let _ = plain::<Range32>;
+  let _ = plain::<PackedType>;
+  let _ = plain::<TypeDef>;
+  let _ = plain::<FieldDef>;
+  let _ = plain::<InputValueDef>;
+  let _ = plain::<DirectiveDef>;
+  let _ = plain::<DirectiveLocations>;
+};
+
+/// The wrapper word, exercised without a schema to build it from.
+///
+/// A `const` evaluation is the strongest form this can take: it runs at compile time on the
+/// target, needs no allocator and no test harness, and would stop the build rather than a test
+/// run. `[[Int!]!]!` is the shape that uses every code and both nesting directions.
+const _: () = {
+  let int = PackedType::named(Sym::new(0), TypeId::new(0));
+  assert!(int.depth() == 0);
+  assert!(!int.is_non_null());
+
+  let Some(non_null) = int.push_non_null() else {
+    panic!("one wrapper fits")
+  };
+  let Some(list) = non_null.push_list() else {
+    panic!("two wrappers fit")
+  };
+  let Some(list) = list.push_non_null() else {
+    panic!("three wrappers fit")
+  };
+  let Some(outer) = list.push_list() else {
+    panic!("four wrappers fit")
+  };
+  let Some(outer) = outer.push_non_null() else {
+    panic!("five wrappers fit")
+  };
+
+  assert!(outer.depth() == 5);
+  assert!(outer.is_non_null());
+  assert!(!outer.is_list());
+  assert!(outer.nullable().is_list());
+};

--- a/smear-smoke/Cargo.toml
+++ b/smear-smoke/Cargo.toml
@@ -33,6 +33,7 @@ smear = { path = "../smear", default-features = false, features = [
   "graphql",
   "graphqlx",
   "parser",
+  "validator",
   "smallvec",
   "bytes",
   "bstr",

--- a/smear-smoke/src/lib.rs
+++ b/smear-smoke/src/lib.rs
@@ -31,7 +31,7 @@
 //!   *package `smear-smoke` depends on `smear` with feature `lossless-coverage` but `smear` does
 //!   not have that feature*.
 //!
-//! One caveat on the second direction, found while proving it. Six of the twelve features —
+//! One caveat on the second direction, found while proving it. Six of the thirteen features —
 //! `bytes`, `bstr`, `hipstr`, `smol-bytes`, `smallvec`, `rowan` — share a name with an OPTIONAL
 //! DEPENDENCY, so deleting the explicit `[features]` line does not remove the name: cargo falls
 //! back to the implicit feature an optional dependency creates, resolution succeeds, and only the
@@ -119,6 +119,84 @@ pub fn graphqlx_parser(
     Document::<&str>::graphqlx,
   )
   .parse_str(src)
+}
+
+/// `validator` — the built-once schema, reached through the dependency edge and built from a
+/// parsed SDL document.
+///
+/// With the feature off, `smear::validator` is not a module and this function does not resolve.
+pub fn graphql_schema(
+  sdl: &str,
+) -> Result<smear::validator::Schema, smear::validator::SchemaErrors> {
+  use smear::parser::graphql::{
+    GraphQL, ast::TypeSystemDocument, error::GraphqlErrors, syntactic::GraphqlLexer,
+  };
+
+  let document = Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    TypeSystemDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(smear::parser::graphql::syntactic::type_system_document)
+  .parse_str(sdl)
+  .expect("the probe's SDL parses");
+
+  smear::validator::Schema::build(&document)
+}
+
+/// `validator`, the other half — the source-slice bound, asserted over `tokora`'s whole
+/// `Source<usize>` implementor lattice.
+///
+/// # Why this lives here and not in `smear`'s own tests
+///
+/// The claim is that `Schema::build`'s `S: AsRef<[u8]>` bound admits **every** slice type a
+/// `smear` parse can produce, so no caller has to newtype, narrow, or copy to build a schema.
+/// Proving it needs all four source-backing features on at once and all four backing crates
+/// nameable — which is this crate's configuration and nothing else's, since it enables every
+/// feature unconditionally and forbids `#[cfg]` on principle.
+///
+/// The assertion runs on `<Src as Source<usize>>::Slice<'_>` itself, the associated type the AST's
+/// `S` is instantiated with, and it instantiates the real `Schema::build` at that type rather than
+/// restating its bound. So it fails in both directions: a `tokora` change that gives a source a
+/// slice type outside `AsRef<[u8]>`, and a `smear` change that narrows the builder's bound.
+pub fn validator_source_lattice() {
+  use smear::{
+    lexer::tokora::Source,
+    parser::graphql::ast::TypeSystemDocument,
+    validator::{Schema, SchemaErrors},
+  };
+
+  fn assert_lattice_member<Src>()
+  where
+    Src: Source<usize> + ?Sized + 'static,
+    for<'a> <Src as Source<usize>>::Slice<'a>: AsRef<[u8]>,
+  {
+    fn builds<S: AsRef<[u8]>>(document: &TypeSystemDocument<S>) -> Result<Schema, SchemaErrors> {
+      Schema::build(document)
+    }
+    let _ = builds::<<Src as Source<usize>>::Slice<'static>>;
+  }
+
+  // Borrowed tier: slices are reborrows, so a diagnostic built from one cannot outlive the
+  // request buffer.
+  assert_lattice_member::<str>();
+  assert_lattice_member::<[u8]>();
+  assert_lattice_member::<&'static str>();
+  assert_lattice_member::<&'static [u8]>();
+  assert_lattice_member::<bstr::BStr>();
+  assert_lattice_member::<&'static bstr::BStr>();
+
+  // Refcounted tier: slices own, so a diagnostic may escape the call that produced it.
+  assert_lattice_member::<bytes::Bytes>();
+  assert_lattice_member::<smol_bytes::shared::Bytes>();
+  assert_lattice_member::<smol_bytes::compact::Bytes>();
+  assert_lattice_member::<smol_bytes::Utf8Bytes>();
+  assert_lattice_member::<smol_bytes::compact::Utf8Bytes>();
+
+  // Three-way tier: inline, borrowed, or shared, decided at runtime but pinned by `'h`.
+  assert_lattice_member::<hipstr::HipStr<'static>>();
+  assert_lattice_member::<hipstr::HipByt<'static>>();
 }
 
 /// `smallvec` — the error container is SmallVec-backed rather than `Vec`-backed.
@@ -241,6 +319,27 @@ pub mod exported_macro {
 mod tests {
   use std::collections::BTreeSet;
 
+  /// The source-lattice conformance assertion, run as a test so a failure names itself rather
+  /// than appearing as "the workspace does not build".
+  ///
+  /// The body compiles the claim; calling it is what puts it in a test report.
+  #[test]
+  fn the_validator_admits_every_source_slice_type() {
+    super::validator_source_lattice();
+  }
+
+  /// The validator, driven end to end across the dependency edge.
+  #[test]
+  fn the_validator_builds_a_schema_and_refuses_a_non_schema() {
+    let schema = super::graphql_schema("type Query { ok: Int }").expect("a schema");
+    assert!(schema.type_by_name(b"Query").is_some());
+    // Introspection is unconditional, feature or no feature.
+    assert!(schema.type_by_name(b"__Schema").is_some());
+
+    let errors = super::graphql_schema("type NotARoot { ok: Int }").expect_err("not a schema");
+    assert!(!errors.is_empty());
+  }
+
   /// Features named in `smear`'s manifest but deliberately not smoked, each with a written
   /// reason.
   ///
@@ -294,7 +393,7 @@ mod tests {
     // A census over an empty set passes vacuously, which is the failure mode this whole crate is
     // about. Assert it read something first.
     assert!(
-      declared.len() >= 12,
+      declared.len() >= 13,
       "read only {} features out of smear's manifest; the parse is wrong, not the manifest",
       declared.len()
     );

--- a/smear/Cargo.toml
+++ b/smear/Cargo.toml
@@ -44,6 +44,19 @@ graphqlx = []
 # can only ever be on is not a gate.
 parser = []
 
+# GraphQL document validation (`smear::validator`), including the built-once `Schema` and the
+# draft §3 "Type Validation" pass that runs inside its build.
+#
+# Off by default until the API stabilises; it flips into `default` alongside a minor bump. It
+# implies `parser` because the builder consumes a parsed `TypeSystemDocument`, and `graphql`
+# because the specification it implements is standard GraphQL's — GraphQLx deliberately has no
+# validator.
+#
+# It adds NO dependency. The schema representation is `core` + `alloc` and nothing else, which the
+# `smear-noatomic` workspace member holds to by compiling those very files for
+# `thumbv6m-none-eabi` with an empty `[dependencies]` table.
+validator = ["parser", "graphql"]
+
 smallvec = ["dep:smallvec"]
 bytes = ["dep:bytes", "tokora/bytes_1"]
 bstr = ["dep:bstr", "tokora/bstr_1"]

--- a/smear/src/lib.rs
+++ b/smear/src/lib.rs
@@ -66,6 +66,27 @@ pub mod lexer;
 #[allow(clippy::type_complexity)]
 pub mod parser;
 
+/// GraphQL document validation, and the built-once schema every rule reads.
+///
+/// Draft §3 "Type Validation" runs inside [`Schema::build`](validator::Schema::build), so a
+/// malformed SDL is refused once at startup rather than rediscovered per request.
+///
+/// Standard GraphQL only —
+#[cfg_attr(
+  feature = "graphqlx",
+  doc = "[`graphqlx`](parser::graphqlx) has no validator, deliberately: its generics, \
+         `where` constraints, map and set types and namespaced paths have no specification \
+         semantics, so validating them would be language design rather than conformance."
+)]
+#[cfg_attr(
+  not(feature = "graphqlx"),
+  doc = "the GraphQLx dialect has no validator, deliberately: its extensions have no \
+         specification semantics to validate against."
+)]
+#[cfg(feature = "validator")]
+#[cfg_attr(docsrs, doc(cfg(feature = "validator")))]
+pub mod validator;
+
 #[doc(hidden)]
 pub mod __private {
   pub use tokora;

--- a/smear/src/validator/mod.rs
+++ b/smear/src/validator/mod.rs
@@ -1,0 +1,43 @@
+//! GraphQL document validation.
+//!
+//! Standard GraphQL only. The `graphqlx` dialect's generics, `where` constraints, map and set
+//! types and namespaced paths have no specification semantics to validate against, so nothing in
+//! this module knows about them.
+//!
+//! # What is here now
+//!
+//! [`schema`](crate::validator::schema) — the built-once
+//! [`Schema`](crate::validator::schema::Schema) every rule reads, and the draft §3 "Type
+//! Validation" pass that runs while building it. A server rejects a malformed SDL exactly once,
+//! at startup, and never rediscovers it per request.
+//!
+//! Every link in this module's docs is crate-absolute on purpose. `pub mod validator;` in
+//! `lib.rs` carries an outer doc comment as well, and rustdoc resolves the merged fragments in
+//! the **parent** module's scope — so a `schema`-relative link here reports "no item named
+//! `schema` in module `smear`" under `RUSTDOCFLAGS="-D warnings"`.
+//!
+//! Executable-document validation (draft §5) is built on this substrate and lands separately.
+//!
+//! # The shape, and why
+//!
+//! Three properties of [`Schema`](crate::validator::schema::Schema) decide everything
+//! downstream:
+//!
+//! - **It is not generic over the document's source type.** The builder consumes a
+//!   `TypeSystemDocument<S>` for any `S: AsRef<[u8]>` — the bound `tokora`'s entire source lattice
+//!   satisfies — and produces one owned, source-independent value. So the SDL can be dropped the
+//!   moment the schema exists, and the schema can be `'static`, sent across threads, or handed to
+//!   a foreign caller.
+//! - **It holds no `Arc`, no atomics and no interior mutability.** Validation takes `&Schema`, so
+//!   there is no shared-ownership primitive to choose and no target tier to gate: the caller wraps
+//!   it in whatever pointer their platform has. That also forbids lazy interning and per-query
+//!   memoisation inside it, which is a constraint, not an oversight — it is what keeps a rule a
+//!   pure function of `(schema, document)`.
+//! - **Every cost a rule would otherwise pay per query is paid once, here.** Names are `u32`
+//!   symbols, field lookup is a binary search over a sym-sorted group, directive locations are a
+//!   `u32` mask, and an interface's implementors are a bitset — so draft 5.5.2.3, all four of its
+//!   subsections, is one word-`AND`.
+
+pub mod schema;
+
+pub use schema::{Schema, SchemaBuilder, SchemaError, SchemaErrorKind, SchemaErrors};

--- a/smear/src/validator/schema/builder.rs
+++ b/smear/src/validator/schema/builder.rs
@@ -1,0 +1,2160 @@
+//! Turning one or more `TypeSystemDocument`s into a [`Schema`], and refusing the ones that are
+//! not schemas.
+//!
+//! # Everything happens here, once
+//!
+//! The builder interns, merges extensions, injects the built-in and introspection definitions,
+//! resolves every type reference, runs draft §3 "Type Validation", and flattens the result into
+//! the tables validation reads. A server pays for all of it at startup and nothing per request —
+//! which is the whole reason the representation looks the way it does.
+//!
+//! # The source type stops at the door
+//!
+//! [`SchemaBuilder::document`] is generic over the document's source slice `S`, bounded by
+//! `AsRef<[u8]>` — the bound the entire `tokora` source lattice satisfies, from `&str` through
+//! `bytes::Bytes` to `HipStr`. Names are copied into the schema's own arena as they are interned,
+//! so the finished [`Schema`] borrows nothing and a single builder may be fed documents with
+//! *different* `S` types. The generic parameter never appears on `Schema`.
+
+use std::{
+  borrow::ToOwned,
+  boxed::Box,
+  collections::BTreeMap,
+  string::{String, ToString},
+  vec,
+  vec::Vec,
+};
+
+use tokora::{Parse as _, Parser, SimpleSpan, span::AsSpan};
+
+use crate::parser::graphql::{
+  GraphQL,
+  ast::{
+    ConstDirectives, ConstInputValue, DirectiveDefinition, EnumTypeDefinition,
+    EnumValuesDefinition, FieldsDefinition, ImplementInterfaces, InputFieldsDefinition,
+    InputObjectTypeDefinition, InputValueDefinition, InterfaceTypeDefinition, Location, Name,
+    ObjectTypeDefinition, OperationType, ScalarTypeDefinition, SchemaDefinition, Type,
+    TypeDefinition, TypeExtension, TypeSystemDefinition, TypeSystemDefinitionOrExtension,
+    TypeSystemDocument, TypeSystemExtension, UnionMemberTypes, UnionTypeDefinition,
+  },
+  error::GraphqlErrors,
+  syntactic::{GraphqlLexer, type_system_document},
+};
+
+use super::{
+  builtin,
+  error::{SchemaError, SchemaErrorKind, SchemaErrors, owner_path},
+  repr::{
+    DefaultKind, DirectiveDef, DirectiveLocation, DirectiveLocations, FieldDef, InputValueDef,
+    MAX_SYMBOLS, NameIndex, PackedType, Range32, RootOperation, Schema, Sym, TypeDef, TypeFlags,
+    TypeId, TypeKind, is_name, is_reserved,
+  },
+};
+
+/// The placeholder a type reference carries until its base name is resolved.
+const UNRESOLVED: TypeId = TypeId::new(u32::MAX);
+
+// ---------------------------------------------------------------------------------------------
+// interning
+// ---------------------------------------------------------------------------------------------
+
+/// The growable half of the name arena.
+///
+/// The finished [`Schema`] keeps `strings` and `spans` and a probe-only [`NameIndex`]; this map
+/// exists only while building, which is why the schema has no hash map in it at all.
+#[derive(Debug, Default)]
+struct Interner {
+  strings: Vec<u8>,
+  spans: Vec<(u32, u32)>,
+  map: BTreeMap<Box<[u8]>, u32>,
+}
+
+impl Interner {
+  fn intern(&mut self, bytes: &[u8]) -> Sym {
+    if let Some(sym) = self.map.get(bytes) {
+      return Sym::new(*sym);
+    }
+    let start = self.strings.len() as u32;
+    self.strings.extend_from_slice(bytes);
+    let end = self.strings.len() as u32;
+    let sym = self.spans.len() as u32;
+    self.spans.push((start, end));
+    self.map.insert(bytes.to_owned().into_boxed_slice(), sym);
+    Sym::new(sym)
+  }
+
+  fn lookup(&self, bytes: &[u8]) -> Option<Sym> {
+    self.map.get(bytes).copied().map(Sym::new)
+  }
+
+  fn bytes(&self, sym: Sym) -> &[u8] {
+    let (start, end) = self.spans[sym.get() as usize];
+    &self.strings[start as usize..end as usize]
+  }
+
+  fn text(&self, sym: Sym) -> &str {
+    // ASCII by construction; every name is admitted through `is_name` first.
+    core::str::from_utf8(self.bytes(sym)).unwrap_or("")
+  }
+
+  fn len(&self) -> u32 {
+    self.spans.len() as u32
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// the owned intermediate model
+// ---------------------------------------------------------------------------------------------
+
+/// An interned name with the position and document it was read from.
+#[derive(Debug, Clone, Copy)]
+struct Located {
+  sym: Sym,
+  span: SimpleSpan,
+  document: u32,
+}
+
+/// A type reference whose base has been interned but not yet resolved.
+#[derive(Debug, Clone, Copy)]
+struct RawTypeRef {
+  base: Located,
+  span: SimpleSpan,
+  packed: PackedType,
+  too_deep: bool,
+}
+
+#[derive(Debug, Clone)]
+struct RawInput {
+  name: Located,
+  ty: RawTypeRef,
+  default: DefaultKind,
+  directives: Vec<Located>,
+}
+
+#[derive(Debug, Clone)]
+struct RawField {
+  name: Located,
+  ty: RawTypeRef,
+  args: Vec<RawInput>,
+}
+
+#[derive(Debug, Clone)]
+struct RawEnumValue {
+  name: Located,
+  directives: Vec<Located>,
+}
+
+#[derive(Debug, Clone)]
+struct RawType {
+  name: Located,
+  kind: TypeKind,
+  built_in: bool,
+  /// The definition collides with an introspection type, already reported as
+  /// `RedefinedBuiltInType`; the reserved-name rule stays quiet so one defect reports once.
+  collides_with_built_in: bool,
+  implements: Vec<Located>,
+  fields: Vec<RawField>,
+  input_fields: Vec<RawInput>,
+  members: Vec<Located>,
+  enum_values: Vec<RawEnumValue>,
+  directives: Vec<Located>,
+  /// The interface closure, filled in during validation.
+  closure: Vec<u32>,
+}
+
+impl RawType {
+  fn new(name: Located, kind: TypeKind, built_in: bool) -> Self {
+    Self {
+      name,
+      kind,
+      built_in,
+      collides_with_built_in: false,
+      implements: Vec::new(),
+      fields: Vec::new(),
+      input_fields: Vec::new(),
+      members: Vec::new(),
+      enum_values: Vec::new(),
+      directives: Vec::new(),
+      closure: Vec::new(),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+struct RawDirectiveDef {
+  name: Located,
+  args: Vec<RawInput>,
+  locations: DirectiveLocations,
+  repeatable: bool,
+  built_in: bool,
+}
+
+/// A type extension, converted to owned form and applied once every document has been read.
+#[derive(Debug, Clone, Default)]
+struct RawExtension {
+  target: Option<Located>,
+  kind: Option<TypeKind>,
+  implements: Vec<Located>,
+  fields: Vec<RawField>,
+  input_fields: Vec<RawInput>,
+  members: Vec<Located>,
+  enum_values: Vec<RawEnumValue>,
+  directives: Vec<Located>,
+  /// Root operations, for a `extend schema` rather than a type extension.
+  roots: Vec<(RootOperation, Located)>,
+}
+
+// ---------------------------------------------------------------------------------------------
+// the builder
+// ---------------------------------------------------------------------------------------------
+
+/// Accumulates type-system documents and produces a [`Schema`].
+///
+/// Documents are read in the order they are given; extensions are applied only once every
+/// document has been read, so an `extend type Foo` may precede `type Foo` and may live in a
+/// different document.
+#[derive(Debug, Default)]
+pub struct SchemaBuilder {
+  interner: Interner,
+  types: Vec<RawType>,
+  /// `Sym` to an index into `types`, dense over the symbol space; `u32::MAX` for "not a type".
+  type_of_sym: Vec<u32>,
+  directives: Vec<RawDirectiveDef>,
+  /// `Sym` to an index into `directives`; `u32::MAX` for "not a directive".
+  directive_of_sym: Vec<u32>,
+  roots: [Option<Located>; 3],
+  schema_definition: Option<SimpleSpan>,
+  extensions: Vec<RawExtension>,
+  errors: Vec<SchemaError>,
+  document: u32,
+}
+
+impl SchemaBuilder {
+  /// Creates an empty builder.
+  #[inline]
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Reads one type-system document.
+  ///
+  /// Definitions are recorded immediately; extensions are deferred to [`SchemaBuilder::finish`].
+  /// Errors are accumulated rather than returned, so a caller sees every problem in every
+  /// document at the end rather than one at a time.
+  pub fn document<S>(&mut self, doc: &TypeSystemDocument<S>) -> &mut Self
+  where
+    S: AsRef<[u8]>,
+  {
+    for entry in doc.definitions() {
+      match entry {
+        TypeSystemDefinitionOrExtension::Definition(described) => {
+          self.definition(described.node(), false);
+        }
+        TypeSystemDefinitionOrExtension::Extension(extension) => {
+          self.extension(extension);
+        }
+      }
+    }
+    self.document += 1;
+    self
+  }
+
+  /// Consumes the builder and produces a schema, or every reason it is not one.
+  pub fn finish(mut self) -> Result<Schema, SchemaErrors> {
+    // Injection precedes extension so that `extend scalar Int @tag(...)` — extending something
+    // the specification provided rather than something the document defined — is not reported as
+    // an undefined target. Whether a built-in is injected at all is decided by the *definitions*,
+    // all of which are already in, so the order does not change what gets replaced.
+    self.inject_built_ins();
+    self.apply_extensions();
+    self.validate();
+
+    if !self.errors.is_empty() {
+      return Err(SchemaErrors::new(self.errors));
+    }
+    self.flatten()
+  }
+
+  // -- error helpers --------------------------------------------------------------------------
+
+  fn push(&mut self, kind: SchemaErrorKind, subject: &str, at: Located) {
+    self
+      .errors
+      .push(SchemaError::new(kind, subject, at.span).in_document(at.document));
+  }
+
+  fn push_owned(&mut self, kind: SchemaErrorKind, subject: &str, owner: String, at: Located) {
+    self.errors.push(
+      SchemaError::new(kind, subject, at.span)
+        .owned_by(owner)
+        .in_document(at.document),
+    );
+  }
+
+  fn push_related(
+    &mut self,
+    kind: SchemaErrorKind,
+    subject: &str,
+    owner: Option<String>,
+    at: Located,
+    related: SimpleSpan,
+  ) {
+    let mut error = SchemaError::new(kind, subject, at.span)
+      .in_document(at.document)
+      .related_to(related);
+    if let Some(owner) = owner {
+      error = error.owned_by(owner);
+    }
+    self.errors.push(error);
+  }
+
+  // -- interning ------------------------------------------------------------------------------
+
+  fn located<S>(&mut self, name: &Name<S>) -> Located
+  where
+    S: AsRef<[u8]>,
+  {
+    let bytes = name.source().as_ref();
+    let span = *name.as_span();
+    let document = self.document;
+    if !is_name(bytes) {
+      // Unreachable from parsed input; reachable from a hand-assembled AST, and the arena's
+      // ASCII invariant is what makes `Schema::name` infallible, so it is checked.
+      let rendered = String::from_utf8_lossy(bytes).to_string();
+      self.errors.push(
+        SchemaError::new(SchemaErrorKind::InvalidName, &rendered, span).in_document(document),
+      );
+      let sym = self.interner.intern(b"__invalid");
+      return Located {
+        sym,
+        span,
+        document,
+      };
+    }
+    let sym = self.interner.intern(bytes);
+    Located {
+      sym,
+      span,
+      document,
+    }
+  }
+
+  fn text(&self, sym: Sym) -> &str {
+    self.interner.text(sym)
+  }
+
+  // -- ingest ---------------------------------------------------------------------------------
+
+  fn definition<S>(&mut self, definition: &TypeSystemDefinition<S>, built_in: bool)
+  where
+    S: AsRef<[u8]>,
+  {
+    match definition {
+      TypeSystemDefinition::Type(ty) => self.type_definition(ty, built_in),
+      TypeSystemDefinition::Directive(directive) => self.directive_definition(directive, built_in),
+      TypeSystemDefinition::Schema(schema) => self.schema_definition(schema),
+    }
+  }
+
+  fn type_definition<S>(&mut self, definition: &TypeDefinition<S>, built_in: bool)
+  where
+    S: AsRef<[u8]>,
+  {
+    let raw = match definition {
+      TypeDefinition::Scalar(def) => self.scalar(def, built_in),
+      TypeDefinition::Object(def) => self.object(def, built_in),
+      TypeDefinition::Interface(def) => self.interface(def, built_in),
+      TypeDefinition::Union(def) => self.union(def, built_in),
+      TypeDefinition::Enum(def) => self.enumeration(def, built_in),
+      TypeDefinition::InputObject(def) => self.input_object(def, built_in),
+    };
+    self.record_type(raw);
+  }
+
+  fn record_type(&mut self, raw: RawType) {
+    let sym = raw.name.sym;
+    if let Some(previous) = self.type_index(sym) {
+      let related = self.types[previous].name.span;
+      let subject = self.text(sym).to_owned();
+      self.push_related(
+        SchemaErrorKind::DuplicateTypeName,
+        &subject,
+        None,
+        raw.name,
+        related,
+      );
+      return;
+    }
+    let index = self.types.len() as u32;
+    self.set_type_index(sym, index);
+    self.types.push(raw);
+  }
+
+  fn type_index(&self, sym: Sym) -> Option<usize> {
+    match self.type_of_sym.get(sym.get() as usize) {
+      Some(&index) if index != u32::MAX => Some(index as usize),
+      _ => None,
+    }
+  }
+
+  fn set_type_index(&mut self, sym: Sym, index: u32) {
+    let slot = sym.get() as usize;
+    if self.type_of_sym.len() <= slot {
+      self.type_of_sym.resize(slot + 1, u32::MAX);
+    }
+    self.type_of_sym[slot] = index;
+  }
+
+  fn directive_index(&self, sym: Sym) -> Option<usize> {
+    match self.directive_of_sym.get(sym.get() as usize) {
+      Some(&index) if index != u32::MAX => Some(index as usize),
+      _ => None,
+    }
+  }
+
+  fn set_directive_index(&mut self, sym: Sym, index: u32) {
+    let slot = sym.get() as usize;
+    if self.directive_of_sym.len() <= slot {
+      self.directive_of_sym.resize(slot + 1, u32::MAX);
+    }
+    self.directive_of_sym[slot] = index;
+  }
+
+  fn scalar<S>(&mut self, def: &ScalarTypeDefinition<S>, built_in: bool) -> RawType
+  where
+    S: AsRef<[u8]>,
+  {
+    let name = self.located(def.name());
+    let mut raw = RawType::new(name, TypeKind::Scalar, built_in);
+    raw.directives = self.directive_uses(def.directives());
+    raw
+  }
+
+  fn object<S>(&mut self, def: &ObjectTypeDefinition<S>, built_in: bool) -> RawType
+  where
+    S: AsRef<[u8]>,
+  {
+    let name = self.located(def.name());
+    let mut raw = RawType::new(name, TypeKind::Object, built_in);
+    raw.implements = self.implements(def.implements());
+    raw.directives = self.directive_uses(def.directives());
+    raw.fields = self.fields(def.fields_definition());
+    raw
+  }
+
+  fn interface<S>(&mut self, def: &InterfaceTypeDefinition<S>, built_in: bool) -> RawType
+  where
+    S: AsRef<[u8]>,
+  {
+    let name = self.located(def.name());
+    let mut raw = RawType::new(name, TypeKind::Interface, built_in);
+    raw.implements = self.implements(def.implements());
+    raw.directives = self.directive_uses(def.directives());
+    raw.fields = self.fields(def.fields_definition());
+    raw
+  }
+
+  fn union<S>(&mut self, def: &UnionTypeDefinition<S>, built_in: bool) -> RawType
+  where
+    S: AsRef<[u8]>,
+  {
+    let name = self.located(def.name());
+    let mut raw = RawType::new(name, TypeKind::Union, built_in);
+    raw.directives = self.directive_uses(def.directives());
+    raw.members = self.members(def.member_types());
+    raw
+  }
+
+  fn enumeration<S>(&mut self, def: &EnumTypeDefinition<S>, built_in: bool) -> RawType
+  where
+    S: AsRef<[u8]>,
+  {
+    let name = self.located(def.name());
+    let mut raw = RawType::new(name, TypeKind::Enum, built_in);
+    raw.directives = self.directive_uses(def.directives());
+    raw.enum_values = self.enum_values(def.enum_values_definition());
+    raw
+  }
+
+  fn input_object<S>(&mut self, def: &InputObjectTypeDefinition<S>, built_in: bool) -> RawType
+  where
+    S: AsRef<[u8]>,
+  {
+    let name = self.located(def.name());
+    let mut raw = RawType::new(name, TypeKind::InputObject, built_in);
+    raw.directives = self.directive_uses(def.directives());
+    raw.input_fields = self.input_fields(def.fields_definition());
+    raw
+  }
+
+  fn directive_definition<S>(&mut self, def: &DirectiveDefinition<S>, built_in: bool)
+  where
+    S: AsRef<[u8]>,
+  {
+    let name = self.located(def.name());
+    let args = match def.arguments_definition() {
+      Some(arguments) => self.input_values(arguments.input_value_definitions()),
+      None => Vec::new(),
+    };
+    let mut locations = DirectiveLocations::EMPTY;
+    for location in def.locations().locations() {
+      if let Some(mapped) = map_location(location) {
+        locations.insert(mapped);
+      }
+    }
+    let repeatable = def.repeatable();
+
+    if let Some(previous) = self.directive_index(name.sym) {
+      let related = self.directives[previous].name.span;
+      let subject = self.text(name.sym).to_owned();
+      self.push_related(
+        SchemaErrorKind::DuplicateDirectiveDefinition,
+        &subject,
+        None,
+        name,
+        related,
+      );
+      return;
+    }
+    let index = self.directives.len() as u32;
+    self.set_directive_index(name.sym, index);
+    self.directives.push(RawDirectiveDef {
+      name,
+      args,
+      locations,
+      repeatable,
+      built_in,
+    });
+  }
+
+  fn schema_definition<S>(&mut self, def: &SchemaDefinition<S>)
+  where
+    S: AsRef<[u8]>,
+  {
+    let span = *def.span();
+    if let Some(previous) = self.schema_definition {
+      self.errors.push(
+        SchemaError::new(SchemaErrorKind::DuplicateSchemaDefinition, "schema", span)
+          .in_document(self.document)
+          .related_to(previous),
+      );
+      return;
+    }
+    self.schema_definition = Some(span);
+    for root in def
+      .root_operation_types_definition()
+      .root_operation_type_definitions()
+    {
+      let operation = map_operation(root.operation_type());
+      let target = self.located(root.name());
+      self.set_root(operation, target);
+    }
+  }
+
+  fn set_root(&mut self, operation: RootOperation, target: Located) {
+    if let Some(previous) = self.roots[operation.index()] {
+      let subject = operation.as_str();
+      self.push_related(
+        SchemaErrorKind::DuplicateRootOperationType,
+        subject,
+        None,
+        target,
+        previous.span,
+      );
+      return;
+    }
+    self.roots[operation.index()] = Some(target);
+  }
+
+  fn implements<S, C>(
+    &mut self,
+    implements: Option<&ImplementInterfaces<Name<S>, C>>,
+  ) -> Vec<Located>
+  where
+    S: AsRef<[u8]>,
+    C: AsRef<[Name<S>]>,
+  {
+    match implements {
+      None => Vec::new(),
+      Some(list) => list
+        .interfaces()
+        .iter()
+        .map(|name| {
+          let bytes = name.source().as_ref().to_owned();
+          let span = *name.as_span();
+          let document = self.document;
+          let sym = self.interner.intern(&bytes);
+          Located {
+            sym,
+            span,
+            document,
+          }
+        })
+        .collect(),
+    }
+  }
+
+  fn members<S, C>(&mut self, members: Option<&UnionMemberTypes<Name<S>, C>>) -> Vec<Located>
+  where
+    S: AsRef<[u8]>,
+    C: AsRef<[Name<S>]>,
+  {
+    match members {
+      None => Vec::new(),
+      Some(list) => list
+        .members()
+        .iter()
+        .map(|name| {
+          let bytes = name.source().as_ref().to_owned();
+          let span = *name.as_span();
+          let document = self.document;
+          let sym = self.interner.intern(&bytes);
+          Located {
+            sym,
+            span,
+            document,
+          }
+        })
+        .collect(),
+    }
+  }
+
+  fn directive_uses<S>(&mut self, directives: Option<&ConstDirectives<S>>) -> Vec<Located>
+  where
+    S: AsRef<[u8]>,
+  {
+    match directives {
+      None => Vec::new(),
+      Some(list) => list
+        .directives()
+        .iter()
+        .map(|directive| self.located(directive.name()))
+        .collect(),
+    }
+  }
+
+  fn fields<S>(&mut self, fields: Option<&FieldsDefinition<S>>) -> Vec<RawField>
+  where
+    S: AsRef<[u8]>,
+  {
+    let Some(fields) = fields else {
+      return Vec::new();
+    };
+    fields
+      .field_definitions()
+      .iter()
+      .map(|field| {
+        let name = self.located(field.name());
+        let ty = self.type_ref(field.ty());
+        let args = match field.arguments_definition() {
+          Some(arguments) => self.input_values(arguments.input_value_definitions()),
+          None => Vec::new(),
+        };
+        RawField { name, ty, args }
+      })
+      .collect()
+  }
+
+  fn input_fields<S>(&mut self, fields: Option<&InputFieldsDefinition<S>>) -> Vec<RawInput>
+  where
+    S: AsRef<[u8]>,
+  {
+    match fields {
+      None => Vec::new(),
+      Some(fields) => self.input_values(fields.input_value_definitions()),
+    }
+  }
+
+  fn input_values<S>(&mut self, values: &[InputValueDefinition<S>]) -> Vec<RawInput>
+  where
+    S: AsRef<[u8]>,
+  {
+    values
+      .iter()
+      .map(|value| {
+        let name = self.located(value.name());
+        let ty = self.type_ref(value.ty());
+        let default = match value.default_value() {
+          None => DefaultKind::Absent,
+          Some(default) => match default.value() {
+            ConstInputValue::Null(_) => DefaultKind::Null,
+            _ => DefaultKind::NonNull,
+          },
+        };
+        let directives = self.directive_uses(value.directives());
+        RawInput {
+          name,
+          ty,
+          default,
+          directives,
+        }
+      })
+      .collect()
+  }
+
+  fn enum_values<S>(&mut self, values: Option<&EnumValuesDefinition<S>>) -> Vec<RawEnumValue>
+  where
+    S: AsRef<[u8]>,
+  {
+    let Some(values) = values else {
+      return Vec::new();
+    };
+    values
+      .enum_value_definitions()
+      .iter()
+      .map(|value| {
+        let name = self.located(value.value());
+        let directives = self.directive_uses(value.directives());
+        RawEnumValue { name, directives }
+      })
+      .collect()
+  }
+
+  /// Flattens a type reference into a base name plus a wrapper word.
+  fn type_ref<S>(&mut self, ty: &Type<Name<S>>) -> RawTypeRef
+  where
+    S: AsRef<[u8]>,
+  {
+    match ty {
+      Type::Name(named) => {
+        let base = self.located(named.name());
+        let packed = PackedType::named(base.sym, UNRESOLVED);
+        let (packed, too_deep) = if named.required() {
+          match packed.push_non_null() {
+            Some(packed) => (packed, false),
+            None => (packed, true),
+          }
+        } else {
+          (packed, false)
+        };
+        RawTypeRef {
+          base,
+          span: *named.span(),
+          packed,
+          too_deep,
+        }
+      }
+      Type::List(list) => {
+        let inner = self.type_ref(list.ty());
+        let mut too_deep = inner.too_deep;
+        let mut packed = inner.packed;
+        match packed.push_list() {
+          Some(next) => packed = next,
+          None => too_deep = true,
+        }
+        if list.required() {
+          match packed.push_non_null() {
+            Some(next) => packed = next,
+            None => too_deep = true,
+          }
+        }
+        RawTypeRef {
+          base: inner.base,
+          span: *list.span(),
+          packed,
+          too_deep,
+        }
+      }
+    }
+  }
+
+  fn extension<S>(&mut self, extension: &TypeSystemExtension<S>)
+  where
+    S: AsRef<[u8]>,
+  {
+    let mut raw = RawExtension::default();
+    match extension {
+      TypeSystemExtension::Schema(schema) => {
+        raw.directives = self.directive_uses(schema.directives());
+        if let Some(roots) = schema.root_operation_types_definition() {
+          for root in roots.root_operation_type_definitions() {
+            let operation = map_operation(root.operation_type());
+            let target = self.located(root.name());
+            raw.roots.push((operation, target));
+          }
+        }
+      }
+      TypeSystemExtension::Type(ty) => match ty {
+        TypeExtension::Scalar(def) => {
+          raw.target = Some(self.located(def.name()));
+          raw.kind = Some(TypeKind::Scalar);
+          raw.directives = self.directive_uses(Some(def.directives()));
+        }
+        TypeExtension::Object(def) => {
+          raw.target = Some(self.located(def.name()));
+          raw.kind = Some(TypeKind::Object);
+          raw.implements = self.implements(def.implements());
+          raw.directives = self.directive_uses(def.directives());
+          raw.fields = self.fields(def.fields_definition());
+        }
+        TypeExtension::Interface(def) => {
+          raw.target = Some(self.located(def.name()));
+          raw.kind = Some(TypeKind::Interface);
+          raw.implements = self.implements(def.implements());
+          raw.directives = self.directive_uses(def.directives());
+          raw.fields = self.fields(def.fields_definition());
+        }
+        TypeExtension::Union(def) => {
+          raw.target = Some(self.located(def.name()));
+          raw.kind = Some(TypeKind::Union);
+          raw.directives = self.directive_uses(def.directives());
+          raw.members = self.members(def.member_types());
+        }
+        TypeExtension::Enum(def) => {
+          raw.target = Some(self.located(def.name()));
+          raw.kind = Some(TypeKind::Enum);
+          raw.directives = self.directive_uses(def.directives());
+          raw.enum_values = self.enum_values(def.enum_values_definition());
+        }
+        TypeExtension::InputObject(def) => {
+          raw.target = Some(self.located(def.name()));
+          raw.kind = Some(TypeKind::InputObject);
+          raw.directives = self.directive_uses(def.directives());
+          raw.input_fields = self.input_fields(def.fields_definition());
+        }
+      },
+    }
+    self.extensions.push(raw);
+  }
+
+  fn apply_extensions(&mut self) {
+    let extensions = core::mem::take(&mut self.extensions);
+    for extension in extensions {
+      let Some(target) = extension.target else {
+        // `extend schema`.
+        for (operation, located) in extension.roots {
+          self.set_root(operation, located);
+        }
+        continue;
+      };
+      let Some(index) = self.type_index(target.sym) else {
+        let subject = self.text(target.sym).to_owned();
+        self.push(SchemaErrorKind::UndefinedExtensionTarget, &subject, target);
+        continue;
+      };
+      if self.types[index].kind != extension.kind.unwrap_or(self.types[index].kind) {
+        let subject = self.text(target.sym).to_owned();
+        let related = self.types[index].name.span;
+        self.push_related(
+          SchemaErrorKind::ExtensionKindMismatch,
+          &subject,
+          None,
+          target,
+          related,
+        );
+        continue;
+      }
+      let raw = &mut self.types[index];
+      raw.implements.extend(extension.implements);
+      raw.fields.extend(extension.fields);
+      raw.input_fields.extend(extension.input_fields);
+      raw.members.extend(extension.members);
+      raw.enum_values.extend(extension.enum_values);
+      raw.directives.extend(extension.directives);
+    }
+  }
+
+  // -- built-ins ------------------------------------------------------------------------------
+
+  /// Parses one of the crate's own SDL constants.
+  ///
+  /// # Panics
+  ///
+  /// If a constant in [`builtin`] stops parsing, which is a defect in this crate rather than in
+  /// any input. `builtin_sdl_parses` in the build test suite is the standing guard.
+  fn parse_builtin(sdl: &'static str) -> TypeSystemDocument<&'static str> {
+    Parser::with_parser::<
+      GraphqlLexer<'static, str>,
+      TypeSystemDocument<&'static str>,
+      GraphqlErrors<&'static str>,
+      _,
+      GraphQL,
+    >(type_system_document)
+    .parse_str(sdl)
+    .expect("smear's own built-in SDL must parse; this is a defect in smear, not in the input")
+  }
+
+  fn inject_built_ins(&mut self) {
+    // Anything injected here belongs to no document the caller supplied; `self.document` is
+    // already one past the last real index, which is what an injected definition reports under.
+
+    // The introspection meta-schema is unconditional: an introspection query must validate
+    // against every schema. A user definition of one of its types collides.
+    let introspection = Self::parse_builtin(builtin::INTROSPECTION_SDL);
+    for entry in introspection.definitions() {
+      let TypeSystemDefinitionOrExtension::Definition(described) = entry else {
+        continue;
+      };
+      let TypeSystemDefinition::Type(ty) = described.node() else {
+        continue;
+      };
+      let name = introspection_type_name(ty);
+      match self.interner.lookup(name.as_bytes()).and_then(|sym| {
+        self
+          .type_index(sym)
+          .map(|index| (sym, self.types[index].name))
+      }) {
+        Some((sym, at)) => {
+          let subject = self.text(sym).to_owned();
+          self.push(SchemaErrorKind::RedefinedBuiltInType, &subject, at);
+          if let Some(index) = self.type_index(sym) {
+            self.types[index].collides_with_built_in = true;
+          }
+        }
+        None => self.type_definition(ty, true),
+      }
+    }
+
+    // Built-in scalars and directives are replaceable: a document that spells one out keeps its
+    // own, which is what makes a printed schema re-readable.
+    let scalars = Self::parse_builtin(builtin::BUILT_IN_SCALARS_SDL);
+    for entry in scalars.definitions() {
+      let TypeSystemDefinitionOrExtension::Definition(described) = entry else {
+        continue;
+      };
+      let TypeSystemDefinition::Type(ty) = described.node() else {
+        continue;
+      };
+      let name = introspection_type_name(ty);
+      let taken = self
+        .interner
+        .lookup(name.as_bytes())
+        .is_some_and(|sym| self.type_index(sym).is_some());
+      if !taken {
+        self.type_definition(ty, true);
+      }
+    }
+
+    let directives = Self::parse_builtin(builtin::BUILT_IN_DIRECTIVES_SDL);
+    for entry in directives.definitions() {
+      let TypeSystemDefinitionOrExtension::Definition(described) = entry else {
+        continue;
+      };
+      let TypeSystemDefinition::Directive(def) = described.node() else {
+        continue;
+      };
+      let taken = self
+        .interner
+        .lookup(def.name().source().as_bytes())
+        .is_some_and(|sym| self.directive_index(sym).is_some());
+      if !taken {
+        self.directive_definition(def, true);
+      }
+    }
+
+    // The three meta-field names, interned now so flattening never has to grow the arena.
+    self.interner.intern(builtin::TYPENAME_FIELD.as_bytes());
+    self.interner.intern(builtin::SCHEMA_FIELD.as_bytes());
+    self.interner.intern(builtin::TYPE_FIELD.as_bytes());
+    self
+      .interner
+      .intern(builtin::TYPE_FIELD_ARGUMENT.as_bytes());
+  }
+
+  // -- validation (draft §3) --------------------------------------------------------------------
+
+  fn validate(&mut self) {
+    self.resolve_roots();
+    self.resolve_type_refs();
+    self.compute_closures();
+    self.validate_types();
+    self.validate_directive_definitions();
+    self.validate_interface_implementations();
+    self.validate_input_object_cycles();
+    self.validate_directive_cycles();
+  }
+
+  fn resolve_roots(&mut self) {
+    // With no `schema` definition, the roots default to the conventionally named object types.
+    for operation in RootOperation::ALL {
+      if self.roots[operation.index()].is_some() {
+        continue;
+      }
+      let name = operation.default_type_name();
+      if let Some(sym) = self.interner.lookup(name.as_bytes())
+        && let Some(index) = self.type_index(sym)
+        && self.types[index].kind == TypeKind::Object
+      {
+        self.roots[operation.index()] = Some(self.types[index].name);
+      }
+    }
+
+    for operation in RootOperation::ALL {
+      let Some(root) = self.roots[operation.index()] else {
+        if operation == RootOperation::Query {
+          self.errors.push(
+            SchemaError::new(
+              SchemaErrorKind::MissingQueryRootOperationType,
+              "query",
+              self.schema_definition.unwrap_or_default(),
+            )
+            .in_document(0),
+          );
+        }
+        continue;
+      };
+      match self.type_index(root.sym) {
+        None => {
+          let subject = self.text(root.sym).to_owned();
+          self.push(SchemaErrorKind::UndefinedRootOperationType, &subject, root);
+          self.roots[operation.index()] = None;
+        }
+        Some(index) if self.types[index].kind != TypeKind::Object => {
+          let subject = self.text(root.sym).to_owned();
+          self.push(SchemaErrorKind::RootOperationTypeNotObject, &subject, root);
+          self.roots[operation.index()] = None;
+        }
+        Some(_) => {}
+      }
+    }
+  }
+
+  /// Resolves every type reference's base to a type index, reporting the ones that name nothing.
+  fn resolve_type_refs(&mut self) {
+    let mut unresolved: Vec<(Located, String, SimpleSpan)> = Vec::new();
+    let mut too_deep: Vec<(Located, String, SimpleSpan)> = Vec::new();
+
+    for index in 0..self.types.len() {
+      let owner = self.types[index].name.sym;
+      let owner_name = self.text(owner).to_owned();
+
+      for field in 0..self.types[index].fields.len() {
+        let field_name = self
+          .text(self.types[index].fields[field].name.sym)
+          .to_owned();
+        let path = owner_path(&[&owner_name, &field_name]);
+        Self::resolve_one(
+          &self.type_of_sym,
+          &mut self.types[index].fields[field].ty,
+          &path,
+          &mut unresolved,
+          &mut too_deep,
+        );
+        for arg in 0..self.types[index].fields[field].args.len() {
+          let arg_name = self
+            .text(self.types[index].fields[field].args[arg].name.sym)
+            .to_owned();
+          let path = owner_path(&[&owner_name, &field_name, &arg_name]);
+          Self::resolve_one(
+            &self.type_of_sym,
+            &mut self.types[index].fields[field].args[arg].ty,
+            &path,
+            &mut unresolved,
+            &mut too_deep,
+          );
+        }
+      }
+
+      for field in 0..self.types[index].input_fields.len() {
+        let field_name = self
+          .text(self.types[index].input_fields[field].name.sym)
+          .to_owned();
+        let path = owner_path(&[&owner_name, &field_name]);
+        Self::resolve_one(
+          &self.type_of_sym,
+          &mut self.types[index].input_fields[field].ty,
+          &path,
+          &mut unresolved,
+          &mut too_deep,
+        );
+      }
+    }
+
+    for index in 0..self.directives.len() {
+      let owner_name = self.text(self.directives[index].name.sym).to_owned();
+      for arg in 0..self.directives[index].args.len() {
+        let arg_name = self
+          .text(self.directives[index].args[arg].name.sym)
+          .to_owned();
+        let path = owner_path(&[&owner_name, &arg_name]);
+        Self::resolve_one(
+          &self.type_of_sym,
+          &mut self.directives[index].args[arg].ty,
+          &path,
+          &mut unresolved,
+          &mut too_deep,
+        );
+      }
+    }
+
+    for (at, path, _) in unresolved {
+      let subject = self.text(at.sym).to_owned();
+      self.push_owned(SchemaErrorKind::UndefinedType, &subject, path, at);
+    }
+    for (at, path, span) in too_deep {
+      let subject = self.text(at.sym).to_owned();
+      let mut at = at;
+      at.span = span;
+      self.push_owned(SchemaErrorKind::TypeReferenceTooDeep, &subject, path, at);
+    }
+  }
+
+  fn resolve_one(
+    type_of_sym: &[u32],
+    reference: &mut RawTypeRef,
+    path: &str,
+    unresolved: &mut Vec<(Located, String, SimpleSpan)>,
+    too_deep: &mut Vec<(Located, String, SimpleSpan)>,
+  ) {
+    if reference.too_deep {
+      too_deep.push((reference.base, path.to_owned(), reference.span));
+    }
+    let slot = reference.base.sym.get() as usize;
+    match type_of_sym.get(slot) {
+      Some(&index) if index != u32::MAX => {
+        reference.packed = PackedType::from_parts(
+          reference.base.sym,
+          TypeId::new(index),
+          reference.packed.wrappers(),
+        );
+      }
+      _ => unresolved.push((reference.base, path.to_owned(), reference.span)),
+    }
+  }
+
+  /// Fills every type's interface closure, reporting interfaces that implement themselves.
+  fn compute_closures(&mut self) {
+    let count = self.types.len();
+    for index in 0..count {
+      if self.types[index].implements.is_empty() {
+        continue;
+      }
+      let mut closure: Vec<u32> = Vec::new();
+      let mut stack: Vec<u32> = Vec::new();
+      for declared in &self.types[index].implements {
+        if let Some(target) = self.type_index(declared.sym) {
+          stack.push(target as u32);
+        }
+      }
+      while let Some(next) = stack.pop() {
+        if closure.contains(&next) {
+          continue;
+        }
+        closure.push(next);
+        for declared in &self.types[next as usize].implements {
+          if let Some(target) = self.type_index(declared.sym) {
+            stack.push(target as u32);
+          }
+        }
+      }
+      closure.sort_unstable();
+      self.types[index].closure = closure;
+    }
+
+    for index in 0..count {
+      if self.types[index].kind != TypeKind::Interface {
+        continue;
+      }
+      if self.types[index].closure.contains(&(index as u32)) {
+        let at = self.types[index].name;
+        let subject = self.text(at.sym).to_owned();
+        self.push(SchemaErrorKind::SelfImplementingInterface, &subject, at);
+        // Break the cycle so nothing downstream walks it.
+        self.types[index].closure.retain(|id| *id != index as u32);
+      }
+    }
+  }
+
+  fn validate_types(&mut self) {
+    for index in 0..self.types.len() {
+      let kind = self.types[index].kind;
+      let built_in = self.types[index].built_in;
+      let at = self.types[index].name;
+      let name = self.text(at.sym).to_owned();
+
+      if !built_in && !self.types[index].collides_with_built_in && is_reserved(name.as_bytes()) {
+        self.push(SchemaErrorKind::ReservedTypeName, &name, at);
+      }
+
+      // `@oneOf` is read here rather than at ingest so an extension that adds it is seen.
+      let one_of = self.has_directive(index, "oneOf");
+
+      match kind {
+        TypeKind::Scalar => {}
+        TypeKind::Object | TypeKind::Interface => {
+          self.validate_fields(index, &name);
+          self.validate_implements(index, &name);
+        }
+        TypeKind::Union => self.validate_union(index, &name),
+        TypeKind::Enum => self.validate_enum(index, &name),
+        TypeKind::InputObject => self.validate_input_object(index, &name, one_of),
+      }
+    }
+  }
+
+  fn has_directive(&self, index: usize, name: &str) -> bool {
+    self.types[index]
+      .directives
+      .iter()
+      .any(|used| self.text(used.sym) == name)
+  }
+
+  fn validate_fields(&mut self, index: usize, owner: &str) {
+    if self.types[index].fields.is_empty() {
+      let at = self.types[index].name;
+      self.push(SchemaErrorKind::EmptyFieldsDefinition, owner, at);
+      return;
+    }
+
+    let mut seen: Vec<(Sym, SimpleSpan)> = Vec::new();
+    for field in 0..self.types[index].fields.len() {
+      let at = self.types[index].fields[field].name;
+      let name = self.text(at.sym).to_owned();
+
+      if let Some((_, first)) = seen.iter().find(|(sym, _)| *sym == at.sym).copied() {
+        self.push_related(
+          SchemaErrorKind::DuplicateFieldName,
+          &name,
+          Some(owner.to_owned()),
+          at,
+          first,
+        );
+      } else {
+        seen.push((at.sym, at.span));
+      }
+
+      if !self.types[index].built_in && is_reserved(name.as_bytes()) {
+        self.push_owned(
+          SchemaErrorKind::ReservedFieldName,
+          &name,
+          owner.to_owned(),
+          at,
+        );
+      }
+
+      let base = self.types[index].fields[field].ty.packed.base_id();
+      if base != UNRESOLVED && !self.types[base.get() as usize].kind.is_output() {
+        let subject = self
+          .text(self.types[base.get() as usize].name.sym)
+          .to_owned();
+        let path = owner_path(&[owner, &name]);
+        let mut where_ = at;
+        where_.span = self.types[index].fields[field].ty.span;
+        self.push_owned(
+          SchemaErrorKind::FieldTypeNotOutputType,
+          &subject,
+          path,
+          where_,
+        );
+      }
+
+      let path = owner_path(&[owner, &name]);
+      let args = self.types[index].fields[field].args.clone();
+      let built_in = self.types[index].built_in;
+      self.validate_arguments(
+        args,
+        &path,
+        built_in,
+        SchemaErrorKind::DuplicateArgumentName,
+        SchemaErrorKind::ReservedArgumentName,
+        SchemaErrorKind::ArgumentTypeNotInputType,
+      );
+    }
+  }
+
+  fn validate_arguments(
+    &mut self,
+    args: Vec<RawInput>,
+    owner: &str,
+    built_in: bool,
+    duplicate: SchemaErrorKind,
+    reserved: SchemaErrorKind,
+    not_input: SchemaErrorKind,
+  ) {
+    let mut seen: Vec<(Sym, SimpleSpan)> = Vec::new();
+    for arg in &args {
+      let at = arg.name;
+      let name = self.text(at.sym).to_owned();
+
+      if let Some((_, first)) = seen.iter().find(|(sym, _)| *sym == at.sym).copied() {
+        self.push_related(duplicate, &name, Some(owner.to_owned()), at, first);
+      } else {
+        seen.push((at.sym, at.span));
+      }
+
+      if !built_in && is_reserved(name.as_bytes()) {
+        self.push_owned(reserved, &name, owner.to_owned(), at);
+      }
+
+      let base = arg.ty.packed.base_id();
+      if base != UNRESOLVED && !self.types[base.get() as usize].kind.is_input() {
+        let subject = self
+          .text(self.types[base.get() as usize].name.sym)
+          .to_owned();
+        let path = owner_path(&[owner, &name]);
+        let mut where_ = at;
+        where_.span = arg.ty.span;
+        self.push_owned(not_input, &subject, path, where_);
+      }
+    }
+  }
+
+  fn validate_implements(&mut self, index: usize, owner: &str) {
+    let implements = self.types[index].implements.clone();
+    let mut seen: Vec<(Sym, SimpleSpan)> = Vec::new();
+    for declared in implements {
+      let name = self.text(declared.sym).to_owned();
+      if let Some((_, first)) = seen.iter().find(|(sym, _)| *sym == declared.sym).copied() {
+        self.push_related(
+          SchemaErrorKind::DuplicateImplementsInterface,
+          &name,
+          Some(owner.to_owned()),
+          declared,
+          first,
+        );
+        continue;
+      }
+      seen.push((declared.sym, declared.span));
+
+      match self.type_index(declared.sym) {
+        None => self.push_owned(
+          SchemaErrorKind::UndefinedImplementsInterface,
+          &name,
+          owner.to_owned(),
+          declared,
+        ),
+        Some(target) if self.types[target].kind != TypeKind::Interface => self.push_owned(
+          SchemaErrorKind::ImplementsNonInterface,
+          &name,
+          owner.to_owned(),
+          declared,
+        ),
+        Some(_) => {}
+      }
+    }
+  }
+
+  fn validate_union(&mut self, index: usize, owner: &str) {
+    if self.types[index].members.is_empty() {
+      let at = self.types[index].name;
+      self.push(SchemaErrorKind::EmptyUnionMembers, owner, at);
+      return;
+    }
+    let members = self.types[index].members.clone();
+    let mut seen: Vec<(Sym, SimpleSpan)> = Vec::new();
+    for member in members {
+      let name = self.text(member.sym).to_owned();
+      if let Some((_, first)) = seen.iter().find(|(sym, _)| *sym == member.sym).copied() {
+        self.push_related(
+          SchemaErrorKind::DuplicateUnionMember,
+          &name,
+          Some(owner.to_owned()),
+          member,
+          first,
+        );
+        continue;
+      }
+      seen.push((member.sym, member.span));
+
+      match self.type_index(member.sym) {
+        None => self.push_owned(
+          SchemaErrorKind::UndefinedUnionMember,
+          &name,
+          owner.to_owned(),
+          member,
+        ),
+        Some(target) if self.types[target].kind != TypeKind::Object => self.push_owned(
+          SchemaErrorKind::UnionMemberNotObject,
+          &name,
+          owner.to_owned(),
+          member,
+        ),
+        Some(_) => {}
+      }
+    }
+  }
+
+  fn validate_enum(&mut self, index: usize, owner: &str) {
+    if self.types[index].enum_values.is_empty() {
+      let at = self.types[index].name;
+      self.push(SchemaErrorKind::EmptyEnumValues, owner, at);
+      return;
+    }
+    let built_in = self.types[index].built_in;
+    let values: Vec<Located> = self.types[index]
+      .enum_values
+      .iter()
+      .map(|value| value.name)
+      .collect();
+    let mut seen: Vec<(Sym, SimpleSpan)> = Vec::new();
+    for value in values {
+      let name = self.text(value.sym).to_owned();
+      if let Some((_, first)) = seen.iter().find(|(sym, _)| *sym == value.sym).copied() {
+        self.push_related(
+          SchemaErrorKind::DuplicateEnumValue,
+          &name,
+          Some(owner.to_owned()),
+          value,
+          first,
+        );
+      } else {
+        seen.push((value.sym, value.span));
+      }
+      if !built_in && is_reserved(name.as_bytes()) {
+        self.push_owned(
+          SchemaErrorKind::ReservedEnumValueName,
+          &name,
+          owner.to_owned(),
+          value,
+        );
+      }
+    }
+  }
+
+  fn validate_input_object(&mut self, index: usize, owner: &str, one_of: bool) {
+    if self.types[index].input_fields.is_empty() {
+      let at = self.types[index].name;
+      self.push(SchemaErrorKind::EmptyInputFields, owner, at);
+      return;
+    }
+    let built_in = self.types[index].built_in;
+    let fields = self.types[index].input_fields.clone();
+    let mut seen: Vec<(Sym, SimpleSpan)> = Vec::new();
+    for field in &fields {
+      let at = field.name;
+      let name = self.text(at.sym).to_owned();
+
+      if let Some((_, first)) = seen.iter().find(|(sym, _)| *sym == at.sym).copied() {
+        self.push_related(
+          SchemaErrorKind::DuplicateInputFieldName,
+          &name,
+          Some(owner.to_owned()),
+          at,
+          first,
+        );
+      } else {
+        seen.push((at.sym, at.span));
+      }
+
+      if !built_in && is_reserved(name.as_bytes()) {
+        self.push_owned(
+          SchemaErrorKind::ReservedInputFieldName,
+          &name,
+          owner.to_owned(),
+          at,
+        );
+      }
+
+      let base = field.ty.packed.base_id();
+      if base != UNRESOLVED && !self.types[base.get() as usize].kind.is_input() {
+        let subject = self
+          .text(self.types[base.get() as usize].name.sym)
+          .to_owned();
+        let path = owner_path(&[owner, &name]);
+        let mut where_ = at;
+        where_.span = field.ty.span;
+        self.push_owned(
+          SchemaErrorKind::InputFieldTypeNotInputType,
+          &subject,
+          path,
+          where_,
+        );
+      }
+
+      if one_of {
+        if field.ty.packed.is_non_null() {
+          self.push_owned(
+            SchemaErrorKind::OneOfFieldNotNullable,
+            &name,
+            owner.to_owned(),
+            at,
+          );
+        }
+        if field.default.is_present() {
+          self.push_owned(
+            SchemaErrorKind::OneOfFieldHasDefault,
+            &name,
+            owner.to_owned(),
+            at,
+          );
+        }
+      }
+    }
+  }
+
+  fn validate_directive_definitions(&mut self) {
+    for index in 0..self.directives.len() {
+      let at = self.directives[index].name;
+      let name = self.text(at.sym).to_owned();
+      let built_in = self.directives[index].built_in;
+
+      if !built_in && is_reserved(name.as_bytes()) {
+        self.push(SchemaErrorKind::ReservedDirectiveName, &name, at);
+      }
+
+      let args = self.directives[index].args.clone();
+      self.validate_arguments(
+        args,
+        &name,
+        built_in,
+        SchemaErrorKind::DuplicateDirectiveArgumentName,
+        SchemaErrorKind::ReservedDirectiveArgumentName,
+        SchemaErrorKind::DirectiveArgumentTypeNotInputType,
+      );
+    }
+  }
+
+  /// Draft §3.6.1/§3.7.1: transitivity, covariance of field types, invariance of argument types.
+  fn validate_interface_implementations(&mut self) {
+    for index in 0..self.types.len() {
+      if !matches!(
+        self.types[index].kind,
+        TypeKind::Object | TypeKind::Interface
+      ) {
+        continue;
+      }
+      let owner = self.text(self.types[index].name.sym).to_owned();
+      let declared: Vec<Located> = self.types[index].implements.clone();
+
+      for entry in &declared {
+        let Some(interface) = self.type_index(entry.sym) else {
+          continue;
+        };
+        if self.types[interface].kind != TypeKind::Interface {
+          continue;
+        }
+
+        // Transitivity: every interface the interface implements must also be declared here.
+        let required: Vec<u32> = self.types[interface].closure.clone();
+        for needed in required {
+          if needed as usize == index {
+            continue;
+          }
+          let is_declared = declared
+            .iter()
+            .any(|d| self.type_index(d.sym) == Some(needed as usize));
+          if !is_declared {
+            let subject = self.text(self.types[needed as usize].name.sym).to_owned();
+            self.push_owned(
+              SchemaErrorKind::MissingTransitiveInterface,
+              &subject,
+              owner.clone(),
+              *entry,
+            );
+          }
+        }
+
+        // Field coverage, covariance, and argument invariance.
+        let interface_fields = self.types[interface].fields.clone();
+        for interface_field in &interface_fields {
+          let field_name = self.text(interface_field.name.sym).to_owned();
+          let Some(position) = self.types[index]
+            .fields
+            .iter()
+            .position(|f| f.name.sym == interface_field.name.sym)
+          else {
+            self.push_owned(
+              SchemaErrorKind::MissingInterfaceField,
+              &field_name,
+              owner.clone(),
+              *entry,
+            );
+            continue;
+          };
+          let own = self.types[index].fields[position].clone();
+
+          if !self.is_valid_implementation_type(own.ty.packed, interface_field.ty.packed) {
+            let path = owner_path(&[&owner, &field_name]);
+            let expected = self.render_type(interface_field.ty.packed);
+            self.push_owned(
+              SchemaErrorKind::InvalidInterfaceFieldType,
+              &expected,
+              path,
+              own.name,
+            );
+          }
+
+          for interface_arg in &interface_field.args {
+            let arg_name = self.text(interface_arg.name.sym).to_owned();
+            match own
+              .args
+              .iter()
+              .find(|a| a.name.sym == interface_arg.name.sym)
+            {
+              None => {
+                let path = owner_path(&[&owner, &field_name]);
+                self.push_owned(
+                  SchemaErrorKind::MissingInterfaceFieldArgument,
+                  &arg_name,
+                  path,
+                  own.name,
+                );
+              }
+              Some(own_arg) => {
+                if own_arg.ty.packed != interface_arg.ty.packed {
+                  let path = owner_path(&[&owner, &field_name, &arg_name]);
+                  let expected = self.render_type(interface_arg.ty.packed);
+                  self.push_owned(
+                    SchemaErrorKind::InvalidInterfaceFieldArgumentType,
+                    &expected,
+                    path,
+                    own_arg.name,
+                  );
+                }
+              }
+            }
+          }
+
+          for own_arg in &own.args {
+            let declared_by_interface = interface_field
+              .args
+              .iter()
+              .any(|a| a.name.sym == own_arg.name.sym);
+            if declared_by_interface {
+              continue;
+            }
+            if own_arg.ty.packed.is_non_null() && !own_arg.default.is_present() {
+              let arg_name = self.text(own_arg.name.sym).to_owned();
+              let path = owner_path(&[&owner, &field_name]);
+              self.push_owned(
+                SchemaErrorKind::UnexpectedRequiredArgument,
+                &arg_name,
+                path,
+                own_arg.name,
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Draft's `IsValidImplementationFieldType`.
+  fn is_valid_implementation_type(&self, field: PackedType, implemented: PackedType) -> bool {
+    if field.is_non_null() {
+      return self.is_valid_implementation_type(field.nullable(), implemented.nullable());
+    }
+    if let (Some(item), Some(implemented_item)) = (field.list_item(), implemented.list_item()) {
+      return self.is_valid_implementation_type(item, implemented_item);
+    }
+    if field == implemented {
+      return true;
+    }
+    if field.wrappers() != implemented.wrappers() {
+      return false;
+    }
+    self.is_sub_type(field.base_id(), implemented.base_id())
+  }
+
+  /// Whether `candidate` is one of `abstract_type`'s possible types, in the draft's wider sense:
+  /// union membership, or the interface closure — which, unlike the runtime possible-object
+  /// bitsets, includes interfaces implementing interfaces.
+  fn is_sub_type(&self, candidate: TypeId, abstract_type: TypeId) -> bool {
+    if candidate == UNRESOLVED || abstract_type == UNRESOLVED {
+      return false;
+    }
+    let target = &self.types[abstract_type.get() as usize];
+    match target.kind {
+      TypeKind::Union => target
+        .members
+        .iter()
+        .any(|member| self.type_index(member.sym) == Some(candidate.get() as usize)),
+      TypeKind::Interface => self.types[candidate.get() as usize]
+        .closure
+        .contains(&abstract_type.get()),
+      _ => false,
+    }
+  }
+
+  fn render_type(&self, packed: PackedType) -> String {
+    struct Rendered<'a>(PackedType, &'a str);
+    impl core::fmt::Display for Rendered<'_> {
+      fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.write(f, self.1)
+      }
+    }
+    Rendered(packed, self.text(packed.base())).to_string()
+  }
+
+  /// Draft §3.10.1: an input-object cycle must have at least one nullable or list link.
+  fn validate_input_object_cycles(&mut self) {
+    let count = self.types.len();
+    // 0 = unvisited, 1 = on the current path, 2 = settled.
+    let mut colour = vec![0u8; count];
+    let mut reported = vec![false; count];
+
+    for start in 0..count {
+      if self.types[start].kind != TypeKind::InputObject || colour[start] != 0 {
+        continue;
+      }
+      // Explicit stack: (type, next field to examine).
+      let mut stack: Vec<(usize, usize)> = vec![(start, 0)];
+      colour[start] = 1;
+      while let Some((current, cursor)) = stack.pop() {
+        if cursor >= self.types[current].input_fields.len() {
+          colour[current] = 2;
+          continue;
+        }
+        stack.push((current, cursor + 1));
+        let field = &self.types[current].input_fields[cursor];
+        let packed = field.ty.packed;
+        // The only link that cannot be broken by a `null` or an empty list is a bare `X!`.
+        if packed.depth() != 1 || !packed.is_non_null() {
+          continue;
+        }
+        let target = packed.base_id();
+        if target == UNRESOLVED {
+          continue;
+        }
+        let target = target.get() as usize;
+        if self.types[target].kind != TypeKind::InputObject {
+          continue;
+        }
+        if colour[target] == 1 {
+          if !reported[current] {
+            reported[current] = true;
+            let owner = self.text(self.types[current].name.sym).to_owned();
+            let name = self.text(field.name.sym).to_owned();
+            let at = field.name;
+            self.push_owned(SchemaErrorKind::CircularNonNullInputField, &name, owner, at);
+          }
+          continue;
+        }
+        if colour[target] == 0 {
+          colour[target] = 1;
+          stack.push((target, 0));
+        }
+      }
+    }
+  }
+
+  /// Draft §3.13.1: a directive definition must not refer to itself, directly or indirectly.
+  ///
+  /// One reachability walk per directive, over two interleaved worklists — directives to expand
+  /// and types to expand — with a visited bit each. Iterative on purpose: the type graph's depth
+  /// is bounded by nothing but the document, and a recursive walk would put an SDL's input-object
+  /// chain on the call stack.
+  ///
+  /// The cycle is only reported on the directive the walk *started* from. A directive `@b` that
+  /// merely uses a self-referential `@a` is not itself self-referential, and blaming it would put
+  /// the diagnostic on the wrong definition — the same refinement apollo-compiler makes.
+  fn validate_directive_cycles(&mut self) {
+    let directives = self.directives.len();
+    if directives == 0 {
+      return;
+    }
+    let types = self.types.len();
+    let mut cyclic: Vec<usize> = Vec::new();
+
+    for start in 0..directives {
+      let mut seen_directives = vec![false; directives];
+      let mut seen_types = vec![false; types];
+      let mut pending_directives: Vec<usize> = Vec::new();
+      let mut pending_types: Vec<usize> = Vec::new();
+
+      // Seed with what the definition itself names: the directives applied to its arguments, and
+      // the types those arguments accept.
+      for arg in &self.directives[start].args {
+        self.push_directive_uses(&arg.directives, &mut pending_directives);
+        self.push_type(arg.ty.packed.base_id(), &mut pending_types);
+      }
+
+      let mut found = false;
+      while !found {
+        if let Some(next) = pending_directives.pop() {
+          if next == start {
+            found = true;
+            break;
+          }
+          if seen_directives[next] {
+            continue;
+          }
+          seen_directives[next] = true;
+          for arg in &self.directives[next].args {
+            self.push_directive_uses(&arg.directives, &mut pending_directives);
+            self.push_type(arg.ty.packed.base_id(), &mut pending_types);
+          }
+          continue;
+        }
+        let Some(next) = pending_types.pop() else {
+          break;
+        };
+        if seen_types[next] {
+          continue;
+        }
+        seen_types[next] = true;
+        let raw = &self.types[next];
+        self.push_directive_uses(&raw.directives, &mut pending_directives);
+        for field in &raw.input_fields {
+          self.push_directive_uses(&field.directives, &mut pending_directives);
+          self.push_type(field.ty.packed.base_id(), &mut pending_types);
+        }
+        for value in &raw.enum_values {
+          self.push_directive_uses(&value.directives, &mut pending_directives);
+        }
+      }
+
+      if found {
+        cyclic.push(start);
+      }
+    }
+
+    for index in cyclic {
+      let at = self.directives[index].name;
+      let name = self.text(at.sym).to_owned();
+      self.push(SchemaErrorKind::SelfReferentialDirective, &name, at);
+    }
+  }
+
+  fn push_directive_uses(&self, uses: &[Located], pending: &mut Vec<usize>) {
+    for used in uses {
+      if let Some(index) = self.directive_index(used.sym) {
+        pending.push(index);
+      }
+    }
+  }
+
+  fn push_type(&self, base: TypeId, pending: &mut Vec<usize>) {
+    if base != UNRESOLVED {
+      pending.push(base.get() as usize);
+    }
+  }
+
+  // -- flattening -------------------------------------------------------------------------------
+
+  fn flatten(self) -> Result<Schema, SchemaErrors> {
+    let Self {
+      interner,
+      types: raw_types,
+      type_of_sym: raw_type_of_sym,
+      directives: raw_directives,
+      roots: raw_roots,
+      ..
+    } = self;
+
+    let symbol_count = interner.len();
+    // `raw_type_of_sym` is the builder's own symbol-to-index map; reusing it keeps flattening
+    // linear instead of rescanning the type table for every member and root.
+    let id_of = |sym: Sym| -> Option<TypeId> {
+      match raw_type_of_sym.get(sym.get() as usize) {
+        Some(&index) if index != u32::MAX => Some(TypeId::new(index)),
+        _ => None,
+      }
+    };
+    if symbol_count > MAX_SYMBOLS {
+      return Err(SchemaErrors::new(vec![SchemaError::new(
+        SchemaErrorKind::TooManyNames,
+        "schema",
+        SimpleSpan::default(),
+      )]));
+    }
+
+    // Object ordinals, in type-id order.
+    let mut objects: Vec<TypeId> = Vec::new();
+    let mut ordinal_of: Vec<u32> = vec![TypeDef::NONE; raw_types.len()];
+    for (index, raw) in raw_types.iter().enumerate() {
+      if raw.kind == TypeKind::Object {
+        ordinal_of[index] = objects.len() as u32;
+        objects.push(TypeId::new(index as u32));
+      }
+    }
+    let possible_words = objects.len().div_ceil(64).max(1) as u32;
+
+    let string_id = interner
+      .lookup(b"String")
+      .and_then(id_of)
+      .unwrap_or(UNRESOLVED);
+    let schema_type_id = interner
+      .lookup(b"__Schema")
+      .and_then(id_of)
+      .unwrap_or(UNRESOLVED);
+    let type_type_id = interner
+      .lookup(b"__Type")
+      .and_then(id_of)
+      .unwrap_or(UNRESOLVED);
+    let typename_sym = interner.lookup(builtin::TYPENAME_FIELD.as_bytes());
+    let schema_field_sym = interner.lookup(builtin::SCHEMA_FIELD.as_bytes());
+    let type_field_sym = interner.lookup(builtin::TYPE_FIELD.as_bytes());
+    let type_arg_sym = interner.lookup(builtin::TYPE_FIELD_ARGUMENT.as_bytes());
+
+    let query_root = raw_roots[RootOperation::Query.index()]
+      .and_then(|root| id_of(root.sym))
+      .unwrap_or(UNRESOLVED);
+
+    let mut types: Vec<TypeDef> = Vec::with_capacity(raw_types.len());
+    let mut fields: Vec<FieldDef> = Vec::new();
+    let mut inputs: Vec<InputValueDef> = Vec::new();
+    let mut interfaces: Vec<TypeId> = Vec::new();
+    let mut members: Vec<TypeId> = Vec::new();
+    let mut enum_values: Vec<Sym> = Vec::new();
+    let mut possible: Vec<u64> = Vec::new();
+
+    for (index, raw) in raw_types.iter().enumerate() {
+      let id = TypeId::new(index as u32);
+
+      let interfaces_range = {
+        let start = interfaces.len() as u32;
+        interfaces.extend(raw.closure.iter().map(|i| TypeId::new(*i)));
+        Range32::new(start, interfaces.len() as u32)
+      };
+
+      let members_range = {
+        let start = members.len() as u32;
+        for member in &raw.members {
+          if let Some(target) = id_of(member.sym) {
+            members.push(target);
+          }
+        }
+        Range32::new(start, members.len() as u32)
+      };
+
+      let enum_range = {
+        let start = enum_values.len() as u32;
+        let mut values: Vec<Sym> = raw.enum_values.iter().map(|value| value.name.sym).collect();
+        values.sort_unstable();
+        enum_values.extend(values);
+        Range32::new(start, enum_values.len() as u32)
+      };
+
+      let fields_range = match raw.kind {
+        TypeKind::Object | TypeKind::Interface | TypeKind::Union => {
+          let mut rows: Vec<FieldDef> = Vec::with_capacity(raw.fields.len() + 3);
+          for field in &raw.fields {
+            let args_start = inputs.len() as u32;
+            let mut args: Vec<InputValueDef> = field
+              .args
+              .iter()
+              .map(|arg| InputValueDef::new(arg.name.sym, arg.ty.packed, arg.default))
+              .collect();
+            args.sort_unstable_by_key(|arg| arg.name().get());
+            inputs.extend(args);
+            let args_range = Range32::new(args_start, inputs.len() as u32);
+            rows.push(FieldDef::new(field.name.sym, field.ty.packed, args_range));
+          }
+
+          // The meta-fields, on the types draft §4.4 puts them on.
+          if let (Some(typename), true) = (typename_sym, string_id != UNRESOLVED)
+            && !rows.iter().any(|row| row.name() == typename)
+          {
+            let ty = PackedType::named(raw_types[string_id.get() as usize].name.sym, string_id);
+            let ty = ty.push_non_null().unwrap_or(ty);
+            rows.push(FieldDef::new(typename, ty, Range32::EMPTY));
+          }
+          if id == query_root {
+            if let (Some(name), true) = (schema_field_sym, schema_type_id != UNRESOLVED)
+              && !rows.iter().any(|row| row.name() == name)
+            {
+              let ty = PackedType::named(
+                raw_types[schema_type_id.get() as usize].name.sym,
+                schema_type_id,
+              );
+              let ty = ty.push_non_null().unwrap_or(ty);
+              rows.push(FieldDef::new(name, ty, Range32::EMPTY));
+            }
+            if let (Some(name), Some(arg), true) =
+              (type_field_sym, type_arg_sym, type_type_id != UNRESOLVED)
+              && !rows.iter().any(|row| row.name() == name)
+            {
+              let args_start = inputs.len() as u32;
+              let arg_ty =
+                PackedType::named(raw_types[string_id.get() as usize].name.sym, string_id);
+              let arg_ty = arg_ty.push_non_null().unwrap_or(arg_ty);
+              inputs.push(InputValueDef::new(arg, arg_ty, DefaultKind::Absent));
+              let args_range = Range32::new(args_start, inputs.len() as u32);
+              let ty = PackedType::named(
+                raw_types[type_type_id.get() as usize].name.sym,
+                type_type_id,
+              );
+              rows.push(FieldDef::new(name, ty, args_range));
+            }
+          }
+
+          rows.sort_unstable_by_key(|row| row.name().get());
+          let start = fields.len() as u32;
+          fields.extend(rows);
+          Range32::new(start, fields.len() as u32)
+        }
+        TypeKind::InputObject => {
+          let mut rows: Vec<InputValueDef> = raw
+            .input_fields
+            .iter()
+            .map(|field| InputValueDef::new(field.name.sym, field.ty.packed, field.default))
+            .collect();
+          rows.sort_unstable_by_key(|row| row.name().get());
+          let start = inputs.len() as u32;
+          inputs.extend(rows);
+          Range32::new(start, inputs.len() as u32)
+        }
+        _ => Range32::EMPTY,
+      };
+
+      let possible_start = if raw.kind.is_composite() {
+        let start = possible.len() as u32;
+        possible.resize(possible.len() + possible_words as usize, 0);
+        match raw.kind {
+          TypeKind::Object => {
+            set_bit(&mut possible, start, ordinal_of[index]);
+          }
+          TypeKind::Union => {
+            for member in &raw.members {
+              if let Some(target) = id_of(member.sym) {
+                let ordinal = ordinal_of[target.get() as usize];
+                set_bit(&mut possible, start, ordinal);
+              }
+            }
+          }
+          TypeKind::Interface => {
+            for (candidate, other) in raw_types.iter().enumerate() {
+              if other.kind == TypeKind::Object && other.closure.contains(&(index as u32)) {
+                set_bit(&mut possible, start, ordinal_of[candidate]);
+              }
+            }
+          }
+          _ => {}
+        }
+        start
+      } else {
+        TypeDef::NONE
+      };
+
+      let mut flags = TypeFlags::EMPTY;
+      if raw.built_in {
+        flags = flags.union(TypeFlags::BUILT_IN);
+      }
+      if raw
+        .directives
+        .iter()
+        .any(|used| interner.text(used.sym) == "oneOf")
+      {
+        flags = flags.union(TypeFlags::ONE_OF);
+      }
+
+      types.push(TypeDef::new(
+        raw.name.sym,
+        raw.kind,
+        flags,
+        fields_range,
+        interfaces_range,
+        members_range,
+        enum_range,
+        possible_start,
+        ordinal_of[index],
+      ));
+    }
+
+    let mut directives: Vec<DirectiveDef> = Vec::with_capacity(raw_directives.len());
+    for raw in &raw_directives {
+      let args_start = inputs.len() as u32;
+      let mut args: Vec<InputValueDef> = raw
+        .args
+        .iter()
+        .map(|arg| InputValueDef::new(arg.name.sym, arg.ty.packed, arg.default))
+        .collect();
+      args.sort_unstable_by_key(|arg| arg.name().get());
+      inputs.extend(args);
+      let args_range = Range32::new(args_start, inputs.len() as u32);
+      directives.push(DirectiveDef::new(
+        raw.name.sym,
+        raw.locations,
+        args_range,
+        raw.repeatable,
+        raw.built_in,
+      ));
+    }
+    directives.sort_unstable_by_key(|directive| directive.name().get());
+
+    let mut type_of_sym = vec![u32::MAX; symbol_count as usize];
+    for (index, raw) in raw_types.iter().enumerate() {
+      type_of_sym[raw.name.sym.get() as usize] = index as u32;
+    }
+
+    let Interner {
+      strings,
+      spans,
+      map: _,
+    } = interner;
+    let strings = strings.into_boxed_slice();
+    let spans = spans.into_boxed_slice();
+    let index = {
+      let spans_ref = &spans;
+      let strings_ref = &strings;
+      NameIndex::build(symbol_count, |sym| {
+        let (start, end) = spans_ref[sym as usize];
+        &strings_ref[start as usize..end as usize]
+      })
+    };
+    let Some(index) = index else {
+      return Err(SchemaErrors::new(vec![SchemaError::new(
+        SchemaErrorKind::TooManyNames,
+        "schema",
+        SimpleSpan::default(),
+      )]));
+    };
+
+    let roots = [
+      raw_roots[0].and_then(|root| id_of(root.sym)),
+      raw_roots[1].and_then(|root| id_of(root.sym)),
+      raw_roots[2].and_then(|root| id_of(root.sym)),
+    ];
+
+    Ok(Schema {
+      strings,
+      spans,
+      index,
+      types: types.into_boxed_slice(),
+      type_of_sym: type_of_sym.into_boxed_slice(),
+      fields: fields.into_boxed_slice(),
+      inputs: inputs.into_boxed_slice(),
+      interfaces: interfaces.into_boxed_slice(),
+      members: members.into_boxed_slice(),
+      enum_values: enum_values.into_boxed_slice(),
+      possible: possible.into_boxed_slice(),
+      possible_words,
+      objects: objects.into_boxed_slice(),
+      directives: directives.into_boxed_slice(),
+      roots,
+    })
+  }
+}
+
+fn set_bit(words: &mut [u64], start: u32, ordinal: u32) {
+  if ordinal == TypeDef::NONE {
+    return;
+  }
+  let word = start as usize + (ordinal / 64) as usize;
+  if let Some(slot) = words.get_mut(word) {
+    *slot |= 1u64 << (ordinal % 64);
+  }
+}
+
+fn map_operation(operation: &OperationType) -> RootOperation {
+  match operation {
+    OperationType::Query(_) => RootOperation::Query,
+    OperationType::Mutation(_) => RootOperation::Mutation,
+    _ => RootOperation::Subscription,
+  }
+}
+
+fn map_location(location: &Location) -> Option<DirectiveLocation> {
+  DirectiveLocation::from_name(location.as_str())
+}
+
+/// The name of a type definition, as a `&str` over the built-in SDL's `&'static str` source.
+fn introspection_type_name(definition: &TypeDefinition<&'static str>) -> &'static str {
+  match definition {
+    TypeDefinition::Scalar(def) => def.name().source(),
+    TypeDefinition::Object(def) => def.name().source(),
+    TypeDefinition::Interface(def) => def.name().source(),
+    TypeDefinition::Union(def) => def.name().source(),
+    TypeDefinition::Enum(def) => def.name().source(),
+    TypeDefinition::InputObject(def) => def.name().source(),
+  }
+}
+
+impl Schema {
+  /// Builds a schema from one type-system document.
+  ///
+  /// Draft §3 "Type Validation" runs here: a document that is not a valid schema comes back as
+  /// [`SchemaErrors`] rather than as a `Schema` nobody checked.
+  ///
+  /// Use [`SchemaBuilder`] directly when the schema spans several documents.
+  #[inline]
+  pub fn build<S>(document: &TypeSystemDocument<S>) -> Result<Self, SchemaErrors>
+  where
+    S: AsRef<[u8]>,
+  {
+    let mut builder = SchemaBuilder::new();
+    builder.document(document);
+    builder.finish()
+  }
+}

--- a/smear/src/validator/schema/builder.rs
+++ b/smear/src/validator/schema/builder.rs
@@ -888,7 +888,7 @@ impl SchemaBuilder {
       let TypeSystemDefinition::Type(ty) = described.node() else {
         continue;
       };
-      let name = introspection_type_name(ty);
+      let name = type_definition_name(ty);
       match self.interner.lookup(name.as_bytes()).and_then(|sym| {
         self
           .type_index(sym)
@@ -915,7 +915,7 @@ impl SchemaBuilder {
       let TypeSystemDefinition::Type(ty) = described.node() else {
         continue;
       };
-      let name = introspection_type_name(ty);
+      let name = type_definition_name(ty);
       let taken = self
         .interner
         .lookup(name.as_bytes())
@@ -1941,9 +1941,11 @@ impl SchemaBuilder {
               let ty = ty.push_non_null().unwrap_or(ty);
               rows.push(FieldDef::new(name, ty, Range32::EMPTY));
             }
-            if let (Some(name), Some(arg), true) =
-              (type_field_sym, type_arg_sym, type_type_id != UNRESOLVED)
-              && !rows.iter().any(|row| row.name() == name)
+            if let (Some(name), Some(arg), true) = (
+              type_field_sym,
+              type_arg_sym,
+              type_type_id != UNRESOLVED && string_id != UNRESOLVED,
+            ) && !rows.iter().any(|row| row.name() == name)
             {
               let args_start = inputs.len() as u32;
               let arg_ty =
@@ -2130,7 +2132,10 @@ fn map_location(location: &Location) -> Option<DirectiveLocation> {
 }
 
 /// The name of a type definition, as a `&str` over the built-in SDL's `&'static str` source.
-fn introspection_type_name(definition: &TypeDefinition<&'static str>) -> &'static str {
+///
+/// Used for both the introspection types and the built-in scalars; the two differ in what the
+/// caller does when the name is already taken, not in how it is read.
+fn type_definition_name(definition: &TypeDefinition<&'static str>) -> &'static str {
   match definition {
     TypeDefinition::Scalar(def) => def.name().source(),
     TypeDefinition::Object(def) => def.name().source(),

--- a/smear/src/validator/schema/builtin.rs
+++ b/smear/src/validator/schema/builtin.rs
@@ -1,0 +1,165 @@
+//! The specification-provided part of every schema, as SDL.
+//!
+//! # Why the meta-schema is unconditional
+//!
+//! An introspection *query* is an executable document like any other, and draft 5.3.1 asks
+//! whether each of its fields exists on the type it is selected from. `{ __schema { types { name
+//! } } }` therefore only validates against a schema that knows `__Schema` and `__Type` — so the
+//! meta-schema is injected into every schema this crate builds, not behind a feature. The
+//! `introspection` cargo feature is a *construction door* (building a schema out of an
+//! introspection response), which is a different thing and does not gate this.
+//!
+//! # Why the built-in scalars and directives are conditional
+//!
+//! `Int`, `Float`, `String`, `Boolean`, `ID` and the five specified directives are injected only
+//! when the document does not define them. A document that spells one out replaces it, which is
+//! what the ecosystem does and what a schema printed by one server and re-read by another
+//! requires — a printed schema repeats the built-ins verbatim, and rejecting that would make
+//! round-tripping impossible. The introspection types are not replaceable the same way: they are
+//! `__`-prefixed, so a definition of one is a reserved-name violation, reported as
+//! [`RedefinedBuiltInType`](super::SchemaErrorKind::RedefinedBuiltInType).
+
+/// The five built-in scalars, injected when the document does not define them.
+pub const BUILT_IN_SCALARS_SDL: &str = "\
+scalar Int
+scalar Float
+scalar String
+scalar Boolean
+scalar ID
+";
+
+/// The names of the five built-in scalars, in the order [`BUILT_IN_SCALARS_SDL`] declares them.
+pub const BUILT_IN_SCALARS: [&str; 5] = ["Int", "Float", "String", "Boolean", "ID"];
+
+/// The five specified directives, injected when the document does not define them.
+pub const BUILT_IN_DIRECTIVES_SDL: &str = "\
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @deprecated(reason: String = \"No longer supported\") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
+directive @specifiedBy(url: String!) on SCALAR
+directive @oneOf on INPUT_OBJECT
+";
+
+/// The names of the five specified directives, without the `@`.
+pub const BUILT_IN_DIRECTIVES: [&str; 5] =
+  ["skip", "include", "deprecated", "specifiedBy", "oneOf"];
+
+/// The draft §4 introspection type system, injected into every schema.
+pub const INTROSPECTION_SDL: &str = "\
+type __Schema {
+  description: String
+  types: [__Type!]!
+  queryType: __Type!
+  mutationType: __Type
+  subscriptionType: __Type
+  directives: [__Directive!]!
+}
+
+type __Type {
+  kind: __TypeKind!
+  name: String
+  description: String
+  specifiedByURL: String
+  fields(includeDeprecated: Boolean = false): [__Field!]
+  interfaces: [__Type!]
+  possibleTypes: [__Type!]
+  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+  inputFields(includeDeprecated: Boolean = false): [__InputValue!]
+  ofType: __Type
+  isOneOf: Boolean
+}
+
+type __Field {
+  name: String!
+  description: String
+  args(includeDeprecated: Boolean = false): [__InputValue!]!
+  type: __Type!
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+type __InputValue {
+  name: String!
+  description: String
+  type: __Type!
+  defaultValue: String
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+type __EnumValue {
+  name: String!
+  description: String
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+enum __TypeKind {
+  SCALAR
+  OBJECT
+  INTERFACE
+  UNION
+  ENUM
+  INPUT_OBJECT
+  LIST
+  NON_NULL
+}
+
+type __Directive {
+  name: String!
+  description: String
+  locations: [__DirectiveLocation!]!
+  args(includeDeprecated: Boolean = false): [__InputValue!]!
+  isRepeatable: Boolean!
+}
+
+enum __DirectiveLocation {
+  QUERY
+  MUTATION
+  SUBSCRIPTION
+  FIELD
+  FRAGMENT_DEFINITION
+  FRAGMENT_SPREAD
+  INLINE_FRAGMENT
+  VARIABLE_DEFINITION
+  SCHEMA
+  SCALAR
+  OBJECT
+  FIELD_DEFINITION
+  ARGUMENT_DEFINITION
+  INTERFACE
+  UNION
+  ENUM
+  ENUM_VALUE
+  INPUT_OBJECT
+  INPUT_FIELD_DEFINITION
+}
+";
+
+/// The names of the introspection types, in the order [`INTROSPECTION_SDL`] declares them.
+pub const INTROSPECTION_TYPES: [&str; 8] = [
+  "__Schema",
+  "__Type",
+  "__Field",
+  "__InputValue",
+  "__EnumValue",
+  "__TypeKind",
+  "__Directive",
+  "__DirectiveLocation",
+];
+
+/// `__typename`, the meta-field every object, interface and union carries (draft §4.4).
+///
+/// The three meta-fields are assembled directly into the flattened field table rather than
+/// declared as SDL: they belong to types the document defines, not to a type of their own, and
+/// giving them a synthetic carrier would leave a phantom entry in the type table forever.
+pub const TYPENAME_FIELD: &str = "__typename";
+
+/// `__schema`, the query root's meta-field returning the whole schema (draft §4.4).
+pub const SCHEMA_FIELD: &str = "__schema";
+
+/// `__type`, the query root's meta-field returning one named type (draft §4.4).
+pub const TYPE_FIELD: &str = "__type";
+
+/// The name of `__type`'s single argument.
+pub const TYPE_FIELD_ARGUMENT: &str = "name";

--- a/smear/src/validator/schema/error.rs
+++ b/smear/src/validator/schema/error.rs
@@ -1,0 +1,488 @@
+//! What [`Schema::build`] refuses, and how it says so.
+//!
+//! Draft §3 "Type Validation" runs inside the build, so a server rejects a bad SDL exactly once
+//! rather than rediscovering it per request. This module is the vocabulary of that refusal:
+//! [`SchemaErrorKind`] enumerates every class the build rejects, and [`SchemaError`] names the
+//! artifact it rejected and points at it.
+//!
+//! The build path is explicitly not performance-critical — it runs once — so these errors own
+//! their strings. That is what keeps [`Schema`](super::Schema)'s promise honest in the failure
+//! direction too: a `SchemaErrors` outlives the SDL it came from and can cross a thread or an FFI
+//! boundary with nothing borrowed.
+
+use std::{boxed::Box, string::String, vec::Vec};
+
+use tokora::SimpleSpan;
+
+/// Which of draft §3's rules a [`SchemaError`] reports.
+///
+/// Each variant carries the section it comes from in its documentation. The set is closed by the
+/// specification, not by taste: `SchemaErrorKind::ALL` enumerates it, and the build fixtures pair
+/// every variant with a schema that makes it fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum SchemaErrorKind {
+  // -- §3.3 The schema, and document-level uniqueness ---------------------------------------
+  /// Two definitions give the same name to a type (draft §3.3).
+  DuplicateTypeName,
+  /// Two definitions give the same name to a directive (draft §3.3).
+  DuplicateDirectiveDefinition,
+  /// A document defines `schema` more than once (draft §3.3).
+  DuplicateSchemaDefinition,
+  /// A `schema` block names the same root operation twice (draft §3.3).
+  DuplicateRootOperationType,
+  /// A root operation names a type the document does not define (draft §3.3).
+  UndefinedRootOperationType,
+  /// A root operation names a type that is not an object type (draft §3.3).
+  RootOperationTypeNotObject,
+  /// The schema provides no query root operation type (draft §3.3).
+  MissingQueryRootOperationType,
+  /// `extend` names a type the document does not define (draft §3.3).
+  UndefinedExtensionTarget,
+  /// `extend` names a type of a different kind than the extension's keyword (draft §3.3).
+  ExtensionKindMismatch,
+  /// A definition redefines an introspection type (draft §3.3).
+  ///
+  /// The five built-in scalars and the five specified directives are *not* in this class: a
+  /// document that spells one out replaces it, which is what makes a printed schema re-readable.
+  /// The introspection types are `__`-prefixed and injected unconditionally, so a definition of
+  /// one is a genuine collision.
+  RedefinedBuiltInType,
+  /// A user-defined type name begins with `__` (draft §3.3, "Reserved Names").
+  ReservedTypeName,
+  /// A type reference names a type the document does not define (draft §3.4).
+  UndefinedType,
+  /// A type reference nests more list and non-null wrappers than the representation admits.
+  ///
+  /// Not a specification rule: [`MAX_WRAPPERS`](super::MAX_WRAPPERS) is this implementation's
+  /// packing limit, and refusing is the only alternative to silently truncating a type.
+  TypeReferenceTooDeep,
+  /// A name in the document is not spelled `/[_A-Za-z][_0-9A-Za-z]*/`.
+  ///
+  /// Unreachable from parsed input — the lexer's identifier rule is the same grammar — and
+  /// checked anyway, because the AST types are public and a caller may assemble one by hand.
+  InvalidName,
+  /// The document interns more distinct names than the index can address.
+  ///
+  /// A capacity limit of this implementation ([`MAX_SYMBOLS`](super::MAX_SYMBOLS)), not a
+  /// specification rule.
+  TooManyNames,
+
+  // -- §3.6 Objects, §3.7 Interfaces --------------------------------------------------------
+  /// An object or interface type defines no fields (draft §3.6.1, §3.7.1).
+  EmptyFieldsDefinition,
+  /// A type defines the same field name twice (draft §3.6.1, §3.7.1).
+  DuplicateFieldName,
+  /// A field name begins with `__` (draft §3.6.1, §3.7.1).
+  ReservedFieldName,
+  /// A field's result type is an input type (draft §3.6.1, §3.7.1).
+  FieldTypeNotOutputType,
+  /// A field declares the same argument name twice (draft §3.6.1, §3.7.1).
+  DuplicateArgumentName,
+  /// An argument name begins with `__` (draft §3.6.1, §3.7.1).
+  ReservedArgumentName,
+  /// An argument's type is an output type (draft §3.6.1, §3.7.1).
+  ArgumentTypeNotInputType,
+  /// `implements` names a type that is not an interface (draft §3.6.1, §3.7.1).
+  ImplementsNonInterface,
+  /// `implements` names a type the document does not define (draft §3.6.1, §3.7.1).
+  UndefinedImplementsInterface,
+  /// `implements` names the same interface twice (draft §3.6.1, §3.7.1).
+  DuplicateImplementsInterface,
+  /// An interface implements itself (draft §3.7.1).
+  SelfImplementingInterface,
+  /// A type implements an interface without also declaring what that interface implements
+  /// (draft §3.6.1, §3.7.1).
+  MissingTransitiveInterface,
+  /// A type implements an interface but omits one of its fields (draft §3.6.1, §3.7.1).
+  MissingInterfaceField,
+  /// A field's type is not a valid implementation of the interface field's type — the covariance
+  /// rule (draft §3.6.1, §3.7.1).
+  InvalidInterfaceFieldType,
+  /// A field omits an argument the interface field declares (draft §3.6.1, §3.7.1).
+  MissingInterfaceFieldArgument,
+  /// A field's argument type differs from the interface field's — arguments are invariant, not
+  /// contravariant (draft §3.6.1, §3.7.1).
+  InvalidInterfaceFieldArgumentType,
+  /// A field adds a required argument the interface field does not declare (draft §3.6.1,
+  /// §3.7.1).
+  UnexpectedRequiredArgument,
+
+  // -- §3.8 Unions --------------------------------------------------------------------------
+  /// A union type declares no members (draft §3.8.1).
+  EmptyUnionMembers,
+  /// A union member is not an object type (draft §3.8.1).
+  UnionMemberNotObject,
+  /// A union names a type the document does not define (draft §3.8.1).
+  UndefinedUnionMember,
+  /// A union names the same member twice (draft §3.8.1).
+  DuplicateUnionMember,
+
+  // -- §3.9 Enums ---------------------------------------------------------------------------
+  /// An enum type defines no values (draft §3.9.1).
+  EmptyEnumValues,
+  /// An enum defines the same value twice (draft §3.9.1).
+  DuplicateEnumValue,
+  /// An enum value name begins with `__` (draft §3.3, "Reserved Names").
+  ReservedEnumValueName,
+
+  // -- §3.10 Input objects ------------------------------------------------------------------
+  /// An input object type defines no fields (draft §3.10.1).
+  EmptyInputFields,
+  /// An input object defines the same field name twice (draft §3.10.1).
+  DuplicateInputFieldName,
+  /// An input field name begins with `__` (draft §3.10.1).
+  ReservedInputFieldName,
+  /// An input field's type is an output type (draft §3.10.1).
+  InputFieldTypeNotInputType,
+  /// A field of a `@oneOf` input object is non-null (draft §3.10.1).
+  OneOfFieldNotNullable,
+  /// A field of a `@oneOf` input object declares a default value (draft §3.10.1).
+  OneOfFieldHasDefault,
+  /// Input objects form a cycle in which every link is non-null, so no finite value satisfies it
+  /// (draft §3.10.1).
+  CircularNonNullInputField,
+
+  // -- §3.13 Directives ---------------------------------------------------------------------
+  /// A directive name begins with `__` (draft §3.13.1).
+  ReservedDirectiveName,
+  /// A directive declares the same argument name twice (draft §3.13.1).
+  DuplicateDirectiveArgumentName,
+  /// A directive argument name begins with `__` (draft §3.13.1).
+  ReservedDirectiveArgumentName,
+  /// A directive argument's type is an output type (draft §3.13.1).
+  DirectiveArgumentTypeNotInputType,
+  /// A directive definition refers to itself, directly or through the types it names
+  /// (draft §3.13.1).
+  SelfReferentialDirective,
+}
+
+impl SchemaErrorKind {
+  /// Every kind the build can report.
+  ///
+  /// The build fixtures iterate this rather than a hand-kept list, so a kind added without a
+  /// schema that makes it fire fails a test instead of shipping unexercised.
+  pub const ALL: &'static [Self] = &[
+    Self::DuplicateTypeName,
+    Self::DuplicateDirectiveDefinition,
+    Self::DuplicateSchemaDefinition,
+    Self::DuplicateRootOperationType,
+    Self::UndefinedRootOperationType,
+    Self::RootOperationTypeNotObject,
+    Self::MissingQueryRootOperationType,
+    Self::UndefinedExtensionTarget,
+    Self::ExtensionKindMismatch,
+    Self::RedefinedBuiltInType,
+    Self::ReservedTypeName,
+    Self::UndefinedType,
+    Self::TypeReferenceTooDeep,
+    Self::InvalidName,
+    Self::TooManyNames,
+    Self::EmptyFieldsDefinition,
+    Self::DuplicateFieldName,
+    Self::ReservedFieldName,
+    Self::FieldTypeNotOutputType,
+    Self::DuplicateArgumentName,
+    Self::ReservedArgumentName,
+    Self::ArgumentTypeNotInputType,
+    Self::ImplementsNonInterface,
+    Self::UndefinedImplementsInterface,
+    Self::DuplicateImplementsInterface,
+    Self::SelfImplementingInterface,
+    Self::MissingTransitiveInterface,
+    Self::MissingInterfaceField,
+    Self::InvalidInterfaceFieldType,
+    Self::MissingInterfaceFieldArgument,
+    Self::InvalidInterfaceFieldArgumentType,
+    Self::UnexpectedRequiredArgument,
+    Self::EmptyUnionMembers,
+    Self::UnionMemberNotObject,
+    Self::UndefinedUnionMember,
+    Self::DuplicateUnionMember,
+    Self::EmptyEnumValues,
+    Self::DuplicateEnumValue,
+    Self::ReservedEnumValueName,
+    Self::EmptyInputFields,
+    Self::DuplicateInputFieldName,
+    Self::ReservedInputFieldName,
+    Self::InputFieldTypeNotInputType,
+    Self::OneOfFieldNotNullable,
+    Self::OneOfFieldHasDefault,
+    Self::CircularNonNullInputField,
+    Self::ReservedDirectiveName,
+    Self::DuplicateDirectiveArgumentName,
+    Self::ReservedDirectiveArgumentName,
+    Self::DirectiveArgumentTypeNotInputType,
+    Self::SelfReferentialDirective,
+  ];
+
+  /// Returns the phrase this kind renders as, with no subject attached.
+  pub const fn message(&self) -> &'static str {
+    match self {
+      Self::DuplicateTypeName => "duplicate type definition",
+      Self::DuplicateDirectiveDefinition => "duplicate directive definition",
+      Self::DuplicateSchemaDefinition => "duplicate schema definition",
+      Self::DuplicateRootOperationType => "duplicate root operation type",
+      Self::UndefinedRootOperationType => "undefined root operation type",
+      Self::RootOperationTypeNotObject => "root operation type is not an object type",
+      Self::MissingQueryRootOperationType => "no query root operation type",
+      Self::UndefinedExtensionTarget => "extension target is not defined",
+      Self::ExtensionKindMismatch => "extension does not match the kind of the type it extends",
+      Self::RedefinedBuiltInType => "redefinition of an introspection type",
+      Self::ReservedTypeName => "type name is reserved for introspection",
+      Self::UndefinedType => "undefined type",
+      Self::TypeReferenceTooDeep => "type reference nests too deeply",
+      Self::InvalidName => "not a GraphQL name",
+      Self::TooManyNames => "too many distinct names",
+      Self::EmptyFieldsDefinition => "type defines no fields",
+      Self::DuplicateFieldName => "duplicate field",
+      Self::ReservedFieldName => "field name is reserved for introspection",
+      Self::FieldTypeNotOutputType => "field type is not an output type",
+      Self::DuplicateArgumentName => "duplicate argument",
+      Self::ReservedArgumentName => "argument name is reserved for introspection",
+      Self::ArgumentTypeNotInputType => "argument type is not an input type",
+      Self::ImplementsNonInterface => "implemented type is not an interface",
+      Self::UndefinedImplementsInterface => "implemented interface is not defined",
+      Self::DuplicateImplementsInterface => "duplicate implemented interface",
+      Self::SelfImplementingInterface => "interface implements itself",
+      Self::MissingTransitiveInterface => "transitively implemented interface is not declared",
+      Self::MissingInterfaceField => "interface field is missing",
+      Self::InvalidInterfaceFieldType => {
+        "field type is not a valid implementation of the \
+                                          interface field type"
+      }
+      Self::MissingInterfaceFieldArgument => "interface field argument is missing",
+      Self::InvalidInterfaceFieldArgumentType => {
+        "argument type differs from the interface \
+                                                  field's"
+      }
+      Self::UnexpectedRequiredArgument => {
+        "required argument is not declared by the interface \
+                                            field"
+      }
+      Self::EmptyUnionMembers => "union declares no member types",
+      Self::UnionMemberNotObject => "union member is not an object type",
+      Self::UndefinedUnionMember => "union member is not defined",
+      Self::DuplicateUnionMember => "duplicate union member",
+      Self::EmptyEnumValues => "enum defines no values",
+      Self::DuplicateEnumValue => "duplicate enum value",
+      Self::ReservedEnumValueName => "enum value name is reserved for introspection",
+      Self::EmptyInputFields => "input object defines no fields",
+      Self::DuplicateInputFieldName => "duplicate input field",
+      Self::ReservedInputFieldName => "input field name is reserved for introspection",
+      Self::InputFieldTypeNotInputType => "input field type is not an input type",
+      Self::OneOfFieldNotNullable => "field of a @oneOf input object is non-null",
+      Self::OneOfFieldHasDefault => "field of a @oneOf input object has a default value",
+      Self::CircularNonNullInputField => "input object cycle has no nullable or list link",
+      Self::ReservedDirectiveName => "directive name is reserved for introspection",
+      Self::DuplicateDirectiveArgumentName => "duplicate directive argument",
+      Self::ReservedDirectiveArgumentName => {
+        "directive argument name is reserved for introspection"
+      }
+      Self::DirectiveArgumentTypeNotInputType => "directive argument type is not an input type",
+      Self::SelfReferentialDirective => "directive definition refers to itself",
+    }
+  }
+}
+
+impl core::fmt::Display for SchemaErrorKind {
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str(self.message())
+  }
+}
+
+/// One reason [`Schema::build`](super::Schema::build) refused a document.
+///
+/// Every error names its subject — the artifact that was rejected, qualified by its owner where
+/// it has one, so `User.pet` reads as the field and `User.pet.first` as its argument — and points
+/// at it with a span into the document it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaError {
+  kind: SchemaErrorKind,
+  subject: Box<str>,
+  owner: Option<Box<str>>,
+  span: SimpleSpan,
+  related: Option<SimpleSpan>,
+  document: u32,
+}
+
+impl SchemaError {
+  /// Assembles an error naming a top-level artifact.
+  pub(crate) fn new(kind: SchemaErrorKind, subject: &str, span: SimpleSpan) -> Self {
+    Self {
+      kind,
+      subject: subject.into(),
+      owner: None,
+      span,
+      related: None,
+      document: 0,
+    }
+  }
+
+  /// Qualifies the subject with the artifact that owns it.
+  pub(crate) fn owned_by(mut self, owner: impl Into<String>) -> Self {
+    self.owner = Some(owner.into().into_boxed_str());
+    self
+  }
+
+  /// Points at a second, related position — the first of two duplicates, say.
+  pub(crate) fn related_to(mut self, span: SimpleSpan) -> Self {
+    self.related = Some(span);
+    self
+  }
+
+  /// Records which of the builder's documents the spans belong to.
+  pub(crate) fn in_document(mut self, index: u32) -> Self {
+    self.document = index;
+    self
+  }
+
+  /// Returns which rule refused.
+  #[inline]
+  pub const fn kind(&self) -> SchemaErrorKind {
+    self.kind
+  }
+
+  /// Returns the name of the rejected artifact, unqualified.
+  #[inline]
+  pub fn subject(&self) -> &str {
+    &self.subject
+  }
+
+  /// Returns the name of the artifact that owns the subject, when it has one.
+  #[inline]
+  pub fn owner(&self) -> Option<&str> {
+    self.owner.as_deref()
+  }
+
+  /// Returns the subject's position in its document.
+  #[inline]
+  pub const fn span(&self) -> SimpleSpan {
+    self.span
+  }
+
+  /// Returns a second position the error refers to, when there is one.
+  #[inline]
+  pub const fn related(&self) -> Option<SimpleSpan> {
+    self.related
+  }
+
+  /// Returns the index of the document the spans belong to, in the order the builder was given
+  /// them.
+  #[inline]
+  pub const fn document(&self) -> u32 {
+    self.document
+  }
+}
+
+impl core::fmt::Display for SchemaError {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "{}: `", self.kind)?;
+    if let Some(owner) = &self.owner {
+      write!(f, "{owner}.")?;
+    }
+    write!(f, "{}`", self.subject)
+  }
+}
+
+impl core::error::Error for SchemaError {}
+
+/// Every reason a build failed, in the order the builder found them.
+///
+/// The build does not stop at the first refusal: an SDL author wants the whole list, and the path
+/// runs once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaErrors {
+  errors: Vec<SchemaError>,
+}
+
+impl SchemaErrors {
+  /// Wraps a nonempty error list.
+  pub(crate) fn new(errors: Vec<SchemaError>) -> Self {
+    Self { errors }
+  }
+
+  /// Returns the errors.
+  #[inline]
+  pub fn errors(&self) -> &[SchemaError] {
+    &self.errors
+  }
+
+  /// Returns how many errors the build reported.
+  #[inline]
+  pub fn len(&self) -> usize {
+    self.errors.len()
+  }
+
+  /// Returns whether the list is empty. It never is for a returned `Err`.
+  #[inline]
+  pub fn is_empty(&self) -> bool {
+    self.errors.is_empty()
+  }
+
+  /// Returns whether any error has the given kind.
+  #[inline]
+  pub fn contains_kind(&self, kind: SchemaErrorKind) -> bool {
+    self.errors.iter().any(|error| error.kind() == kind)
+  }
+
+  /// Returns every kind reported, deduplicated and sorted.
+  pub fn kinds(&self) -> Vec<SchemaErrorKind> {
+    let mut kinds: Vec<_> = self.errors.iter().map(SchemaError::kind).collect();
+    kinds.sort_unstable();
+    kinds.dedup();
+    kinds
+  }
+}
+
+impl AsRef<[SchemaError]> for SchemaErrors {
+  #[inline]
+  fn as_ref(&self) -> &[SchemaError] {
+    &self.errors
+  }
+}
+
+impl core::ops::Deref for SchemaErrors {
+  type Target = [SchemaError];
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    &self.errors
+  }
+}
+
+impl IntoIterator for SchemaErrors {
+  type Item = SchemaError;
+  type IntoIter = std::vec::IntoIter<SchemaError>;
+
+  #[inline]
+  fn into_iter(self) -> Self::IntoIter {
+    self.errors.into_iter()
+  }
+}
+
+impl core::fmt::Display for SchemaErrors {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let plural = if self.errors.len() == 1 { "" } else { "s" };
+    write!(f, "{} schema error{plural}", self.errors.len())?;
+    for error in &self.errors {
+      write!(f, "\n  {error}")?;
+    }
+    Ok(())
+  }
+}
+
+impl core::error::Error for SchemaErrors {}
+
+/// Convenience for the builder: an owner path built from up to three name segments.
+pub(crate) fn owner_path(segments: &[&str]) -> String {
+  let mut path = String::new();
+  for (index, segment) in segments.iter().enumerate() {
+    if index > 0 {
+      path.push('.');
+    }
+    path.push_str(segment);
+  }
+  path
+}

--- a/smear/src/validator/schema/mod.rs
+++ b/smear/src/validator/schema/mod.rs
@@ -1,0 +1,49 @@
+//! The built-once schema: representation, construction, and draft §3 refusal.
+//!
+//! [`Schema`] is the substrate every validation rule sits on. It is built once from a
+//! `TypeSystemDocument`, owns everything it needs, and is then read — never written — by an
+//! unbounded number of concurrent validations holding `&Schema`.
+//!
+//! ```
+//! use smear::{
+//!   parser::graphql::{
+//!     GraphQL, ast::TypeSystemDocument, error::GraphqlErrors,
+//!     syntactic::{GraphqlLexer, type_system_document},
+//!   },
+//!   validator::schema::{RootOperation, Schema},
+//! };
+//! use smear::lexer::tokora::{Parse as _, Parser};
+//!
+//! let sdl = "type Query { hero: Character } interface Character { name: String! }";
+//! let document = Parser::with_parser::<
+//!   GraphqlLexer<'_, str>,
+//!   TypeSystemDocument<&str>,
+//!   GraphqlErrors<&str>,
+//!   _,
+//!   GraphQL,
+//! >(type_system_document)
+//! .parse_str(sdl)
+//! .expect("the SDL parses");
+//!
+//! let schema = Schema::build(&document).expect("the SDL is a schema");
+//! let (query, _) = schema.type_by_name(b"Query").expect("Query is defined");
+//! assert_eq!(schema.root(RootOperation::Query), Some(query));
+//!
+//! // Introspection is part of every schema, so an introspection query has something to
+//! // validate against.
+//! assert!(schema.type_by_name(b"__Schema").is_some());
+//! ```
+
+pub mod builtin;
+
+mod builder;
+mod error;
+mod repr;
+
+pub use builder::SchemaBuilder;
+pub use error::{SchemaError, SchemaErrorKind, SchemaErrors};
+pub use repr::{
+  DefaultKind, DirectiveDef, DirectiveLocation, DirectiveLocations, FieldDef, InputValueDef,
+  MAX_SYMBOLS, MAX_WRAPPERS, NameIndex, PackedType, Range32, RootOperation, Schema, Sym, TypeDef,
+  TypeFlags, TypeId, TypeKind, is_name, is_reserved,
+};

--- a/smear/src/validator/schema/repr/location.rs
+++ b/smear/src/validator/schema/repr/location.rs
@@ -1,0 +1,202 @@
+//! The nineteen draft directive locations, and the bitmask a directive definition carries.
+
+/// One of the draft grammar's nineteen `DirectiveLocation`s.
+///
+/// The discriminants are the bit positions used by [`DirectiveLocations`], so the whole of draft
+/// 5.7.2 ("Directives Are In Valid Locations") is `locations.contains(loc)` — one shift and one
+/// `AND` against a word computed at build time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+pub enum DirectiveLocation {
+  /// `QUERY`
+  Query = 0,
+  /// `MUTATION`
+  Mutation = 1,
+  /// `SUBSCRIPTION`
+  Subscription = 2,
+  /// `FIELD`
+  Field = 3,
+  /// `FRAGMENT_DEFINITION`
+  FragmentDefinition = 4,
+  /// `FRAGMENT_SPREAD`
+  FragmentSpread = 5,
+  /// `INLINE_FRAGMENT`
+  InlineFragment = 6,
+  /// `VARIABLE_DEFINITION`
+  VariableDefinition = 7,
+  /// `SCHEMA`
+  Schema = 8,
+  /// `SCALAR`
+  Scalar = 9,
+  /// `OBJECT`
+  Object = 10,
+  /// `FIELD_DEFINITION`
+  FieldDefinition = 11,
+  /// `ARGUMENT_DEFINITION`
+  ArgumentDefinition = 12,
+  /// `INTERFACE`
+  Interface = 13,
+  /// `UNION`
+  Union = 14,
+  /// `ENUM`
+  Enum = 15,
+  /// `ENUM_VALUE`
+  EnumValue = 16,
+  /// `INPUT_OBJECT`
+  InputObject = 17,
+  /// `INPUT_FIELD_DEFINITION`
+  InputFieldDefinition = 18,
+}
+
+impl DirectiveLocation {
+  /// Every location, in grammar order.
+  ///
+  /// Iterating this is how a test enumerates the space rather than restating it.
+  pub const ALL: [Self; 19] = [
+    Self::Query,
+    Self::Mutation,
+    Self::Subscription,
+    Self::Field,
+    Self::FragmentDefinition,
+    Self::FragmentSpread,
+    Self::InlineFragment,
+    Self::VariableDefinition,
+    Self::Schema,
+    Self::Scalar,
+    Self::Object,
+    Self::FieldDefinition,
+    Self::ArgumentDefinition,
+    Self::Interface,
+    Self::Union,
+    Self::Enum,
+    Self::EnumValue,
+    Self::InputObject,
+    Self::InputFieldDefinition,
+  ];
+
+  /// Returns the location's bit position in a [`DirectiveLocations`] mask.
+  #[inline]
+  pub const fn bit(&self) -> u32 {
+    *self as u8 as u32
+  }
+
+  /// Returns the location's canonical GraphQL spelling.
+  #[inline]
+  pub const fn as_str(&self) -> &'static str {
+    match self {
+      Self::Query => "QUERY",
+      Self::Mutation => "MUTATION",
+      Self::Subscription => "SUBSCRIPTION",
+      Self::Field => "FIELD",
+      Self::FragmentDefinition => "FRAGMENT_DEFINITION",
+      Self::FragmentSpread => "FRAGMENT_SPREAD",
+      Self::InlineFragment => "INLINE_FRAGMENT",
+      Self::VariableDefinition => "VARIABLE_DEFINITION",
+      Self::Schema => "SCHEMA",
+      Self::Scalar => "SCALAR",
+      Self::Object => "OBJECT",
+      Self::FieldDefinition => "FIELD_DEFINITION",
+      Self::ArgumentDefinition => "ARGUMENT_DEFINITION",
+      Self::Interface => "INTERFACE",
+      Self::Union => "UNION",
+      Self::Enum => "ENUM",
+      Self::EnumValue => "ENUM_VALUE",
+      Self::InputObject => "INPUT_OBJECT",
+      Self::InputFieldDefinition => "INPUT_FIELD_DEFINITION",
+    }
+  }
+
+  /// Resolves a location from its canonical spelling.
+  ///
+  /// This is the seam the dialect side crosses: the parser's own location enums render through
+  /// `as_str`, so the mapping needs no dependency in either direction.
+  pub fn from_name(name: &str) -> Option<Self> {
+    Some(match name {
+      "QUERY" => Self::Query,
+      "MUTATION" => Self::Mutation,
+      "SUBSCRIPTION" => Self::Subscription,
+      "FIELD" => Self::Field,
+      "FRAGMENT_DEFINITION" => Self::FragmentDefinition,
+      "FRAGMENT_SPREAD" => Self::FragmentSpread,
+      "INLINE_FRAGMENT" => Self::InlineFragment,
+      "VARIABLE_DEFINITION" => Self::VariableDefinition,
+      "SCHEMA" => Self::Schema,
+      "SCALAR" => Self::Scalar,
+      "OBJECT" => Self::Object,
+      "FIELD_DEFINITION" => Self::FieldDefinition,
+      "ARGUMENT_DEFINITION" => Self::ArgumentDefinition,
+      "INTERFACE" => Self::Interface,
+      "UNION" => Self::Union,
+      "ENUM" => Self::Enum,
+      "ENUM_VALUE" => Self::EnumValue,
+      "INPUT_OBJECT" => Self::InputObject,
+      "INPUT_FIELD_DEFINITION" => Self::InputFieldDefinition,
+      _ => return None,
+    })
+  }
+}
+
+impl core::fmt::Display for DirectiveLocation {
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+/// A set of directive locations, as a bitmask over [`DirectiveLocation`] discriminants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub struct DirectiveLocations(u32);
+
+impl DirectiveLocations {
+  /// The empty set.
+  pub const EMPTY: Self = Self(0);
+
+  /// Creates a set from a raw mask.
+  #[inline]
+  pub const fn from_bits(bits: u32) -> Self {
+    Self(bits)
+  }
+
+  /// Returns the raw mask.
+  #[inline]
+  pub const fn bits(&self) -> u32 {
+    self.0
+  }
+
+  /// Returns the set with `location` added.
+  #[inline]
+  pub const fn with(self, location: DirectiveLocation) -> Self {
+    Self(self.0 | (1u32 << location.bit()))
+  }
+
+  /// Adds `location` in place.
+  #[inline]
+  pub const fn insert(&mut self, location: DirectiveLocation) {
+    self.0 |= 1u32 << location.bit();
+  }
+
+  /// Returns whether the set contains `location` — the whole of draft 5.7.2.
+  #[inline]
+  pub const fn contains(&self, location: DirectiveLocation) -> bool {
+    self.0 & (1u32 << location.bit()) != 0
+  }
+
+  /// Returns whether the set is empty.
+  #[inline]
+  pub const fn is_empty(&self) -> bool {
+    self.0 == 0
+  }
+
+  /// Iterates the set's locations in grammar order.
+  pub fn iter(&self) -> impl Iterator<Item = DirectiveLocation> + '_ {
+    DirectiveLocation::ALL
+      .into_iter()
+      .filter(|location| self.contains(*location))
+  }
+}
+
+impl FromIterator<DirectiveLocation> for DirectiveLocations {
+  fn from_iter<T: IntoIterator<Item = DirectiveLocation>>(iter: T) -> Self {
+    iter.into_iter().fold(Self::EMPTY, Self::with)
+  }
+}

--- a/smear/src/validator/schema/repr/mod.rs
+++ b/smear/src/validator/schema/repr/mod.rs
@@ -1,0 +1,368 @@
+//! The schema representation: interned names, flat tables, packed type references and
+//! possible-object bitsets.
+//!
+//! # This module is deliberately dependency-free
+//!
+//! Nothing here names anything outside `core` and `alloc`. Not the parser, not `tokora`, not the
+//! rest of `smear` — no `crate::` path appears in any file of this directory. That is not tidiness,
+//! it is the load-bearing property the design rests on, and it is checked rather than asserted:
+//! the `smear-noatomic` workspace member compiles *these very files* for `thumbv6m-none-eabi`
+//! (Cortex-M0+, no native compare-and-swap) as `#![no_std]` + `alloc` + `#![forbid(unsafe_code)]`
+//! with an empty `[dependencies]` table. If a `use` in this directory ever reaches outside
+//! `core`/`alloc`, that build fails.
+//!
+//! # No `Arc`, no atomics, no interior mutability
+//!
+//! A build-once, read-many value needs no shared-ownership primitive: validation takes
+//! `&Schema`. So the "may not assume `Arc`" constraint is honoured by being vacuous rather than
+//! by a feature tier — on a target with atomics a caller may wrap the schema in
+//! `alloc::sync::Arc`, on one without it in `portable_atomic_util::Arc`, and this crate needs to
+//! know about neither. The corollary the rest of the validator depends on: [`Schema`] is
+//! `Send + Sync` by construction, which is what forbids lazy interning and per-query memoisation
+//! inside it.
+
+mod location;
+mod name;
+mod table;
+mod ty;
+
+pub use location::{DirectiveLocation, DirectiveLocations};
+pub use name::{MAX_SYMBOLS, NameIndex, Range32, Sym, is_name, is_reserved};
+pub use table::{
+  DirectiveDef, FieldDef, InputValueDef, RootOperation, TypeDef, TypeFlags, TypeRef,
+};
+pub use ty::{DefaultKind, MAX_WRAPPERS, PackedType, TypeId, TypeKind};
+
+use std::boxed::Box;
+
+/// The sentinel [`Schema::type_of_sym`] stores for a symbol that names no type.
+const NOT_A_TYPE: u32 = u32::MAX;
+
+/// A built, immutable GraphQL schema.
+///
+/// One owned value with no borrows of the SDL it came from: names are interned into a byte arena,
+/// every child list is a range into a flat table, and schema-side default values are reduced to
+/// [`DefaultKind`]. That is what lets a `Schema` be built from a `TypeSystemDocument<S>` for *any*
+/// source slice type and then outlive it — `'static`-able, `Send + Sync`, and safe to hand across
+/// an FFI boundary without keeping the request buffer alive.
+///
+/// All the cost is in the build. Everything a validation rule would otherwise derive per query is
+/// precomputed here: field lookup tables sorted for binary search, interface implementors as
+/// possible-object bitsets, directive locations as a `u32` mask.
+#[derive(Debug)]
+pub struct Schema {
+  /// Every interned name's bytes, concatenated.
+  pub(crate) strings: Box<[u8]>,
+  /// `Sym` to its `(start, end)` range in [`Schema::strings`].
+  pub(crate) spans: Box<[(u32, u32)]>,
+  /// Name bytes to `Sym`.
+  pub(crate) index: NameIndex,
+  /// Type definitions; a [`TypeId`] indexes this table.
+  pub(crate) types: Box<[TypeDef]>,
+  /// `Sym` to [`TypeId`], dense over the symbol space; [`NOT_A_TYPE`] where the name is not a
+  /// type's.
+  pub(crate) type_of_sym: Box<[u32]>,
+  /// Every field row, grouped by owning type, each group sorted by `Sym`.
+  pub(crate) fields: Box<[FieldDef]>,
+  /// Every input-value row — field arguments, directive arguments and input-object fields —
+  /// grouped by owner, each group sorted by `Sym`.
+  pub(crate) inputs: Box<[InputValueDef]>,
+  /// Interface closures, grouped by implementing type.
+  pub(crate) interfaces: Box<[TypeId]>,
+  /// Union members, grouped by union.
+  pub(crate) members: Box<[TypeId]>,
+  /// Enum value symbols, grouped by enum, each group sorted.
+  pub(crate) enum_values: Box<[Sym]>,
+  /// Concatenated possible-object bitsets, [`Schema::possible_words`] words per composite type.
+  pub(crate) possible: Box<[u64]>,
+  /// How many `u64` words one possible-object bitset occupies.
+  pub(crate) possible_words: u32,
+  /// Object ordinal to [`TypeId`] — the inverse of [`TypeDef::object_ordinal`].
+  pub(crate) objects: Box<[TypeId]>,
+  /// Directive definitions, sorted by `Sym`.
+  pub(crate) directives: Box<[DirectiveDef]>,
+  /// The query, mutation and subscription roots, indexed by [`RootOperation::index`].
+  pub(crate) roots: [Option<TypeId>; 3],
+}
+
+impl Schema {
+  // -- names --------------------------------------------------------------------------------
+
+  /// Returns an interned name's bytes.
+  ///
+  /// # Panics
+  ///
+  /// If `sym` was issued by a different schema and is out of range here. Symbols are only
+  /// meaningful against the schema that produced them.
+  #[inline]
+  pub fn name_bytes(&self, sym: Sym) -> &[u8] {
+    let (start, end) = self.spans[sym.get() as usize];
+    &self.strings[start as usize..end as usize]
+  }
+
+  /// Returns an interned name.
+  ///
+  /// # Panics
+  ///
+  /// As [`Schema::name_bytes`].
+  #[inline]
+  pub fn name(&self, sym: Sym) -> &str {
+    // The arena is ASCII by construction: the builder rejects anything outside
+    // `/[_A-Za-z][_0-9A-Za-z]*/` before it is interned, so the fallback is unreachable.
+    core::str::from_utf8(self.name_bytes(sym)).unwrap_or("")
+  }
+
+  /// Resolves source bytes to their symbol, or `None` when the schema never interned that name.
+  ///
+  /// A miss is the common case on the validation fast path — an undefined field, an undefined
+  /// type — and it costs one hash and one probe.
+  #[inline]
+  pub fn sym(&self, bytes: &[u8]) -> Option<Sym> {
+    let strings = &self.strings;
+    let spans = &self.spans;
+    self.index.get(bytes, |s| {
+      let (start, end) = spans[s as usize];
+      &strings[start as usize..end as usize]
+    })
+  }
+
+  /// Returns how many distinct names the schema interned.
+  #[inline]
+  pub fn symbol_count(&self) -> u32 {
+    self.spans.len() as u32
+  }
+
+  // -- types --------------------------------------------------------------------------------
+
+  /// Returns every type definition, indexed by [`TypeId`].
+  #[inline]
+  pub fn types(&self) -> &[TypeDef] {
+    &self.types
+  }
+
+  /// Returns a type definition by id.
+  #[inline]
+  pub fn type_def(&self, id: TypeId) -> &TypeDef {
+    &self.types[id.get() as usize]
+  }
+
+  /// Resolves a type name's symbol to its id.
+  #[inline]
+  pub fn type_of_sym(&self, sym: Sym) -> Option<TypeId> {
+    let id = *self.type_of_sym.get(sym.get() as usize)?;
+    (id != NOT_A_TYPE).then(|| TypeId::new(id))
+  }
+
+  /// Resolves source bytes to a type id and its row.
+  #[inline]
+  pub fn type_by_name(&self, bytes: &[u8]) -> Option<TypeRef<'_>> {
+    let id = self.type_of_sym(self.sym(bytes)?)?;
+    Some((id, self.type_def(id)))
+  }
+
+  /// Returns the object types, in object-ordinal order.
+  #[inline]
+  pub fn object_types(&self) -> &[TypeId] {
+    &self.objects
+  }
+
+  // -- fields and inputs --------------------------------------------------------------------
+
+  /// Returns a type's field group — empty unless the type is composite.
+  ///
+  /// A union's group holds exactly `__typename`, which is what makes draft 5.3.1's "only
+  /// `__typename` may be selected on a union" fall out of the ordinary field lookup instead of
+  /// needing a rule of its own.
+  #[inline]
+  pub fn fields_of(&self, id: TypeId) -> &[FieldDef] {
+    let def = self.type_def(id);
+    if def.kind().is_composite() {
+      def.fields().slice(&self.fields)
+    } else {
+      &[]
+    }
+  }
+
+  /// Returns an input object's field group — empty unless the type is an input object.
+  #[inline]
+  pub fn input_fields_of(&self, id: TypeId) -> &[InputValueDef] {
+    let def = self.type_def(id);
+    match def.kind() {
+      TypeKind::InputObject => def.fields().slice(&self.inputs),
+      _ => &[],
+    }
+  }
+
+  /// Looks a field up on an object or interface type — binary search over the sym-sorted group.
+  #[inline]
+  pub fn field(&self, id: TypeId, name: Sym) -> Option<&FieldDef> {
+    let group = self.fields_of(id);
+    group
+      .binary_search_by_key(&name.get(), |f| f.name().get())
+      .ok()
+      .map(|i| &group[i])
+  }
+
+  /// Looks an input-object field up — binary search over the sym-sorted group.
+  #[inline]
+  pub fn input_field(&self, id: TypeId, name: Sym) -> Option<&InputValueDef> {
+    let group = self.input_fields_of(id);
+    group
+      .binary_search_by_key(&name.get(), |f| f.name().get())
+      .ok()
+      .map(|i| &group[i])
+  }
+
+  /// Returns an argument group named by a [`FieldDef`] or a [`DirectiveDef`].
+  #[inline]
+  pub fn inputs(&self, args: Range32) -> &[InputValueDef] {
+    args.slice(&self.inputs)
+  }
+
+  /// Looks an argument up in a group — binary search over the sym-sorted group.
+  #[inline]
+  pub fn input(&self, args: Range32, name: Sym) -> Option<&InputValueDef> {
+    let group = self.inputs(args);
+    group
+      .binary_search_by_key(&name.get(), |a| a.name().get())
+      .ok()
+      .map(|i| &group[i])
+  }
+
+  /// Returns an enum's value symbols, sorted.
+  #[inline]
+  pub fn enum_values_of(&self, id: TypeId) -> &[Sym] {
+    self.type_def(id).enum_values().slice(&self.enum_values)
+  }
+
+  /// Returns whether an enum defines a value — binary search over the sorted group.
+  #[inline]
+  pub fn has_enum_value(&self, id: TypeId, value: Sym) -> bool {
+    self
+      .enum_values_of(id)
+      .binary_search_by_key(&value.get(), Sym::get)
+      .is_ok()
+  }
+
+  /// Returns a type's interface closure.
+  ///
+  /// Draft §3.7 requires every transitively implemented interface to be declared, so in any
+  /// schema that builds this is also the declared set.
+  #[inline]
+  pub fn interfaces_of(&self, id: TypeId) -> &[TypeId] {
+    self.type_def(id).interfaces().slice(&self.interfaces)
+  }
+
+  /// Returns a union's member types.
+  #[inline]
+  pub fn members_of(&self, id: TypeId) -> &[TypeId] {
+    self.type_def(id).members().slice(&self.members)
+  }
+
+  // -- directives ---------------------------------------------------------------------------
+
+  /// Returns every directive definition, sorted by name symbol.
+  #[inline]
+  pub fn directives(&self) -> &[DirectiveDef] {
+    &self.directives
+  }
+
+  /// Looks a directive definition up by name symbol.
+  #[inline]
+  pub fn directive(&self, name: Sym) -> Option<&DirectiveDef> {
+    self
+      .directives
+      .binary_search_by_key(&name.get(), |d| d.name().get())
+      .ok()
+      .map(|i| &self.directives[i])
+  }
+
+  /// Looks a directive definition up by source bytes.
+  #[inline]
+  pub fn directive_by_name(&self, bytes: &[u8]) -> Option<&DirectiveDef> {
+    self.directive(self.sym(bytes)?)
+  }
+
+  // -- roots --------------------------------------------------------------------------------
+
+  /// Returns a root operation type, or `None` when the schema does not define one.
+  ///
+  /// A `None` query root cannot occur: draft §3.3 requires it and the build refuses without it.
+  #[inline]
+  pub fn root(&self, operation: RootOperation) -> Option<TypeId> {
+    self.roots[operation.index()]
+  }
+
+  // -- possible-object bitsets --------------------------------------------------------------
+
+  /// Returns how many `u64` words one possible-object bitset occupies.
+  #[inline]
+  pub fn possible_words(&self) -> u32 {
+    self.possible_words
+  }
+
+  /// Returns a composite type's possible-object bitset, or `None` for a non-composite type.
+  ///
+  /// The bit at index `n` is set when the object type with ordinal `n` is a possible runtime type
+  /// of this one: an object's set is a singleton, an interface's is its implementors (transitive),
+  /// and a union's is its members.
+  #[inline]
+  pub fn possible_objects(&self, id: TypeId) -> Option<&[u64]> {
+    let start = self.type_def(id).possible_start();
+    if start == TypeDef::NONE {
+      return None;
+    }
+    let start = start as usize;
+    let end = start + self.possible_words as usize;
+    self.possible.get(start..end)
+  }
+
+  /// Returns whether two composite types share a possible object type.
+  ///
+  /// This one word-`AND` per 64 object types is the whole of draft 5.5.2.3 — all four of its
+  /// subsections — and it also serves 5.3.2's abstract/concrete parent split.
+  #[inline]
+  pub fn possible_objects_intersect(&self, a: TypeId, b: TypeId) -> bool {
+    match (self.possible_objects(a), self.possible_objects(b)) {
+      (Some(a), Some(b)) => a.iter().zip(b.iter()).any(|(x, y)| x & y != 0),
+      _ => false,
+    }
+  }
+
+  /// Iterates a composite type's possible object types, in ordinal order.
+  pub fn possible_object_ids(&self, id: TypeId) -> impl Iterator<Item = TypeId> + '_ {
+    let words = self.possible_objects(id).unwrap_or(&[]);
+    words.iter().enumerate().flat_map(move |(word, bits)| {
+      (0..64u32)
+        .filter(move |bit| bits & (1u64 << bit) != 0)
+        .map(move |bit| self.objects[(word as u32 * 64 + bit) as usize])
+    })
+  }
+
+  /// Returns whether `object` is a possible runtime type of the composite type `id`.
+  #[inline]
+  pub fn is_possible_object(&self, id: TypeId, object: TypeId) -> bool {
+    let ordinal = self.type_def(object).object_ordinal();
+    if ordinal == TypeDef::NONE {
+      return false;
+    }
+    match self.possible_objects(id) {
+      Some(words) => {
+        let word = (ordinal / 64) as usize;
+        words
+          .get(word)
+          .is_some_and(|bits| bits & (1u64 << (ordinal % 64)) != 0)
+      }
+      None => false,
+    }
+  }
+}
+
+// The three static facts the whole design rests on, checked by the compiler rather than argued.
+// A `Cell`, an `Rc` or a raw pointer anywhere in the tables would fail this.
+const _: () = {
+  const fn assert_send_sync<T: Send + Sync>() {}
+  let _ = assert_send_sync::<Schema>;
+  let _ = assert_send_sync::<TypeDef>;
+  let _ = assert_send_sync::<PackedType>;
+};

--- a/smear/src/validator/schema/repr/name.rs
+++ b/smear/src/validator/schema/repr/name.rs
@@ -1,0 +1,205 @@
+//! Interned names: the symbol type and the build-once name index.
+//!
+//! GraphQL names are ASCII by grammar (`/[_A-Za-z][_0-9A-Za-z]*/`), so the interner is byte-keyed
+//! and serves `&str` and `&[u8]` documents alike — one arena, one index, whatever the document's
+//! source slice type was.
+
+use std::{boxed::Box, vec};
+
+/// An interned name.
+///
+/// A `Sym` is an index into the owning [`Schema`]'s name tables and is **meaningless without
+/// it** — two schemas assign symbols independently, and a symbol from one is not a symbol in the
+/// other. Every API that returns a `Sym` documents the schema it belongs to.
+///
+/// [`Schema`]: super::Schema
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Sym(u32);
+
+impl Sym {
+  /// Creates a symbol from its raw index.
+  ///
+  /// Callers are responsible for the index belonging to the schema it will be used against; see
+  /// the type-level note.
+  #[inline]
+  pub const fn new(index: u32) -> Self {
+    Self(index)
+  }
+
+  /// Returns the raw index.
+  #[inline]
+  pub const fn get(&self) -> u32 {
+    self.0
+  }
+}
+
+/// A half-open `[start, end)` range into one of the schema's flat tables.
+///
+/// The tables are grouped rather than nested — every field group, argument group, enum-value group
+/// and interface group is a contiguous run of one `Box<[T]>` — so a "child list" is two `u32`s and
+/// no pointer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Range32 {
+  start: u32,
+  end: u32,
+}
+
+impl Range32 {
+  /// The empty range at offset zero.
+  pub const EMPTY: Self = Self { start: 0, end: 0 };
+
+  /// Creates a range from its endpoints.
+  #[inline]
+  pub const fn new(start: u32, end: u32) -> Self {
+    Self { start, end }
+  }
+
+  /// Returns the inclusive start offset.
+  #[inline]
+  pub const fn start(&self) -> u32 {
+    self.start
+  }
+
+  /// Returns the exclusive end offset.
+  #[inline]
+  pub const fn end(&self) -> u32 {
+    self.end
+  }
+
+  /// Returns how many rows the range covers.
+  #[inline]
+  pub const fn len(&self) -> u32 {
+    self.end.saturating_sub(self.start)
+  }
+
+  /// Returns whether the range covers no rows.
+  #[inline]
+  pub const fn is_empty(&self) -> bool {
+    self.end <= self.start
+  }
+
+  /// Borrows the range's rows out of a table.
+  #[inline]
+  pub fn slice<'a, T>(&self, table: &'a [T]) -> &'a [T] {
+    let start = (self.start as usize).min(table.len());
+    let end = (self.end as usize).clamp(start, table.len());
+    &table[start..end]
+  }
+}
+
+/// The largest symbol count [`NameIndex::build`] can index.
+///
+/// The index is a power-of-two open-addressing table at load factor 1/2, so it needs
+/// `2 * next_power_of_two(count)` slots; this cap is what keeps that product inside `u32`.
+pub const MAX_SYMBOLS: u32 = 1 << 30;
+
+/// FxHash-style multiply-fold over short ASCII keys.
+///
+/// Names are identifiers — a handful of bytes each — so an 8-byte-at-a-time fold with one
+/// multiply is all the mixing the index needs, and it costs no dependency.
+#[inline]
+fn hash_bytes(bytes: &[u8]) -> u64 {
+  const K: u64 = 0x517c_c1b7_2722_0a95;
+  let mut h: u64 = 0;
+  let (chunks, rest) = bytes.as_chunks::<8>();
+  for c in chunks {
+    let v = u64::from_le_bytes(*c);
+    h = (h.rotate_left(5) ^ v).wrapping_mul(K);
+  }
+  let mut tail = [0u8; 8];
+  tail[..rest.len()].copy_from_slice(rest);
+  let v = u64::from_le_bytes(tail) ^ ((rest.len() as u64) << 56);
+  (h.rotate_left(5) ^ v).wrapping_mul(K)
+}
+
+/// Open-addressing name index: name bytes to [`Sym`].
+///
+/// Power-of-two capacity, linear probing, `u32::MAX` for an empty slot. Built once from the
+/// finished arena and probed read-only thereafter — which is what lets the whole schema be shared
+/// as `&Schema` with no interior mutability anywhere.
+///
+/// The index stores symbol numbers, not keys: a probe resolves each candidate back through the
+/// arena, so there is exactly one copy of every name in the whole structure.
+#[derive(Debug, Clone)]
+pub struct NameIndex {
+  mask: u32,
+  slots: Box<[u32]>,
+}
+
+impl NameIndex {
+  /// Builds an index over symbols `0..count`, resolving each to its bytes through `resolve`.
+  ///
+  /// Returns `None` when `count` exceeds [`MAX_SYMBOLS`].
+  pub fn build<'a>(count: u32, resolve: impl Fn(u32) -> &'a [u8]) -> Option<Self> {
+    if count > MAX_SYMBOLS {
+      return None;
+    }
+    let cap = count.checked_next_power_of_two()?.checked_mul(2)?.max(8);
+    let mask = cap - 1;
+    let mut slots = vec![u32::MAX; cap as usize].into_boxed_slice();
+    for sym in 0..count {
+      let mut i = (hash_bytes(resolve(sym)) as u32) & mask;
+      while slots[i as usize] != u32::MAX {
+        i = (i + 1) & mask;
+      }
+      slots[i as usize] = sym;
+    }
+    Some(Self { mask, slots })
+  }
+
+  /// Looks a name up by its bytes.
+  #[inline]
+  pub fn get<'a>(&self, bytes: &[u8], resolve: impl Fn(u32) -> &'a [u8]) -> Option<Sym> {
+    let mut i = (hash_bytes(bytes) as u32) & self.mask;
+    loop {
+      let s = self.slots[i as usize];
+      if s == u32::MAX {
+        return None;
+      }
+      if resolve(s) == bytes {
+        return Some(Sym(s));
+      }
+      i = (i + 1) & self.mask;
+    }
+  }
+
+  /// Returns how many probe slots the index holds.
+  ///
+  /// Exposed so a test can pin the load factor rather than infer it.
+  #[inline]
+  pub fn capacity(&self) -> usize {
+    self.slots.len()
+  }
+}
+
+/// Returns whether `bytes` spells a GraphQL `Name`.
+///
+/// This is the arena's admission rule. It is what makes every interned name ASCII, and therefore
+/// what makes [`Schema::name`] infallible.
+///
+/// [`Schema::name`]: super::Schema::name
+#[inline]
+pub const fn is_name(bytes: &[u8]) -> bool {
+  if bytes.is_empty() {
+    return false;
+  }
+  let first = bytes[0];
+  if !(first == b'_' || first.is_ascii_alphabetic()) {
+    return false;
+  }
+  let mut i = 1;
+  while i < bytes.len() {
+    let b = bytes[i];
+    if !(b == b'_' || b.is_ascii_alphanumeric()) {
+      return false;
+    }
+    i += 1;
+  }
+  true
+}
+
+/// Returns whether `bytes` is a reserved (introspection) name — one starting with `__`.
+#[inline]
+pub const fn is_reserved(bytes: &[u8]) -> bool {
+  bytes.len() >= 2 && bytes[0] == b'_' && bytes[1] == b'_'
+}

--- a/smear/src/validator/schema/repr/table.rs
+++ b/smear/src/validator/schema/repr/table.rs
@@ -1,0 +1,352 @@
+//! The flat table rows: type definitions, fields, input values and directive definitions.
+//!
+//! Every row is `Copy` and every "child list" is a [`Range32`] into a sibling table, so the whole
+//! schema is a handful of `Box<[T]>`s with no interior pointers and no per-node allocation.
+
+use super::{
+  location::DirectiveLocations,
+  name::{Range32, Sym},
+  ty::{DefaultKind, PackedType, TypeId, TypeKind},
+};
+
+/// Per-type flags that do not deserve a field of their own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub struct TypeFlags(u8);
+
+impl TypeFlags {
+  /// No flags.
+  pub const EMPTY: Self = Self(0);
+  /// The type carries `@oneOf` (draft §3.10).
+  pub const ONE_OF: Self = Self(1 << 0);
+  /// The type is part of the built-in or introspection meta-schema rather than the user's SDL.
+  pub const BUILT_IN: Self = Self(1 << 1);
+
+  /// Returns the union of two flag sets.
+  #[inline]
+  pub const fn union(self, other: Self) -> Self {
+    Self(self.0 | other.0)
+  }
+
+  /// Returns whether every flag in `other` is set.
+  #[inline]
+  pub const fn contains(self, other: Self) -> bool {
+    self.0 & other.0 == other.0
+  }
+
+  /// Returns the raw bits.
+  #[inline]
+  pub const fn bits(self) -> u8 {
+    self.0
+  }
+}
+
+/// A named type definition.
+///
+/// Which table `fields` indexes depends on `kind`: object and interface types index the schema's
+/// field table, input object types index its input-value table, and every other kind leaves it
+/// empty. [`Schema::fields_of`] and [`Schema::input_fields_of`] are the accessors that keep the
+/// distinction from leaking.
+///
+/// [`Schema::fields_of`]: super::Schema::fields_of
+/// [`Schema::input_fields_of`]: super::Schema::input_fields_of
+#[derive(Debug, Clone, Copy)]
+pub struct TypeDef {
+  name: Sym,
+  kind: TypeKind,
+  flags: TypeFlags,
+  fields: Range32,
+  interfaces: Range32,
+  members: Range32,
+  enum_values: Range32,
+  possible_start: u32,
+  object_ordinal: u32,
+}
+
+impl TypeDef {
+  /// The sentinel `possible_start` / `object_ordinal` for "not applicable".
+  pub const NONE: u32 = u32::MAX;
+
+  /// Assembles a row. Ranges are relative to the schema tables the row will live in.
+  #[allow(clippy::too_many_arguments)]
+  #[inline]
+  pub const fn new(
+    name: Sym,
+    kind: TypeKind,
+    flags: TypeFlags,
+    fields: Range32,
+    interfaces: Range32,
+    members: Range32,
+    enum_values: Range32,
+    possible_start: u32,
+    object_ordinal: u32,
+  ) -> Self {
+    Self {
+      name,
+      kind,
+      flags,
+      fields,
+      interfaces,
+      members,
+      enum_values,
+      possible_start,
+      object_ordinal,
+    }
+  }
+
+  /// Returns the type's interned name.
+  #[inline]
+  pub const fn name(&self) -> Sym {
+    self.name
+  }
+
+  /// Returns the type's kind.
+  #[inline]
+  pub const fn kind(&self) -> TypeKind {
+    self.kind
+  }
+
+  /// Returns the type's flags.
+  #[inline]
+  pub const fn flags(&self) -> TypeFlags {
+    self.flags
+  }
+
+  /// Returns whether the type carries `@oneOf`.
+  #[inline]
+  pub const fn is_one_of(&self) -> bool {
+    self.flags.contains(TypeFlags::ONE_OF)
+  }
+
+  /// Returns whether the type belongs to the injected meta-schema rather than the user's SDL.
+  #[inline]
+  pub const fn is_built_in(&self) -> bool {
+    self.flags.contains(TypeFlags::BUILT_IN)
+  }
+
+  /// Returns the row's field range — into the field table for objects and interfaces, into the
+  /// input-value table for input objects.
+  #[inline]
+  pub const fn fields(&self) -> Range32 {
+    self.fields
+  }
+
+  /// Returns the row's interface range, into the interface table.
+  #[inline]
+  pub const fn interfaces(&self) -> Range32 {
+    self.interfaces
+  }
+
+  /// Returns the row's union-member range, into the member table.
+  #[inline]
+  pub const fn members(&self) -> Range32 {
+    self.members
+  }
+
+  /// Returns the row's enum-value range, into the enum-value table.
+  #[inline]
+  pub const fn enum_values(&self) -> Range32 {
+    self.enum_values
+  }
+
+  /// Returns the offset of the type's possible-object bitset, or [`TypeDef::NONE`] for a
+  /// non-composite type.
+  #[inline]
+  pub const fn possible_start(&self) -> u32 {
+    self.possible_start
+  }
+
+  /// Returns the type's object ordinal — its bit position in every possible-object bitset — or
+  /// [`TypeDef::NONE`] when the type is not an object.
+  #[inline]
+  pub const fn object_ordinal(&self) -> u32 {
+    self.object_ordinal
+  }
+}
+
+/// A field definition on an object or interface type.
+#[derive(Debug, Clone, Copy)]
+pub struct FieldDef {
+  name: Sym,
+  ty: PackedType,
+  args: Range32,
+}
+
+impl FieldDef {
+  /// Assembles a field row.
+  #[inline]
+  pub const fn new(name: Sym, ty: PackedType, args: Range32) -> Self {
+    Self { name, ty, args }
+  }
+
+  /// Returns the field's interned name.
+  #[inline]
+  pub const fn name(&self) -> Sym {
+    self.name
+  }
+
+  /// Returns the field's result type.
+  #[inline]
+  pub const fn ty(&self) -> PackedType {
+    self.ty
+  }
+
+  /// Returns the field's argument range, into the input-value table.
+  #[inline]
+  pub const fn args(&self) -> Range32 {
+    self.args
+  }
+}
+
+/// An input value definition: a field argument, a directive argument, or an input-object field.
+#[derive(Debug, Clone, Copy)]
+pub struct InputValueDef {
+  name: Sym,
+  ty: PackedType,
+  default: DefaultKind,
+}
+
+impl InputValueDef {
+  /// Assembles an input-value row.
+  #[inline]
+  pub const fn new(name: Sym, ty: PackedType, default: DefaultKind) -> Self {
+    Self { name, ty, default }
+  }
+
+  /// Returns the input value's interned name.
+  #[inline]
+  pub const fn name(&self) -> Sym {
+    self.name
+  }
+
+  /// Returns the input value's declared type.
+  #[inline]
+  pub const fn ty(&self) -> PackedType {
+    self.ty
+  }
+
+  /// Returns the presence and null-ness of the declared default.
+  #[inline]
+  pub const fn default_kind(&self) -> DefaultKind {
+    self.default
+  }
+
+  /// Returns whether the input value must be supplied — non-null type and no default
+  /// (draft 5.4.3, 5.6.4).
+  #[inline]
+  pub const fn is_required(&self) -> bool {
+    self.ty.is_non_null() && !self.default.is_present()
+  }
+}
+
+/// A directive definition.
+#[derive(Debug, Clone, Copy)]
+pub struct DirectiveDef {
+  name: Sym,
+  locations: DirectiveLocations,
+  args: Range32,
+  repeatable: bool,
+  built_in: bool,
+}
+
+impl DirectiveDef {
+  /// Assembles a directive row.
+  #[inline]
+  pub const fn new(
+    name: Sym,
+    locations: DirectiveLocations,
+    args: Range32,
+    repeatable: bool,
+    built_in: bool,
+  ) -> Self {
+    Self {
+      name,
+      locations,
+      args,
+      repeatable,
+      built_in,
+    }
+  }
+
+  /// Returns the directive's interned name, without the `@`.
+  #[inline]
+  pub const fn name(&self) -> Sym {
+    self.name
+  }
+
+  /// Returns the locations the directive is valid at.
+  #[inline]
+  pub const fn locations(&self) -> DirectiveLocations {
+    self.locations
+  }
+
+  /// Returns the directive's argument range, into the input-value table.
+  #[inline]
+  pub const fn args(&self) -> Range32 {
+    self.args
+  }
+
+  /// Returns whether the directive may appear more than once at one location.
+  #[inline]
+  pub const fn is_repeatable(&self) -> bool {
+    self.repeatable
+  }
+
+  /// Returns whether the directive is one of the five the specification defines.
+  #[inline]
+  pub const fn is_built_in(&self) -> bool {
+    self.built_in
+  }
+}
+
+/// The three root operation slots, in the order [`RootOperation::ALL`] enumerates them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u8)]
+pub enum RootOperation {
+  /// The `query` root.
+  Query = 0,
+  /// The `mutation` root.
+  Mutation = 1,
+  /// The `subscription` root.
+  Subscription = 2,
+}
+
+impl RootOperation {
+  /// Every root operation, in slot order.
+  pub const ALL: [Self; 3] = [Self::Query, Self::Mutation, Self::Subscription];
+
+  /// Returns the operation's slot index in the schema's `roots` array.
+  #[inline]
+  pub const fn index(&self) -> usize {
+    *self as u8 as usize
+  }
+
+  /// Returns the operation keyword.
+  #[inline]
+  pub const fn as_str(&self) -> &'static str {
+    match self {
+      Self::Query => "query",
+      Self::Mutation => "mutation",
+      Self::Subscription => "subscription",
+    }
+  }
+
+  /// Returns the type name GraphQL defaults the root to when no `schema` definition names one.
+  #[inline]
+  pub const fn default_type_name(&self) -> &'static str {
+    match self {
+      Self::Query => "Query",
+      Self::Mutation => "Mutation",
+      Self::Subscription => "Subscription",
+    }
+  }
+}
+
+impl core::fmt::Display for RootOperation {
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+/// A type-definition row plus its id, used by lookups that return both.
+pub type TypeRef<'a> = (TypeId, &'a TypeDef);

--- a/smear/src/validator/schema/repr/ty.rs
+++ b/smear/src/validator/schema/repr/ty.rs
@@ -1,0 +1,328 @@
+//! Type identity, type kinds, packed type references, and the reduced schema-side default.
+
+use super::name::Sym;
+
+/// An index into the schema's type table.
+///
+/// Like [`Sym`], a `TypeId` belongs to the schema that issued it and to no other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TypeId(u32);
+
+impl TypeId {
+  /// Creates a type id from its raw index.
+  #[inline]
+  pub const fn new(index: u32) -> Self {
+    Self(index)
+  }
+
+  /// Returns the raw index.
+  #[inline]
+  pub const fn get(&self) -> u32 {
+    self.0
+  }
+}
+
+/// One of GraphQL's six named type kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TypeKind {
+  /// A scalar type, built-in or custom.
+  Scalar,
+  /// An object type.
+  Object,
+  /// An interface type.
+  Interface,
+  /// A union type.
+  Union,
+  /// An enum type.
+  Enum,
+  /// An input object type.
+  InputObject,
+}
+
+impl TypeKind {
+  /// Returns whether the kind is composite — object, interface or union.
+  ///
+  /// Composite types are the ones a selection set may be written against, and the ones that carry
+  /// a possible-object bitset.
+  #[inline]
+  pub const fn is_composite(&self) -> bool {
+    matches!(self, Self::Object | Self::Interface | Self::Union)
+  }
+
+  /// Returns whether the kind is abstract — interface or union.
+  #[inline]
+  pub const fn is_abstract(&self) -> bool {
+    matches!(self, Self::Interface | Self::Union)
+  }
+
+  /// Returns whether the kind is a leaf — scalar or enum.
+  #[inline]
+  pub const fn is_leaf(&self) -> bool {
+    matches!(self, Self::Scalar | Self::Enum)
+  }
+
+  /// Returns whether a value of this kind may appear as a field's result type
+  /// (`IsOutputType`, draft §3.4).
+  #[inline]
+  pub const fn is_output(&self) -> bool {
+    !matches!(self, Self::InputObject)
+  }
+
+  /// Returns whether a value of this kind may appear as an argument or input-field type
+  /// (`IsInputType`, draft §3.4).
+  #[inline]
+  pub const fn is_input(&self) -> bool {
+    matches!(self, Self::Scalar | Self::Enum | Self::InputObject)
+  }
+
+  /// Returns the introspection spelling of the kind (`__TypeKind`).
+  #[inline]
+  pub const fn as_str(&self) -> &'static str {
+    match self {
+      Self::Scalar => "SCALAR",
+      Self::Object => "OBJECT",
+      Self::Interface => "INTERFACE",
+      Self::Union => "UNION",
+      Self::Enum => "ENUM",
+      Self::InputObject => "INPUT_OBJECT",
+    }
+  }
+}
+
+impl core::fmt::Display for TypeKind {
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+/// The presence and null-ness of a schema-side default value.
+///
+/// Executable-document validation never needs a default's *content* — only whether one exists and
+/// whether it is `null` (draft 5.4.3, 5.6.4, 5.8.5). Content is checked once, at build, against
+/// the declared type; coercing an actual runtime value is execution's job. Reducing the default to
+/// two bits is what keeps the schema source-independent: there is no borrowed literal left to
+/// keep the SDL alive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[repr(u8)]
+pub enum DefaultKind {
+  /// No `= value` clause at all.
+  #[default]
+  Absent = 0,
+  /// `= null`.
+  Null = 1,
+  /// `= <anything other than null>`.
+  NonNull = 2,
+}
+
+impl DefaultKind {
+  /// Returns whether a default value was written.
+  #[inline]
+  pub const fn is_present(&self) -> bool {
+    !matches!(self, Self::Absent)
+  }
+
+  /// Returns the reduction's spelling, for diagnostics.
+  #[inline]
+  pub const fn as_str(&self) -> &'static str {
+    match self {
+      Self::Absent => "absent",
+      Self::Null => "null",
+      Self::NonNull => "non-null",
+    }
+  }
+}
+
+impl core::fmt::Display for DefaultKind {
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    f.write_str(self.as_str())
+  }
+}
+
+/// The 2-bit wrapper code for `!`.
+const NON_NULL: u32 = 0b01;
+/// The 2-bit wrapper code for `[…]`.
+const LIST: u32 = 0b10;
+
+/// How many list/non-null wrappers a [`PackedType`] can carry.
+///
+/// Fifteen 2-bit codes fill 30 bits of the wrapper word. No real schema comes close; the builder
+/// rejects a deeper reference rather than truncating it.
+pub const MAX_WRAPPERS: u32 = 15;
+
+/// A resolved type reference, flattened into three words.
+///
+/// The base type is stored twice over — once as the interned name and once as the resolved id — so
+/// a diagnostic can render the reference without a table walk while a rule compares it with an
+/// integer. `wrappers` packs the list and non-null modifiers as 2-bit codes **innermost first**,
+/// terminated by the first zero pair, so `[[Int!]]!` is `NonNull, List, NonNull, List` reading
+/// outward from `Int`.
+///
+/// Draft 5.8.5's `AreTypesCompatible` and 5.3.2's shape comparison become integer walks over this
+/// word: no pointer chasing, no allocation, and equality of two references is `==`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PackedType {
+  base: Sym,
+  base_id: TypeId,
+  wrappers: u32,
+}
+
+impl PackedType {
+  /// Creates a bare reference to a named type, with no wrappers.
+  #[inline]
+  pub const fn named(base: Sym, base_id: TypeId) -> Self {
+    Self {
+      base,
+      base_id,
+      wrappers: 0,
+    }
+  }
+
+  /// Creates a reference from a base type and a prebuilt wrapper word.
+  ///
+  /// The word must be well-formed: 2-bit codes `0b01`/`0b10` packed from the low end with no gaps.
+  /// [`PackedType::push_list`] and [`PackedType::push_non_null`] are the checked way to build one.
+  #[inline]
+  pub const fn from_parts(base: Sym, base_id: TypeId, wrappers: u32) -> Self {
+    Self {
+      base,
+      base_id,
+      wrappers,
+    }
+  }
+
+  /// Returns the interned name of the innermost named type.
+  #[inline]
+  pub const fn base(&self) -> Sym {
+    self.base
+  }
+
+  /// Returns the resolved id of the innermost named type.
+  #[inline]
+  pub const fn base_id(&self) -> TypeId {
+    self.base_id
+  }
+
+  /// Returns the raw wrapper word.
+  #[inline]
+  pub const fn wrappers(&self) -> u32 {
+    self.wrappers
+  }
+
+  /// Returns how many wrappers the reference carries.
+  #[inline]
+  pub const fn depth(&self) -> u32 {
+    if self.wrappers == 0 {
+      0
+    } else {
+      // Every occupied slot holds `0b01` or `0b10`, never `0b00`, so the highest set bit locates
+      // the outermost wrapper exactly.
+      (31 - self.wrappers.leading_zeros()) / 2 + 1
+    }
+  }
+
+  /// Wraps the reference in a list, returning `None` past [`MAX_WRAPPERS`].
+  #[inline]
+  pub const fn push_list(self) -> Option<Self> {
+    self.push(LIST)
+  }
+
+  /// Marks the reference non-null, returning `None` past [`MAX_WRAPPERS`].
+  #[inline]
+  pub const fn push_non_null(self) -> Option<Self> {
+    self.push(NON_NULL)
+  }
+
+  #[inline]
+  const fn push(self, code: u32) -> Option<Self> {
+    let depth = self.depth();
+    if depth >= MAX_WRAPPERS {
+      return None;
+    }
+    Some(Self {
+      base: self.base,
+      base_id: self.base_id,
+      wrappers: self.wrappers | (code << (2 * depth)),
+    })
+  }
+
+  /// Returns whether the reference is non-null at its outermost level.
+  #[inline]
+  pub const fn is_non_null(&self) -> bool {
+    let depth = self.depth();
+    depth != 0 && (self.wrappers >> (2 * (depth - 1))) & 0b11 == NON_NULL
+  }
+
+  /// Returns whether the reference is a list at its outermost level.
+  #[inline]
+  pub const fn is_list(&self) -> bool {
+    let depth = self.depth();
+    depth != 0 && (self.wrappers >> (2 * (depth - 1))) & 0b11 == LIST
+  }
+
+  /// Returns the reference with its outermost wrapper removed, or `None` when there is none.
+  #[inline]
+  pub const fn strip_outer(&self) -> Option<Self> {
+    let depth = self.depth();
+    if depth == 0 {
+      return None;
+    }
+    Some(Self {
+      base: self.base,
+      base_id: self.base_id,
+      wrappers: self.wrappers & !(0b11 << (2 * (depth - 1))),
+    })
+  }
+
+  /// Returns the nullable form of the reference — itself, unless it is non-null.
+  #[inline]
+  pub const fn nullable(&self) -> Self {
+    if self.is_non_null() {
+      match self.strip_outer() {
+        Some(inner) => inner,
+        // Unreachable: `is_non_null` already established a wrapper exists.
+        None => *self,
+      }
+    } else {
+      *self
+    }
+  }
+
+  /// Returns the item type of a list reference, or `None` when the reference is not a list.
+  ///
+  /// The reference must already be nullable; `[Int]!` is not a list at its outermost level, it is
+  /// a non-null.
+  #[inline]
+  pub const fn list_item(&self) -> Option<Self> {
+    if self.is_list() {
+      self.strip_outer()
+    } else {
+      None
+    }
+  }
+
+  /// Writes the reference's GraphQL spelling, resolving the base name through `name`.
+  pub fn write(&self, f: &mut core::fmt::Formatter<'_>, name: &str) -> core::fmt::Result {
+    let depth = self.depth();
+    // Opening brackets, outermost first.
+    let mut level = depth;
+    while level > 0 {
+      if (self.wrappers >> (2 * (level - 1))) & 0b11 == LIST {
+        f.write_str("[")?;
+      }
+      level -= 1;
+    }
+    f.write_str(name)?;
+    // Closing brackets and bangs, innermost first.
+    let mut level = 0;
+    while level < depth {
+      match (self.wrappers >> (2 * level)) & 0b11 {
+        LIST => f.write_str("]")?,
+        _ => f.write_str("!")?,
+      }
+      level += 1;
+    }
+    Ok(())
+  }
+}

--- a/smear/tests/validator_schema.rs
+++ b/smear/tests/validator_schema.rs
@@ -1,0 +1,1161 @@
+//! `Schema::build`: what it accepts, what it refuses, and the two reductions that would rot
+//! silently if nothing pinned them.
+//!
+//! # The refusal floor is structural
+//!
+//! [`refusal_floor`] iterates `SchemaErrorKind::ALL` and asserts every kind has a schema in
+//! [`FIXTURES`] that makes it fire, with the **exact** set of kinds that schema produces. A kind
+//! added without a fixture fails; a fixture that starts tripping a second rule fails; a rule that
+//! stops firing fails. The alternative — a builder exercised only on good input — is the defect
+//! class this suite exists to close, so the floor is checked rather than reviewed.
+//!
+//! Two kinds are excused, each with a written reason, in [`UNFIREABLE`].
+
+#![allow(missing_docs)]
+
+use smear::{
+  lexer::tokora::{Parse as _, Parser, SimpleSpan},
+  parser::graphql::{
+    GraphQL,
+    ast::{
+      Described, Name, ScalarTypeDefinition, TypeDefinition, TypeSystemDefinition,
+      TypeSystemDefinitionOrExtension, TypeSystemDocument,
+    },
+    error::GraphqlErrors,
+    syntactic::{GraphqlLexer, type_system_document},
+  },
+  validator::schema::{
+    DefaultKind, RootOperation, Schema, SchemaBuilder, SchemaErrorKind, SchemaErrors, TypeKind,
+    builtin,
+  },
+};
+
+// ---------------------------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------------------------
+
+fn parse(sdl: &str) -> TypeSystemDocument<&str> {
+  Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    TypeSystemDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(type_system_document)
+  .parse_str(sdl)
+  .unwrap_or_else(|errors| panic!("fixture SDL does not parse: {errors:?}\n---\n{sdl}"))
+}
+
+fn build(sdl: &str) -> Result<Schema, SchemaErrors> {
+  Schema::build(&parse(sdl))
+}
+
+fn built(sdl: &str) -> Schema {
+  build(sdl).unwrap_or_else(|errors| panic!("expected a schema, got:\n{errors}\n---\n{sdl}"))
+}
+
+fn refused(sdl: &str) -> SchemaErrors {
+  match build(sdl) {
+    Err(errors) => errors,
+    Ok(_) => panic!("expected a refusal, got a schema\n---\n{sdl}"),
+  }
+}
+
+/// A minimal query root, so a fixture's defect is the only thing wrong with it.
+const ROOT: &str = "type Query { ok: Int }\n";
+
+// ---------------------------------------------------------------------------------------------
+// the refusal floor
+// ---------------------------------------------------------------------------------------------
+
+/// Kinds with no fixture, each excused in writing.
+///
+/// An excuse list is how a census stops being one, so both entries name a limit of the
+/// implementation that no document can reach rather than a rule nobody got round to.
+const UNFIREABLE: &[(SchemaErrorKind, &str)] = &[
+  (
+    SchemaErrorKind::InvalidName,
+    "the lexer's identifier rule is the same grammar the arena admits, so no parsed document can \
+     carry a name that fails it. `invalid_name_from_a_hand_built_ast` fires it through the other \
+     door — a hand-assembled AST — because the AST types are public.",
+  ),
+  (
+    SchemaErrorKind::TooManyNames,
+    "the name index addresses 2^30 symbols; a document that interns more would need gigabytes of \
+     distinct identifiers, so the limit is unreachable in a test.",
+  ),
+];
+
+/// Every kind, with a schema that makes it fire and the complete set of kinds that schema
+/// produces.
+///
+/// Pinning the whole set, not just the kind under test, is what keeps a fixture from quietly
+/// becoming a test of two rules at once.
+#[allow(clippy::type_complexity)]
+const FIXTURES: &[(SchemaErrorKind, &str, &[SchemaErrorKind])] = &[
+  // -- §3.3 -----------------------------------------------------------------------------------
+  (
+    SchemaErrorKind::DuplicateTypeName,
+    "type Query { ok: Int } type Dup { a: Int } type Dup { b: Int }",
+    &[SchemaErrorKind::DuplicateTypeName],
+  ),
+  (
+    SchemaErrorKind::DuplicateDirectiveDefinition,
+    "type Query { ok: Int } directive @d on FIELD directive @d on QUERY",
+    &[SchemaErrorKind::DuplicateDirectiveDefinition],
+  ),
+  (
+    SchemaErrorKind::DuplicateSchemaDefinition,
+    "type Query { ok: Int } schema { query: Query } schema { query: Query }",
+    &[SchemaErrorKind::DuplicateSchemaDefinition],
+  ),
+  (
+    SchemaErrorKind::DuplicateRootOperationType,
+    "type Query { ok: Int } type Other { ok: Int } schema { query: Query query: Other }",
+    &[SchemaErrorKind::DuplicateRootOperationType],
+  ),
+  (
+    SchemaErrorKind::UndefinedRootOperationType,
+    "type Query { ok: Int } schema { query: Query mutation: Nope }",
+    &[SchemaErrorKind::UndefinedRootOperationType],
+  ),
+  (
+    SchemaErrorKind::RootOperationTypeNotObject,
+    "interface Root { ok: Int } schema { query: Root }",
+    &[SchemaErrorKind::RootOperationTypeNotObject],
+  ),
+  (
+    SchemaErrorKind::MissingQueryRootOperationType,
+    "type NotTheRoot { ok: Int }",
+    &[SchemaErrorKind::MissingQueryRootOperationType],
+  ),
+  (
+    SchemaErrorKind::UndefinedExtensionTarget,
+    "type Query { ok: Int } extend type Nope { more: Int }",
+    &[SchemaErrorKind::UndefinedExtensionTarget],
+  ),
+  (
+    SchemaErrorKind::ExtensionKindMismatch,
+    "type Query { ok: Int } interface Iface { a: Int } extend type Iface { b: Int }",
+    &[SchemaErrorKind::ExtensionKindMismatch],
+  ),
+  (
+    SchemaErrorKind::RedefinedBuiltInType,
+    "type Query { ok: Int } type __Type { name: String }",
+    &[SchemaErrorKind::RedefinedBuiltInType],
+  ),
+  (
+    SchemaErrorKind::ReservedTypeName,
+    "type Query { ok: Int } type __Mine { a: Int }",
+    &[SchemaErrorKind::ReservedTypeName],
+  ),
+  (
+    SchemaErrorKind::UndefinedType,
+    "type Query { ok: Nope }",
+    &[SchemaErrorKind::UndefinedType],
+  ),
+  (
+    SchemaErrorKind::TypeReferenceTooDeep,
+    "type Query { ok: [[[[[[[[[[[[[[[[Int]]]]]]]]]]]]]]]] }",
+    &[SchemaErrorKind::TypeReferenceTooDeep],
+  ),
+  // -- §3.6 / §3.7 ------------------------------------------------------------------------------
+  (
+    SchemaErrorKind::EmptyFieldsDefinition,
+    "type Query { ok: Int } type Empty",
+    &[SchemaErrorKind::EmptyFieldsDefinition],
+  ),
+  (
+    SchemaErrorKind::DuplicateFieldName,
+    "type Query { ok: Int dup: Int dup: String }",
+    &[SchemaErrorKind::DuplicateFieldName],
+  ),
+  (
+    SchemaErrorKind::ReservedFieldName,
+    "type Query { ok: Int __mine: Int }",
+    &[SchemaErrorKind::ReservedFieldName],
+  ),
+  (
+    SchemaErrorKind::FieldTypeNotOutputType,
+    "type Query { ok: In } input In { a: Int }",
+    &[SchemaErrorKind::FieldTypeNotOutputType],
+  ),
+  (
+    SchemaErrorKind::DuplicateArgumentName,
+    "type Query { ok(a: Int, a: String): Int }",
+    &[SchemaErrorKind::DuplicateArgumentName],
+  ),
+  (
+    SchemaErrorKind::ReservedArgumentName,
+    "type Query { ok(__a: Int): Int }",
+    &[SchemaErrorKind::ReservedArgumentName],
+  ),
+  (
+    SchemaErrorKind::ArgumentTypeNotInputType,
+    "type Query { ok(a: Query): Int }",
+    &[SchemaErrorKind::ArgumentTypeNotInputType],
+  ),
+  (
+    SchemaErrorKind::ImplementsNonInterface,
+    "type Query { ok: Int } type Thing { a: Int } type Other implements Thing { a: Int }",
+    &[SchemaErrorKind::ImplementsNonInterface],
+  ),
+  (
+    SchemaErrorKind::UndefinedImplementsInterface,
+    "type Query { ok: Int } type Other implements Nope { a: Int }",
+    &[SchemaErrorKind::UndefinedImplementsInterface],
+  ),
+  (
+    SchemaErrorKind::DuplicateImplementsInterface,
+    "type Query { ok: Int } interface I { a: Int } type T implements I & I { a: Int }",
+    &[SchemaErrorKind::DuplicateImplementsInterface],
+  ),
+  (
+    SchemaErrorKind::SelfImplementingInterface,
+    "type Query { ok: Int } interface I implements I { a: Int }",
+    &[SchemaErrorKind::SelfImplementingInterface],
+  ),
+  (
+    SchemaErrorKind::MissingTransitiveInterface,
+    "type Query { ok: Int }
+     interface A { a: Int }
+     interface B implements A { a: Int }
+     type T implements B { a: Int }",
+    &[SchemaErrorKind::MissingTransitiveInterface],
+  ),
+  (
+    SchemaErrorKind::MissingInterfaceField,
+    "type Query { ok: Int } interface I { a: Int b: Int } type T implements I { a: Int }",
+    &[SchemaErrorKind::MissingInterfaceField],
+  ),
+  (
+    SchemaErrorKind::InvalidInterfaceFieldType,
+    "type Query { ok: Int } interface I { a: Int } type T implements I { a: String }",
+    &[SchemaErrorKind::InvalidInterfaceFieldType],
+  ),
+  (
+    SchemaErrorKind::MissingInterfaceFieldArgument,
+    "type Query { ok: Int } interface I { a(x: Int): Int } type T implements I { a: Int }",
+    &[SchemaErrorKind::MissingInterfaceFieldArgument],
+  ),
+  (
+    SchemaErrorKind::InvalidInterfaceFieldArgumentType,
+    "type Query { ok: Int }
+     interface I { a(x: Int): Int }
+     type T implements I { a(x: String): Int }",
+    &[SchemaErrorKind::InvalidInterfaceFieldArgumentType],
+  ),
+  (
+    SchemaErrorKind::UnexpectedRequiredArgument,
+    "type Query { ok: Int } interface I { a: Int } type T implements I { a(x: Int!): Int }",
+    &[SchemaErrorKind::UnexpectedRequiredArgument],
+  ),
+  // -- §3.8 -------------------------------------------------------------------------------------
+  (
+    SchemaErrorKind::EmptyUnionMembers,
+    "type Query { ok: Int } union U",
+    &[SchemaErrorKind::EmptyUnionMembers],
+  ),
+  (
+    SchemaErrorKind::UnionMemberNotObject,
+    "type Query { ok: Int } interface I { a: Int } union U = I",
+    &[SchemaErrorKind::UnionMemberNotObject],
+  ),
+  (
+    SchemaErrorKind::UndefinedUnionMember,
+    "type Query { ok: Int } union U = Nope",
+    &[SchemaErrorKind::UndefinedUnionMember],
+  ),
+  (
+    SchemaErrorKind::DuplicateUnionMember,
+    "type Query { ok: Int } type A { a: Int } union U = A | A",
+    &[SchemaErrorKind::DuplicateUnionMember],
+  ),
+  // -- §3.9 -------------------------------------------------------------------------------------
+  (
+    SchemaErrorKind::EmptyEnumValues,
+    "type Query { ok: Int } enum E",
+    &[SchemaErrorKind::EmptyEnumValues],
+  ),
+  (
+    SchemaErrorKind::DuplicateEnumValue,
+    "type Query { ok: Int } enum E { A A }",
+    &[SchemaErrorKind::DuplicateEnumValue],
+  ),
+  (
+    SchemaErrorKind::ReservedEnumValueName,
+    "type Query { ok: Int } enum E { __A }",
+    &[SchemaErrorKind::ReservedEnumValueName],
+  ),
+  // -- §3.10 ------------------------------------------------------------------------------------
+  (
+    SchemaErrorKind::EmptyInputFields,
+    "type Query { ok: Int } input In",
+    &[SchemaErrorKind::EmptyInputFields],
+  ),
+  (
+    SchemaErrorKind::DuplicateInputFieldName,
+    "type Query { ok: Int } input In { a: Int a: String }",
+    &[SchemaErrorKind::DuplicateInputFieldName],
+  ),
+  (
+    SchemaErrorKind::ReservedInputFieldName,
+    "type Query { ok: Int } input In { __a: Int }",
+    &[SchemaErrorKind::ReservedInputFieldName],
+  ),
+  (
+    SchemaErrorKind::InputFieldTypeNotInputType,
+    "type Query { ok: Int } input In { a: Query }",
+    &[SchemaErrorKind::InputFieldTypeNotInputType],
+  ),
+  (
+    SchemaErrorKind::OneOfFieldNotNullable,
+    "type Query { ok: Int } input In @oneOf { a: Int! }",
+    &[SchemaErrorKind::OneOfFieldNotNullable],
+  ),
+  (
+    SchemaErrorKind::OneOfFieldHasDefault,
+    "type Query { ok: Int } input In @oneOf { a: Int = 1 }",
+    &[SchemaErrorKind::OneOfFieldHasDefault],
+  ),
+  (
+    SchemaErrorKind::CircularNonNullInputField,
+    "type Query { ok: Int } input A { b: B! } input B { a: A! }",
+    &[SchemaErrorKind::CircularNonNullInputField],
+  ),
+  // -- §3.13 ------------------------------------------------------------------------------------
+  (
+    SchemaErrorKind::ReservedDirectiveName,
+    "type Query { ok: Int } directive @__mine on FIELD",
+    &[SchemaErrorKind::ReservedDirectiveName],
+  ),
+  (
+    SchemaErrorKind::DuplicateDirectiveArgumentName,
+    "type Query { ok: Int } directive @d(a: Int, a: String) on FIELD",
+    &[SchemaErrorKind::DuplicateDirectiveArgumentName],
+  ),
+  (
+    SchemaErrorKind::ReservedDirectiveArgumentName,
+    "type Query { ok: Int } directive @d(__a: Int) on FIELD",
+    &[SchemaErrorKind::ReservedDirectiveArgumentName],
+  ),
+  (
+    SchemaErrorKind::DirectiveArgumentTypeNotInputType,
+    "type Query { ok: Int } directive @d(a: Query) on FIELD",
+    &[SchemaErrorKind::DirectiveArgumentTypeNotInputType],
+  ),
+  (
+    SchemaErrorKind::SelfReferentialDirective,
+    "type Query { ok: Int }
+     directive @d(a: In) on FIELD
+     input In { x: Int @d }",
+    &[SchemaErrorKind::SelfReferentialDirective],
+  ),
+];
+
+#[test]
+fn refusal_floor() {
+  let mut missing = Vec::new();
+  for kind in SchemaErrorKind::ALL {
+    let excused = UNFIREABLE.iter().any(|(excused, _)| excused == kind);
+    let has_fixture = FIXTURES.iter().any(|(fixture, ..)| fixture == kind);
+    if !has_fixture && !excused {
+      missing.push(kind);
+    }
+    assert!(
+      !(has_fixture && excused),
+      "{kind:?} is both excused and fixtured; delete the excuse"
+    );
+  }
+  assert!(
+    missing.is_empty(),
+    "these refusal kinds have no schema that makes them fire: {missing:?} — add one to FIXTURES, \
+     or record a written reason in UNFIREABLE"
+  );
+
+  // The census must not pass vacuously.
+  assert!(
+    SchemaErrorKind::ALL.len() >= 50,
+    "read only {} kinds; the enumeration is wrong, not the fixtures",
+    SchemaErrorKind::ALL.len()
+  );
+
+  for (kind, sdl, expected) in FIXTURES {
+    let errors = refused(sdl);
+    let mut want = expected.to_vec();
+    want.sort_unstable();
+    want.dedup();
+    assert_eq!(
+      errors.kinds(),
+      want,
+      "fixture for {kind:?} produced {:?}\n---\n{sdl}",
+      errors.kinds()
+    );
+    assert!(
+      errors.contains_kind(*kind),
+      "fixture for {kind:?} did not fire it"
+    );
+  }
+}
+
+/// Every refusal names the artifact it refused.
+///
+/// A rule that fires without saying what tripped it is a rule an SDL author cannot act on.
+#[test]
+fn every_refusal_names_its_subject() {
+  for (kind, sdl, _) in FIXTURES {
+    let errors = refused(sdl);
+    for error in errors.errors() {
+      assert!(
+        !error.subject().is_empty(),
+        "{kind:?} produced an error with an empty subject: {error}"
+      );
+      let rendered = error.to_string();
+      assert!(
+        rendered.contains(error.subject()),
+        "{kind:?} renders as {rendered:?}, which does not name its subject {:?}",
+        error.subject()
+      );
+    }
+  }
+}
+
+/// Spot-check the qualified subjects, since the floor above only checks that one exists.
+#[test]
+fn subjects_are_qualified_by_their_owner() {
+  let errors = refused("type Query { ok: Int } type T { f(a: Int, a: Int): Int }");
+  let error = &errors.errors()[0];
+  assert_eq!(error.kind(), SchemaErrorKind::DuplicateArgumentName);
+  assert_eq!(error.subject(), "a");
+  assert_eq!(error.owner(), Some("T.f"));
+  assert_eq!(error.to_string(), "duplicate argument: `T.f.a`");
+  assert!(
+    error.related().is_some(),
+    "the first `a` should be pointed at"
+  );
+}
+
+/// The one kind no parsed document can reach, reached the only other way it can be.
+///
+/// The AST types are public and `const`-constructible, so a caller *can* hand the builder a name
+/// the grammar would never produce. The arena's ASCII invariant is what makes `Schema::name`
+/// infallible, so the builder checks rather than assumes.
+#[test]
+fn invalid_name_from_a_hand_built_ast() {
+  let span = SimpleSpan::const_new(0, 9);
+  let scalar = ScalarTypeDefinition::new(span, Name::new(span, "not a name"), None);
+  let definition = TypeSystemDefinition::Type(TypeDefinition::Scalar(scalar));
+  let document = TypeSystemDocument::<&str>::new(
+    span,
+    vec![TypeSystemDefinitionOrExtension::Definition(Described::new(
+      span, None, definition,
+    ))],
+  );
+
+  let errors = Schema::build(&document).expect_err("a name outside the grammar is not a schema");
+  assert!(
+    errors.contains_kind(SchemaErrorKind::InvalidName),
+    "{errors}"
+  );
+  let error = errors
+    .errors()
+    .iter()
+    .find(|error| error.kind() == SchemaErrorKind::InvalidName)
+    .expect("the kind is present");
+  assert_eq!(error.subject(), "not a name");
+}
+
+// ---------------------------------------------------------------------------------------------
+// acceptance
+// ---------------------------------------------------------------------------------------------
+
+/// The realistic schema the rest of the acceptance tests read.
+const STAR_WARS: &str = r#"
+schema { query: Query mutation: Mutation }
+
+directive @auth(role: Role! = USER) repeatable on FIELD_DEFINITION | OBJECT
+
+interface Node { id: ID! }
+interface Character implements Node { id: ID! name: String! friends: [Character] }
+
+type Human implements Character & Node {
+  id: ID!
+  name: String!
+  friends: [Character]
+  homePlanet: String
+}
+
+type Droid implements Character & Node {
+  id: ID!
+  name: String!
+  friends: [Character]
+  primaryFunction: String
+}
+
+type Starship implements Node { id: ID! length(unit: LengthUnit = METER): Float }
+
+union SearchResult = Human | Droid | Starship
+
+enum LengthUnit { METER FOOT }
+enum Role { USER ADMIN }
+
+input ReviewInput { stars: Int! commentary: String tags: [String!] = [] }
+input Filter @oneOf { byName: String byId: ID }
+
+type Query {
+  hero(episode: Int): Character
+  search(text: String!, filter: Filter): [SearchResult]
+  node(id: ID!): Node
+}
+
+type Mutation { createReview(review: ReviewInput!): Int }
+"#;
+
+#[test]
+fn a_realistic_schema_builds() {
+  let schema = built(STAR_WARS);
+
+  let (query, _) = schema.type_by_name(b"Query").expect("Query");
+  assert_eq!(schema.root(RootOperation::Query), Some(query));
+  let (mutation, _) = schema.type_by_name(b"Mutation").expect("Mutation");
+  assert_eq!(schema.root(RootOperation::Mutation), Some(mutation));
+  assert_eq!(schema.root(RootOperation::Subscription), None);
+
+  // Field lookup goes through the interned symbol and a binary search over the sorted group.
+  let hero = schema
+    .sym(b"hero")
+    .and_then(|sym| schema.field(query, sym))
+    .expect("Query.hero");
+  assert_eq!(schema.name(hero.ty().base()), "Character");
+  assert!(!hero.ty().is_non_null());
+
+  // Every composite carries `__typename`, unions included.
+  for name in [
+    &b"Query"[..],
+    b"Character",
+    b"Human",
+    b"SearchResult",
+    b"Node",
+  ] {
+    let (id, _) = schema.type_by_name(name).expect("the type exists");
+    let typename = schema.sym(builtin::TYPENAME_FIELD.as_bytes()).expect("sym");
+    let field = schema.field(id, typename).expect("__typename");
+    assert_eq!(schema.name(field.ty().base()), "String");
+    assert!(field.ty().is_non_null());
+  }
+
+  // A union's field group is exactly `__typename` — which is the whole of draft 5.3.1's
+  // union clause, with no rule of its own.
+  let (search_result, _) = schema.type_by_name(b"SearchResult").expect("SearchResult");
+  assert_eq!(schema.fields_of(search_result).len(), 1);
+
+  // The query root, and only the query root, carries `__schema` and `__type`.
+  let schema_field = schema.sym(b"__schema").expect("sym");
+  assert!(schema.field(query, schema_field).is_some());
+  assert!(schema.field(mutation, schema_field).is_none());
+  let type_field = schema.sym(b"__type").expect("sym");
+  let type_field = schema.field(query, type_field).expect("Query.__type");
+  let args = schema.inputs(type_field.args());
+  assert_eq!(args.len(), 1);
+  assert_eq!(schema.name(args[0].name()), "name");
+  assert!(args[0].is_required());
+
+  // Enum values are a sorted symbol group.
+  let (unit, _) = schema.type_by_name(b"LengthUnit").expect("LengthUnit");
+  assert_eq!(schema.enum_values_of(unit).len(), 2);
+  assert!(schema.has_enum_value(unit, schema.sym(b"METER").expect("sym")));
+  assert!(!schema.has_enum_value(unit, schema.sym(b"Human").expect("sym")));
+
+  // `@oneOf` is a flag, read off the applied directive at build.
+  let (filter, filter_def) = schema.type_by_name(b"Filter").expect("Filter");
+  assert!(filter_def.is_one_of());
+  assert_eq!(schema.input_fields_of(filter).len(), 2);
+
+  // Directive locations are a mask, so 5.7.2 is one `AND`.
+  let auth = schema.directive_by_name(b"auth").expect("@auth");
+  assert!(auth.is_repeatable());
+  assert!(
+    auth
+      .locations()
+      .contains(smear::validator::schema::DirectiveLocation::FieldDefinition)
+  );
+  assert!(
+    !auth
+      .locations()
+      .contains(smear::validator::schema::DirectiveLocation::Query)
+  );
+  assert!(!auth.is_built_in());
+
+  // The five specified directives are injected.
+  for name in builtin::BUILT_IN_DIRECTIVES {
+    let directive = schema
+      .directive_by_name(name.as_bytes())
+      .unwrap_or_else(|| panic!("@{name} is injected"));
+    assert!(directive.is_built_in(), "@{name} should be marked built-in");
+  }
+  // As are the five built-in scalars and the eight introspection types.
+  for name in builtin::BUILT_IN_SCALARS {
+    let (_, def) = schema
+      .type_by_name(name.as_bytes())
+      .unwrap_or_else(|| panic!("{name} is injected"));
+    assert_eq!(def.kind(), TypeKind::Scalar);
+    assert!(def.is_built_in());
+  }
+  for name in builtin::INTROSPECTION_TYPES {
+    let (_, def) = schema
+      .type_by_name(name.as_bytes())
+      .unwrap_or_else(|| panic!("{name} is injected"));
+    assert!(def.is_built_in());
+  }
+}
+
+/// The meta-schema is not behind the `introspection` feature, and never was going to be: an
+/// introspection *query* is an ordinary executable document that draft 5.3.1 checks field by
+/// field, so it needs `__Schema` and friends present in every schema.
+#[test]
+fn introspection_is_part_of_every_schema() {
+  let schema = built(ROOT);
+  let (type_id, def) = schema.type_by_name(b"__Type").expect("__Type");
+  assert_eq!(def.kind(), TypeKind::Object);
+
+  let fields = schema
+    .sym(b"fields")
+    .and_then(|sym| schema.field(type_id, sym));
+  let fields = fields.expect("__Type.fields");
+  let args = schema.inputs(fields.args());
+  assert_eq!(args.len(), 1);
+  assert_eq!(schema.name(args[0].name()), "includeDeprecated");
+  assert_eq!(args[0].default_kind(), DefaultKind::NonNull);
+
+  let (kind_enum, def) = schema.type_by_name(b"__TypeKind").expect("__TypeKind");
+  assert_eq!(def.kind(), TypeKind::Enum);
+  assert_eq!(schema.enum_values_of(kind_enum).len(), 8);
+}
+
+#[test]
+fn builtin_sdl_parses() {
+  // The builder `expect()`s these; this is the standing guard on that expectation.
+  for sdl in [
+    builtin::BUILT_IN_SCALARS_SDL,
+    builtin::BUILT_IN_DIRECTIVES_SDL,
+    builtin::INTROSPECTION_SDL,
+  ] {
+    let document = parse(sdl);
+    assert!(!document.definitions().is_empty());
+  }
+}
+
+/// A document that spells out a built-in scalar or a specified directive replaces it rather than
+/// colliding with it — which is what makes a printed schema re-readable.
+#[test]
+fn built_in_scalars_and_directives_are_replaceable() {
+  let schema = built(
+    "type Query { ok: Int }
+     scalar String
+     directive @skip(if: Boolean!) on FIELD",
+  );
+  let (_, string) = schema.type_by_name(b"String").expect("String");
+  assert!(
+    !string.is_built_in(),
+    "the document's own String should win over the injected one"
+  );
+  let skip = schema.directive_by_name(b"skip").expect("@skip");
+  assert!(!skip.is_built_in());
+  assert!(
+    skip
+      .locations()
+      .contains(smear::validator::schema::DirectiveLocation::Field)
+  );
+  assert!(
+    !skip
+      .locations()
+      .contains(smear::validator::schema::DirectiveLocation::FragmentSpread),
+    "the document's own @skip should replace the injected one, not merge with it"
+  );
+}
+
+/// Extensions are applied once every document has been read, so order does not matter — within a
+/// document or across them.
+#[test]
+fn extensions_apply_regardless_of_order() {
+  let schema = built("extend type Query { extra: Int } type Query { ok: Int }");
+  let (query, _) = schema.type_by_name(b"Query").expect("Query");
+  // `ok`, `extra`, and the three meta-fields the query root carries.
+  assert_eq!(schema.fields_of(query).len(), 5);
+
+  let base = parse("type Query { ok: Int }");
+  let extension =
+    parse("extend type Query { extra: Int } extend schema { mutation: M } type M { go: Int }");
+  let mut builder = SchemaBuilder::new();
+  builder.document(&base).document(&extension);
+  let schema = builder.finish().expect("two documents make one schema");
+  let (query, _) = schema.type_by_name(b"Query").expect("Query");
+  assert!(
+    schema
+      .sym(b"extra")
+      .and_then(|s| schema.field(query, s))
+      .is_some()
+  );
+  assert!(schema.root(RootOperation::Mutation).is_some());
+}
+
+/// A definition the specification provided is still an extension target.
+///
+/// `extend scalar Int @tag(...)` names something the document never wrote, and refusing it as an
+/// undefined target would be a false positive — the worse defect for a validator to have.
+#[test]
+fn built_ins_can_be_extended() {
+  let schema = built(
+    "type Query { ok: Int }
+     directive @tag(name: String!) on SCALAR | OBJECT
+     extend scalar Int @tag(name: \"money\")",
+  );
+  let (int, def) = schema.type_by_name(b"Int").expect("Int");
+  assert!(def.is_built_in());
+  assert_eq!(def.kind(), TypeKind::Scalar);
+  let _ = int;
+}
+
+/// One builder, two documents whose source slice types differ — the property that makes `Schema`
+/// non-generic worth having.
+#[test]
+fn one_builder_accepts_documents_of_different_source_types() {
+  let text = parse("type Query { ok: Int }");
+  let bytes_sdl: &[u8] = b"type Extra { more: Int }";
+  let bytes = Parser::with_parser::<
+    GraphqlLexer<'_, [u8]>,
+    TypeSystemDocument<&[u8]>,
+    GraphqlErrors<&[u8]>,
+    _,
+    GraphQL,
+  >(type_system_document)
+  .parse(bytes_sdl)
+  .expect("the byte SDL parses");
+
+  let mut builder = SchemaBuilder::new();
+  builder.document(&text);
+  builder.document(&bytes);
+  let schema = builder.finish().expect("both documents build one schema");
+  assert!(schema.type_by_name(b"Extra").is_some());
+}
+
+/// The whole point of the arena: the schema outlives every byte it was built from.
+#[test]
+fn a_schema_outlives_its_document() {
+  let schema = {
+    let sdl = String::from("type Query { ok: Int }");
+    let document = parse(&sdl);
+    Schema::build(&document).expect("builds")
+  };
+  assert_eq!(schema.name(schema.sym(b"Query").expect("sym")), "Query");
+
+  fn assert_send_sync<T: Send + Sync + 'static>(_: &T) {}
+  assert_send_sync(&schema);
+}
+
+// ---------------------------------------------------------------------------------------------
+// the two pins
+// ---------------------------------------------------------------------------------------------
+
+/// The possible-object bitsets, against a hand-computed expectation.
+///
+/// Draft 5.5.2.3 — all four subsections — is `possible(scope) ∩ possible(condition) ≠ ∅`, so if
+/// these words are wrong every fragment-spread verdict is wrong and nothing else would say so.
+/// The hierarchy below is small enough to work out by hand and covers all four shapes: an object,
+/// an interface with implementors, an interface with none, and a union.
+#[test]
+fn possible_object_bitsets_match_a_hand_computation() {
+  let schema = built(
+    "type Query { ok: Int }
+     interface Node { id: ID! }
+     interface Named { name: String! }
+     interface Orphan { nothing: Int }
+     type Human implements Node & Named { id: ID! name: String! }
+     type Droid implements Node & Named { id: ID! name: String! }
+     type Ship implements Node { id: ID! }
+     union Living = Human | Droid",
+  );
+
+  // Object ordinals are assigned in type-id order, which is document order for user types, so
+  // the four objects are Query=0, Human=1, Droid=2, Ship=3. Everything below is derived from
+  // that by hand.
+  let names = |ids: Vec<smear::validator::schema::TypeId>| -> Vec<&str> {
+    ids
+      .into_iter()
+      .map(|id| schema.name(schema.type_def(id).name()))
+      .collect()
+  };
+  let ordinal = |name: &[u8]| {
+    let (id, _) = schema.type_by_name(name).expect("the type exists");
+    schema.type_def(id).object_ordinal()
+  };
+  assert_eq!(ordinal(b"Query"), 0);
+  assert_eq!(ordinal(b"Human"), 1);
+  assert_eq!(ordinal(b"Droid"), 2);
+  assert_eq!(ordinal(b"Ship"), 3);
+
+  // Four user objects plus the four introspection objects (__Schema, __Type, __Field,
+  // __InputValue, __EnumValue, __Directive) still fit one 64-bit word.
+  assert_eq!(schema.possible_words(), 1);
+
+  let bits = |name: &[u8]| -> u64 {
+    let (id, _) = schema.type_by_name(name).expect("the type exists");
+    schema.possible_objects(id).expect("a composite")[0]
+  };
+
+  // An object's set is a singleton.
+  assert_eq!(bits(b"Human"), 1 << 1);
+  assert_eq!(bits(b"Ship"), 1 << 3);
+  // An interface's set is its implementors.
+  assert_eq!(bits(b"Node"), (1 << 1) | (1 << 2) | (1 << 3));
+  assert_eq!(bits(b"Named"), (1 << 1) | (1 << 2));
+  // An interface nobody implements has an empty set — which is exactly why draft 5.5.2.3 has an
+  // ecosystem-wide `condition == scope` exception, applied by the rule and not by the schema.
+  assert_eq!(bits(b"Orphan"), 0);
+  // A union's set is its members.
+  assert_eq!(bits(b"Living"), (1 << 1) | (1 << 2));
+
+  // A scalar, an enum and an input object have no set at all.
+  for name in [&b"Int"[..], b"ID", b"String"] {
+    let (id, _) = schema.type_by_name(name).expect("the type exists");
+    assert!(schema.possible_objects(id).is_none(), "{name:?}");
+  }
+
+  // The word-AND, which is what a rule actually calls.
+  let id = |name: &[u8]| schema.type_by_name(name).expect("the type exists").0;
+  assert!(schema.possible_objects_intersect(id(b"Node"), id(b"Living")));
+  assert!(schema.possible_objects_intersect(id(b"Named"), id(b"Human")));
+  assert!(!schema.possible_objects_intersect(id(b"Living"), id(b"Ship")));
+  assert!(!schema.possible_objects_intersect(id(b"Orphan"), id(b"Orphan")));
+  assert!(!schema.possible_objects_intersect(id(b"Node"), id(b"Query")));
+
+  // And the enumeration the bitset stands for.
+  let mut living = names(schema.possible_object_ids(id(b"Living")).collect());
+  living.sort_unstable();
+  assert_eq!(living, ["Droid", "Human"]);
+  let mut node = names(schema.possible_object_ids(id(b"Node")).collect());
+  node.sort_unstable();
+  assert_eq!(node, ["Droid", "Human", "Ship"]);
+  assert_eq!(
+    names(schema.possible_object_ids(id(b"Orphan")).collect()),
+    Vec::<&str>::new()
+  );
+
+  assert!(schema.is_possible_object(id(b"Node"), id(b"Ship")));
+  assert!(!schema.is_possible_object(id(b"Living"), id(b"Ship")));
+  // An abstract type is never a possible *object* of anything, including itself.
+  assert!(!schema.is_possible_object(id(b"Node"), id(b"Named")));
+}
+
+/// The `DefaultKind` reduction, against a schema carrying all of its shapes.
+///
+/// Executable validation needs only whether a default exists and whether it is `null` — 5.4.3,
+/// 5.6.4 and 5.8.5 never read the value — and dropping the content is what lets the schema stop
+/// borrowing the SDL. If the reduction slipped, "required" would be wrong everywhere.
+#[test]
+fn default_kind_reduces_every_shape() {
+  let schema = built(
+    "type Query {
+       f(
+         absent:        Int,
+         nullDefault:   Int  = null,
+         intDefault:    Int  = 0,
+         zeroFloat:     Float = 0.0,
+         falseDefault:  Boolean = false,
+         emptyString:   String = \"\",
+         emptyList:     [Int] = [],
+         emptyObject:   Point = {},
+         enumDefault:   Unit = METER,
+         requiredNoDef: Int!,
+         requiredWithDefault: Int! = 1
+       ): Int
+     }
+     input Point { x: Int y: Int }
+     enum Unit { METER }",
+  );
+
+  let (query, _) = schema.type_by_name(b"Query").expect("Query");
+  let field = schema
+    .sym(b"f")
+    .and_then(|sym| schema.field(query, sym))
+    .expect("Query.f");
+  let args = schema.inputs(field.args());
+
+  let of = |name: &str| {
+    let sym = schema.sym(name.as_bytes()).expect("the argument name");
+    let arg = args
+      .iter()
+      .find(|arg| arg.name() == sym)
+      .unwrap_or_else(|| panic!("argument {name}"));
+    (arg.default_kind(), arg.is_required())
+  };
+
+  // Absent means absent — not "null".
+  assert_eq!(of("absent"), (DefaultKind::Absent, false));
+  // An explicit `null` is its own class: it is present, so a non-null argument carrying it is
+  // not required, and 5.6.4 must be able to tell it from a missing default.
+  assert_eq!(of("nullDefault"), (DefaultKind::Null, false));
+  // Everything else collapses to `NonNull`, whatever its literal shape — including the falsy
+  // ones, which is the reduction most likely to be got wrong.
+  for name in [
+    "intDefault",
+    "zeroFloat",
+    "falseDefault",
+    "emptyString",
+    "emptyList",
+    "emptyObject",
+    "enumDefault",
+  ] {
+    assert_eq!(of(name), (DefaultKind::NonNull, false), "{name}");
+  }
+  // Required is exactly "non-null type and no default".
+  assert_eq!(of("requiredNoDef"), (DefaultKind::Absent, true));
+  assert_eq!(of("requiredWithDefault"), (DefaultKind::NonNull, false));
+
+  // Input fields take the same reduction, through the other table.
+  let schema = built(
+    "type Query { ok: Int }
+     input In { a: Int b: Int = null c: Int = 3 d: Int! e: Int! = 4 }",
+  );
+  let (input, _) = schema.type_by_name(b"In").expect("In");
+  let of = |name: &str| {
+    let sym = schema.sym(name.as_bytes()).expect("the field name");
+    let field = schema.input_field(input, sym).expect("the field");
+    (field.default_kind(), field.is_required())
+  };
+  assert_eq!(of("a"), (DefaultKind::Absent, false));
+  assert_eq!(of("b"), (DefaultKind::Null, false));
+  assert_eq!(of("c"), (DefaultKind::NonNull, false));
+  assert_eq!(of("d"), (DefaultKind::Absent, true));
+  assert_eq!(of("e"), (DefaultKind::NonNull, false));
+}
+
+// ---------------------------------------------------------------------------------------------
+// representation invariants
+// ---------------------------------------------------------------------------------------------
+
+/// Packed type references: the wrapper word, and the walks the §5 rules will do over it.
+#[test]
+fn packed_types_round_trip_their_spelling() {
+  let schema = built(
+    "type Query {
+       plain: Int
+       required: Int!
+       list: [Int]
+       listOfRequired: [Int!]
+       requiredList: [Int]!
+       nested: [[Int!]!]!
+     }",
+  );
+  let (query, _) = schema.type_by_name(b"Query").expect("Query");
+  let ty = |name: &str| {
+    let sym = schema.sym(name.as_bytes()).expect("the field name");
+    schema.field(query, sym).expect("the field").ty()
+  };
+
+  assert_eq!(ty("plain").depth(), 0);
+  assert!(!ty("plain").is_non_null());
+  assert!(ty("required").is_non_null());
+  assert_eq!(ty("required").nullable(), ty("plain"));
+  assert!(ty("list").is_list());
+  assert_eq!(ty("list").list_item(), Some(ty("plain")));
+  assert_eq!(ty("listOfRequired").list_item(), Some(ty("required")));
+  assert!(
+    !ty("requiredList").is_list(),
+    "`[Int]!` is a non-null, not a list"
+  );
+  assert_eq!(ty("requiredList").nullable(), ty("list"));
+  assert_eq!(ty("nested").depth(), 5);
+
+  // The base is stored twice over — resolved id and interned name — so a diagnostic never walks
+  // a table to spell a type.
+  let (int, _) = schema.type_by_name(b"Int").expect("Int");
+  assert_eq!(ty("nested").base_id(), int);
+  assert_eq!(schema.name(ty("nested").base()), "Int");
+}
+
+/// Field and argument groups are sorted by symbol, which is what makes lookup a binary search.
+#[test]
+fn groups_are_sorted_for_binary_search() {
+  let schema = built(STAR_WARS);
+  for (index, def) in schema.types().iter().enumerate() {
+    let id = smear::validator::schema::TypeId::new(index as u32);
+    let fields = schema.fields_of(id);
+    assert!(
+      fields
+        .windows(2)
+        .all(|w| w[0].name().get() < w[1].name().get()),
+      "field group of {} is not sorted",
+      schema.name(def.name())
+    );
+    for field in fields {
+      let args = schema.inputs(field.args());
+      assert!(
+        args
+          .windows(2)
+          .all(|w| w[0].name().get() < w[1].name().get()),
+        "argument group of {}.{} is not sorted",
+        schema.name(def.name()),
+        schema.name(field.name())
+      );
+    }
+    let inputs = schema.input_fields_of(id);
+    assert!(
+      inputs
+        .windows(2)
+        .all(|w| w[0].name().get() < w[1].name().get()),
+      "input field group of {} is not sorted",
+      schema.name(def.name())
+    );
+    let values = schema.enum_values_of(id);
+    assert!(values.windows(2).all(|w| w[0] < w[1]));
+  }
+  assert!(
+    schema
+      .directives()
+      .windows(2)
+      .all(|w| w[0].name().get() < w[1].name().get()),
+    "the directive table is not sorted"
+  );
+}
+
+/// Interface closures are transitive, and are what the §3 covariance check reads.
+#[test]
+fn interface_closures_are_transitive() {
+  let schema = built(
+    "type Query { ok: Int }
+     interface A { a: Int }
+     interface B implements A { a: Int b: Int }
+     type T implements A & B { a: Int b: Int }",
+  );
+  let id = |name: &[u8]| schema.type_by_name(name).expect("the type").0;
+  let mut closure: Vec<&str> = schema
+    .interfaces_of(id(b"T"))
+    .iter()
+    .map(|i| schema.name(schema.type_def(*i).name()))
+    .collect();
+  closure.sort_unstable();
+  assert_eq!(closure, ["A", "B"]);
+  assert_eq!(
+    schema
+      .interfaces_of(id(b"B"))
+      .iter()
+      .map(|i| schema.name(schema.type_def(*i).name()))
+      .collect::<Vec<_>>(),
+    ["A"]
+  );
+  assert!(schema.interfaces_of(id(b"A")).is_empty());
+}
+
+/// Covariance is accepted where the draft accepts it — the direction a refusal-only suite would
+/// never catch.
+#[test]
+fn valid_interface_implementations_are_accepted() {
+  built(
+    "type Query { ok: Int }
+     interface Node { id: ID }
+     interface Named { name: String }
+     type Impl implements Node & Named {
+       # `T!` implements `T`.
+       id: ID!
+       name: String
+       # An extra optional argument is fine; an extra required one is not (fixtured above).
+       extra(x: Int, y: Int = 1): Int
+     }
+     interface Container { item: Node }
+     # An object is a valid implementation of an interface it implements.
+     type Box implements Container { item: Impl }
+     interface ListContainer { items: [Node] }
+     type ListBox implements ListContainer { items: [Impl!]! }",
+  );
+}
+
+/// The cycle rules accept the shapes that are legal, not just refuse the ones that are not.
+#[test]
+fn breakable_cycles_are_accepted() {
+  // A nullable link breaks it.
+  built("type Query { ok: Int } input A { b: B } input B { a: A! }");
+  // So does a list, which may be empty.
+  built("type Query { ok: Int } input A { b: [B!]! } input B { a: A! }");
+  // A directive that names an input object which does not name it back is not self-referential.
+  built(
+    "type Query { ok: Int }
+     directive @d(a: In) on FIELD
+     directive @e on INPUT_FIELD_DEFINITION
+     input In { x: Int @e }",
+  );
+  // `@specifiedBy` on a user scalar is the specification's own idiom and must stay legal: the
+  // walk reaches `String`, which carries no directive, and stops.
+  built("type Query { ok: Int } scalar UUID @specifiedBy(url: \"https://example.invalid\")");
+  // Reporting only lands on the directive that closes the cycle, not on a bystander that merely
+  // uses it — the same refinement apollo-compiler makes.
+  let errors = refused(
+    "type Query { ok: Int }
+     directive @a(x: In) on FIELD
+     directive @b(y: In) on FIELD
+     input In { z: Int @a }",
+  );
+  assert_eq!(errors.len(), 1, "{errors}");
+  assert_eq!(errors.errors()[0].subject(), "a");
+}
+
+/// The default roots are the conventionally named object types, when no `schema` block names any.
+#[test]
+fn default_root_names_are_used_without_a_schema_definition() {
+  let schema =
+    built("type Query { ok: Int } type Mutation { go: Int } type Subscription { s: Int }");
+  for operation in RootOperation::ALL {
+    let root = schema.root(operation).expect("the default root resolves");
+    assert_eq!(
+      schema.name(schema.type_def(root).name()),
+      operation.default_type_name()
+    );
+  }
+  // A conventionally named type that is not an object is not silently adopted.
+  let errors = refused("interface Query { ok: Int }");
+  assert!(errors.contains_kind(SchemaErrorKind::MissingQueryRootOperationType));
+}
+
+/// The name index is a real index: every interned name resolves, nothing else does.
+#[test]
+fn the_name_index_resolves_exactly_what_was_interned() {
+  let schema = built(STAR_WARS);
+  for index in 0..schema.symbol_count() {
+    let sym = smear::validator::schema::Sym::new(index);
+    let bytes = schema.name_bytes(sym);
+    assert_eq!(schema.sym(bytes), Some(sym), "{:?}", schema.name(sym));
+    assert!(
+      smear::validator::schema::is_name(bytes),
+      "the arena admitted a non-name: {bytes:?}"
+    );
+  }
+  assert_eq!(schema.sym(b"NoSuchName"), None);
+  assert_eq!(schema.sym(b""), None);
+}
+
+/// A directive graph deep enough that a recursive walk would be a stack question.
+///
+/// The §3.13.1 check reaches every input type an argument can name, and an SDL's input-object
+/// chain is bounded by nothing. This is the shape that would have found a recursive walk.
+#[test]
+fn a_deep_input_chain_does_not_recurse() {
+  let mut sdl = String::from("type Query { ok: Int }\ndirective @d(a: In0) on FIELD\n");
+  const DEPTH: usize = 20_000;
+  for level in 0..DEPTH {
+    sdl.push_str(&format!("input In{level} {{ next: In{} }}\n", level + 1));
+  }
+  sdl.push_str(&format!("input In{DEPTH} {{ end: Int }}\n"));
+  built(&sdl);
+
+  // The same chain, with the directive applied at the far end, is a cycle and is found.
+  let mut sdl = String::from("type Query { ok: Int }\ndirective @d(a: In0) on FIELD\n");
+  for level in 0..DEPTH {
+    sdl.push_str(&format!("input In{level} {{ next: In{} }}\n", level + 1));
+  }
+  sdl.push_str(&format!("input In{DEPTH} {{ end: Int @d }}\n"));
+  let errors = refused(&sdl);
+  assert!(
+    errors.contains_kind(SchemaErrorKind::SelfReferentialDirective),
+    "{errors}"
+  );
+}


### PR DESCRIPTION
Phase 1 of the validator design in #85: the `Schema` — the substrate the §5 rules, the `Sink` and the differential oracle all sit on. **Not** the rules, not the sink, not the harness; those are later waves. The point of this one is to leave them nothing to argue about.

New module `smear::validator::schema` behind `validator = ["parser", "graphql"]`, off by default. **No new dependency**, runtime or dev.

## The representation

Built once from any `TypeSystemDocument<S>`, and **not generic over `S`**. Names are copied into a byte arena as they are interned, so the finished value borrows nothing: the SDL can be dropped the moment the schema exists, and the schema can be `'static`, sent across threads, or handed to a foreign caller. One `SchemaBuilder` accepts documents whose `S` types differ from each other.

Everything a rule would otherwise derive per query is derived here instead:

| | |
|---|---|
| names | interned `Sym(u32)` over one byte arena, indexed by an in-crate open-addressing map — **no third-party hasher**, matching the workspace's zero-hasher posture |
| tables | flat `Box<[T]>`, every child list a `Range32`, every row `Copy`, no interior pointers |
| field lookup | per-type groups sorted by symbol → binary search |
| type refs | `PackedType`: base symbol + resolved id + list/non-null wrappers as 2-bit codes in a `u32`, innermost first. 5.8.5's `AreTypesCompatible` and 5.3.2's shape comparison become integer walks; reference equality is `==` |
| abstract types | possible-**object** bitsets on every composite, so all four subsections of 5.5.2.3 are one word-`AND` |
| directives | locations as a `u32` mask, so 5.7.2 is one `AND` |
| defaults | reduced to a 2-bit `DefaultKind`. Executable rules need presence and null-ness, never content — and dropping the content is what removes the last borrow of the SDL |

## No `Arc`, no atomics, no interior mutability — built, not asserted

Validation takes `&Schema`, so a build-once/read-many value needs no shared-ownership primitive at all: the caller wraps it in `alloc::sync::Arc` or `portable_atomic_util::Arc` as their platform allows, and this crate needs no tier for it.

The new **`smear-noatomic`** member turns that claim into a build. `#![no_std]` over `alloc`, `#![forbid(unsafe_code)]`, an empty `[dependencies]` table, and it `#[path]`-includes `smear`'s own representation files rather than copying them — so nothing can drift out from under it. CI builds it for `thumbv6m-none-eabi` (Cortex-M0+, no native compare-and-swap) and separately asserts, out of `cargo metadata`, that the dependency count is zero.

**The gate was verified to discriminate.** Adding `struct WouldNeedAtomics(std::sync::Arc<u8>)` to the representation failed it with `cannot find `sync` in `std``; removing it restored green.

`smear` itself cannot build for that target — its syntactic AST offers an `Arc`-backed spelling of recursive list types — which is exactly why the claim is about the *schema* and not the crate. That is written down in the member's own header.

## Draft §3 runs inside the build

A server rejects a bad SDL exactly once, at startup, rather than rediscovering it per request. `SchemaErrorKind` enumerates **51** refusal classes across §3.3, §3.6/§3.7, §3.8, §3.9, §3.10 and §3.13. Every error names the artifact it rejected, qualified by its owner — `duplicate argument: `T.f.a`` — with a primary span, an optional related span, the document index, and **owned** strings, so a `SchemaErrors` outlives the SDL it came from.

`refusal_floor` iterates `SchemaErrorKind::ALL` and asserts every kind has a schema in the fixture table that makes it fire, **with the exact set of kinds that schema produces**. A kind added without a fixture fails the test; a fixture that starts tripping a second rule fails it too. Two kinds are excused in writing (`UNFIREABLE`), both implementation limits rather than specification rules — and one of them, `InvalidName`, is fired anyway through the other door: a hand-assembled AST, because the AST types are public and `const`-constructible.

Acceptance is tested as deliberately as refusal: valid covariance, breakable input cycles, `@specifiedBy` on a user scalar, extensions in either order and across documents.

## Introspection

The §4 meta-schema is injected **unconditionally**, not behind a feature. An introspection query is an ordinary executable document that 5.3.1 checks field by field, so `{ __schema { types { name } } }` only validates against a schema that knows `__Schema` and `__Type`. The `introspection` cargo feature the design reserves is a *construction* door and is not in this PR.

The five built-in scalars and the five specified directives are injected only when the document does not define them, so a printed schema re-reads; the `__`-prefixed introspection types are not replaceable and a definition of one is `RedefinedBuiltInType`.

`__typename` lands on every composite **including unions** — a union's field group is exactly `__typename`, which makes 5.3.1's union clause fall out of the ordinary field lookup with no rule of its own — and `__schema`/`__type` on the query root only.

## The three pins

1. **Possible-object bitsets** against a hand-computed expectation over a small interface hierarchy covering all four shapes: an object (singleton), an interface with implementors, an interface with none (the empty set that 5.5.2.3's ecosystem-wide `condition == scope` exception exists for), and a union. Ordinals, raw words, the intersection, the enumeration, and the non-composite `None`s.
2. **The `DefaultKind` reduction** over a schema with all of its shapes — `absent`, `= null`, and every falsy literal that must still collapse to `NonNull` (`0`, `0.0`, `false`, `""`, `[]`, `{}`), in both the argument table and the input-field table, plus the `is_required` derivation both ways.
3. **The `S: AsRef<[u8]>` bound** over all thirteen of tokora's `Source<usize>` implementors, in `smear-smoke` — the one crate with the whole lattice enabled and a no-`#[cfg]` policy, so the assertion cannot silently compile to nothing. It instantiates the real `Schema::build` at each slice type rather than restating its bound, so it fails in both directions: a tokora change to a `Slice`, and a smear change that narrows the builder.

## Gates

Every one run locally at `342064b + this branch`, exit status captured immediately after its own command.

| gate | result |
|---|---|
| `cargo fmt --all -- --check` | 0 |
| `cargo clippy --workspace --all-features --all-targets` | 0 |
| `cargo hack clippy --each-feature` | 0 |
| `cargo hack clippy -p smear --each-feature --features parser …` (nine cells) | 0 |
| `cargo hack build --each-feature` + pass 2 | 0 |
| `cargo test --all-features` | 0 — 48 suites, incl. 22 new `validator_schema` and 3 `smear-smoke` |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features` | 0 |
| six per-dialect / per-feature doc legs, incl. `--features validator` alone | 0 |
| `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features` | 0, `validator` badge renders |
| `cargo build -p smear-noatomic --target thumbv6m-none-eabi` | 0 |
| `cargo +1.95 build --workspace --all-features` (MSRV) | 0 |

## Workflow changes

- **new `noatomic` job** in `ci.yml`. Deliberately not a cell of the `cross` matrix: that job builds the whole workspace, which cannot build for this target. `-p smear-noatomic` names the package rather than filtering, so a rename is a hard error rather than a warn-and-exit-0.
- **`validator` added to the pass-2 `--exclude-features` list in `ci.yml` *and* `macos.yml`.** It implies `parser`, so its pass-1 cell is already the `parser × validator` pair the second pass exists to restore; without the exclusion the second pass would run an exact duplicate. Both sibling workflows carry the identical block and both were edited — the count in the comment stays nine, verified against `cargo hack`'s own `(n/9)` output.
- `smear-smoke` gains the `validator` feature, two probes and two tests, per its census design; its "twelve features" prose and the `>= 12` floor become thirteen.

## Not in this PR, by design

The `Sink`/`Diagnostic`/`Rule` vocabulary, `Scratch`, `Budget`, the §5 rule engine, the 5.3.2 merge engine, the apollo differential oracle, the allocation gate, the benches, and the `introspection` construction door. Waves W1–W5 of #85.

Closes nothing; #85 stays open until the later waves land.
