### PR TITLE
feat(parser): the GraphQL CST-to-AST projection — #72 retired the span normaliser before it was written

### DIFF
--- a/smear/Cargo.toml
+++ b/smear/Cargo.toml
@@ -126,6 +126,16 @@ rowan = { version = "0.16", optional = true }
 # published manifest does not name a version of itself.
 smear = { path = ".", features = ["test-support"] }
 
+# The projection gate builds a synthetic green tree by hand — a tree whose *text* re-parses to a
+# different structure — so that a "projection" which secretly re-parsed the source could not pass
+# it. That needs rowan's builder, which the library re-exports no door to.
+#
+# Named DIRECTLY, which is the difference from the transitive edge #87 retired below: this one is
+# chosen, visible in this manifest, and carries the same version requirement as the optional
+# dependency above, so the two cannot resolve to different rowans. It is still the crate whose
+# undefined behaviour is #77 — which is survivable here only because `ci/miri_sb.sh` and
+# `ci/miri_tb.sh` run `-p smear --lib`, and no lib unit test reaches this dependency.
+rowan = "0.16"
 # `tokora::conformance` is the lexer-contract test kit; it is test-only, so the
 # feature is pulled in here rather than in the normal dependency.
 tokora = { workspace = true, features = ["conformance"] }
@@ -147,8 +157,10 @@ tokora = { workspace = true, features = ["conformance"] }
 #     target, so this one edge is what forced four Miri cells onto a `macos-latest` runner —
 #     for a reason that has nothing to do with Miri.
 #   * `apollo-parser` pulls `rowan`, and with this package's own `rowan` feature off that edge
-#     was the ONLY thing putting rowan in the graph at all. rowan is the crate whose undefined
-#     behaviour is #77.
+#     used to be the ONLY thing putting rowan in the graph at all. rowan is the crate whose
+#     undefined behaviour is #77. That sentence held until #58's projection gate, which names
+#     `rowan` directly above — the point of the rule was never "no rowan", it was "no rowan
+#     nobody asked for", and a direct entry with a reason beside it is the asked-for kind.
 #
 # A dev-dependency added here that drags either one back re-creates both conditions, and does it
 # silently — nothing in CI reports on the shape of this block.

--- a/smear/src/lexer/graphql/keyword.rs
+++ b/smear/src/lexer/graphql/keyword.rs
@@ -132,8 +132,13 @@ impl ContextualKeyword {
   }
 }
 
+/// The spelling table, in the one direction a reader of *text* needs it.
+///
+/// `pub(crate)` rather than private since #58: the CST-to-AST projection reads a keyword off a
+/// tree token's text and must classify it exactly as the lexer did, and a second copy of this
+/// table in the projection would be a spelling the two layers could disagree about.
 #[inline]
-fn contextual_keyword(source: &[u8]) -> Option<ContextualKeyword> {
+pub(crate) fn contextual_keyword(source: &[u8]) -> Option<ContextualKeyword> {
   match source {
     b"type" => Some(ContextualKeyword::Type),
     b"interface" => Some(ContextualKeyword::Interface),

--- a/smear/src/parser/argument.rs
+++ b/smear/src/parser/argument.rs
@@ -19,7 +19,7 @@ use tokora::{
 /// argument name through the end of its value.
 ///
 /// See the [GraphQL Arguments specification](https://spec.graphql.org/draft/#sec-Language.Arguments).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Argument<Name, Value, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -88,7 +88,7 @@ impl<Name, Value, Span> Argument<Name, Value, Span> {
 /// - `Arg`: the type representing individual arguments
 /// - `Container`: the collection holding the arguments (defaults to `Vec`)
 /// - `Span`: the span type (defaults to [`SimpleSpan`])
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ArgumentList<Arg, Container = Vec<Arg>, Span = SimpleSpan> {
   span: Span,
   arguments: Container,

--- a/smear/src/parser/directive.rs
+++ b/smear/src/parser/directive.rs
@@ -19,7 +19,7 @@ use tokora::{
 /// collections may be represented by `None` on this node.
 ///
 /// See the [GraphQL Directives specification](https://spec.graphql.org/draft/#sec-Language.Directives).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Directive<Name, Args, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -91,7 +91,7 @@ impl<Name, Args, Span> Directive<Name, Args, Span> {
 /// collection is empty with a zero-width span at the parser's starting offset.
 ///
 /// See the [GraphQL Directives specification](https://spec.graphql.org/draft/#sec-Language.Directives).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Directives<Directive, Container = Vec<Directive>, Span = SimpleSpan> {
   span: Span,
   directives: Container,

--- a/smear/src/parser/executable.rs
+++ b/smear/src/parser/executable.rs
@@ -198,7 +198,7 @@ impl<Variable, Type, DefaultValue, Directives, Span> IntoComponents
 }
 
 /// A variable-definition collection.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct VariablesDefinition<
   VariableDefinition,
   Span = SimpleSpan,
@@ -523,7 +523,7 @@ impl<Name, OperationType, VariablesDefinition, Directives, SelectionSet, Span> I
 }
 
 /// A GraphQL-family document.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Document<Definition, Span = SimpleSpan, Container = Vec<Definition>> {
   span: Span,
   definitions: Container,
@@ -587,7 +587,7 @@ impl<Definition, Span, Container> IntoComponents for Document<Definition, Span, 
 }
 
 /// A GraphQL-family definition: either type-system or executable syntax.
-#[derive(Debug, Clone, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum Definition<TypeSystem, Executable> {
@@ -639,7 +639,7 @@ impl<TypeSystem, Executable> Definition<TypeSystem, Executable> {
 
 /// A GraphQL-family definition with its optional description, or a type-system
 /// extension that cannot carry one.
-#[derive(Debug, Clone, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum DefinitionOrExtension<Definition, Extension> {

--- a/smear/src/parser/graphql/ast/executable.rs
+++ b/smear/src/parser/graphql/ast/executable.rs
@@ -131,7 +131,7 @@ pub type NamedOperationDefinition<S, Ty = Type<Name<S>>> =
   >;
 
 /// An operation definition, either named or query shorthand.
-#[derive(Debug, Clone, From, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, From, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 #[non_exhaustive]
@@ -171,7 +171,7 @@ impl<S, Ty> IntoSpan<Span> for OperationDefinition<S, Ty> {
 }
 
 /// An executable definition, either an operation or a fragment.
-#[derive(Debug, Clone, From, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, From, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 #[non_exhaustive]

--- a/smear/src/parser/graphql/ast/field.rs
+++ b/smear/src/parser/graphql/ast/field.rs
@@ -32,7 +32,7 @@ pub type SelectionSet<S> = crate::parser::selection::SelectionSet<Selection<S>>;
 /// A GraphQL selection.
 ///
 /// A selection is a field, a named fragment spread, or an inline fragment.
-#[derive(Debug, Clone, From, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, From, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 #[non_exhaustive]

--- a/smear/src/parser/graphql/ast/ty.rs
+++ b/smear/src/parser/graphql/ast/ty.rs
@@ -16,7 +16,7 @@ macro_rules! ty {
     paste::paste! {
       $(
         $(#[$meta])*
-        #[derive(Debug, Clone, From, IsVariant, Unwrap, TryUnwrap)]
+        #[derive(Debug, Clone, PartialEq, Eq, From, IsVariant, Unwrap, TryUnwrap)]
         #[unwrap(ref, ref_mut)]
         #[try_unwrap(ref, ref_mut)]
         pub enum $name<Name> {

--- a/smear/src/parser/graphql/ast/type_system.rs
+++ b/smear/src/parser/graphql/ast/type_system.rs
@@ -205,7 +205,7 @@ pub type SchemaDefinition<S> =
 pub type DescribedSchemaDefinition<S> = Described<SchemaDefinition<S>, S>;
 
 /// A GraphQL type definition — one of the six named type-system shapes.
-#[derive(Debug, Clone, From, Unwrap, IsVariant, TryUnwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, From, Unwrap, IsVariant, TryUnwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum TypeDefinition<S, Ty = Type<Name<S>>> {

--- a/smear/src/parser/graphql/ast/value.rs
+++ b/smear/src/parser/graphql/ast/value.rs
@@ -63,7 +63,7 @@ pub type ConstObjectField<S> = crate::parser::value::ObjectField<Name<S>, ConstI
 pub type DefaultInputValue<S> = crate::parser::value::DefaultInputValue<ConstInputValue<S>>;
 
 /// GraphQL input value (executable context).
-#[derive(Debug, Clone, From, IsVariant, Unwrap, TryUnwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, From, IsVariant, Unwrap, TryUnwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum InputValue<S> {
@@ -122,7 +122,7 @@ impl<S> IntoSpan<SimpleSpan> for InputValue<S> {
 }
 
 /// GraphQL constant input value (schema context).
-#[derive(Debug, Clone, IsVariant, Unwrap, TryUnwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, IsVariant, Unwrap, TryUnwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum ConstInputValue<S> {

--- a/smear/src/parser/graphql/lossless/mod.rs
+++ b/smear/src/parser/graphql/lossless/mod.rs
@@ -189,6 +189,7 @@ pub mod directive;
 pub mod document;
 pub mod executable;
 pub mod kind_map;
+pub mod project;
 pub mod recover;
 pub mod runner;
 pub mod selection;
@@ -203,3 +204,7 @@ pub mod value;
 pub use runner::{
   Parse, parse_document, parse_executable_document, parse_type_system_document, profile,
 };
+
+// Beside the roots, and named for the symmetry: `parse_document(src) -> Parse`,
+// `project(&parse, src) -> Result<Document, _>`.
+pub use project::{ProjectError, ProjectErrorKind, project};

--- a/smear/src/parser/graphql/lossless/project.rs
+++ b/smear/src/parser/graphql/lossless/project.rs
@@ -1,0 +1,1606 @@
+//! The GraphQL CST → AST projection.
+//!
+//! [`project`] turns a lossless parse plus the text it was parsed from into **the AST the
+//! syntactic parser produces for that text**, without re-parsing. It is the door an editor
+//! goes through: parse losslessly once, format and highlight off the tree, and hand the same
+//! parse to a consumer that wants typed nodes — a validator (#85), a name resolver, a codegen
+//! back end.
+//!
+//! ```
+//! # #[cfg(all(feature = "graphql", feature = "rowan"))] {
+//! use smear::parser::graphql::lossless::{parse_document, project};
+//!
+//! let source = "type Query { field: Int }";
+//! let parse = parse_document(source);
+//! assert!(!parse.has_errors());
+//!
+//! let ast = project(&parse, source).expect("a well-shaped tree projects");
+//! assert_eq!(ast.definitions().len(), 1);
+//! # }
+//! ```
+//!
+//! # Why `source` is a parameter, and why the pair is checked
+//!
+//! The AST is keyed by `S = &'src str` — the syntactic parser has the same property — and
+//! rowan's cursor API cannot lend a `&str` that outlives the transient [`SyntaxToken`] it came
+//! from, so the slices cannot be borrowed from the green tree. The caller who wants "the AST
+//! without re-parsing" is holding the source by construction, so it is an argument.
+//!
+//! It is **verified, not trusted**: every slice is compared against its token's own text before
+//! any constructor sees it, and a mismatch is [`ProjectErrorKind::SourceMismatch`] rather than
+//! a silently wrong AST pointing into unrelated bytes.
+//!
+//! # Shape-faithful, not verdict-faithful
+//!
+//! The projection succeeds iff the tree's **shape** determines a well-formed AST. It does not
+//! re-derive the acceptance verdict, which stays [`Parse::has_errors`].
+//!
+//! The two come apart in one measured direction. `type T { x: Int` — no closing brace — leaves a
+//! shape-complete tree with no recovery hole in it, so it projects, while the syntactic parser
+//! rejects it. Making the projection refuse it would mean re-implementing delimiter accounting,
+//! which is the grammar, which is the drift this door exists to avoid. **Check
+//! [`has_errors`](Parse::has_errors) first**; a projection of an errorful tree is best-effort.
+//!
+//! In the other direction the projection is stricter than shape alone: a tree carrying an
+//! [`Error`](SyntaxKind::Error) hole or a [`Gap`](SyntaxKind::Gap) tile is refused outright,
+//! before any walk, because a hole is a region with no AST image and skipping it would be data
+//! loss wearing a success type.
+//!
+//! # Spans
+//!
+//! Every span is the **token extent** of the constituents it covers — never
+//! [`SyntaxNode::text_range`], which includes committed trivia. See
+//! [`crate::parser::lossless::project`] for that rule and the measurement behind it.
+//!
+//! Two places the tree's geometry and the AST's differ, and both are span-relevant:
+//!
+//! - **Descriptions hoist.** The CST hangs a [`Description`](SyntaxKind::Description) node
+//!   *inside* the definition it precedes; the AST lifts it into the [`Described`] wrapper. At
+//!   document level the wrapper spans description-through-definition while the inner definition
+//!   starts *after* the description, so the inner span is synthesised by folding the node's
+//!   constituents with the description excluded.
+//! - **…except in three node types**, where the syntactic parser gives the wrapper and the inner
+//!   node the *same* span, description included: `FieldDefinition`, `InputValueDefinition` and
+//!   `EnumValueDefinition`. `VariableDefinition` — the fourth described node below document
+//!   level — follows the document-level rule instead, so the four do not agree with each other.
+//!   That asymmetry is trunk's, not this module's, and it is reproduced rather than corrected:
+//!   `tests/lossless_project.rs` compares against the parser, so a "fix" here would be a
+//!   divergence.
+
+use std::{boxed::Box, vec::Vec};
+
+use rowan::{NodeOrToken, TextRange};
+use tokora::SimpleSpan;
+
+use crate::{
+  lexer::{
+    LitStr,
+    graphql::{ContextualKeyword, keyword::contextual_keyword},
+    keywords::{Mutation, Query, Subscription},
+  },
+  parser::{
+    graphql::{
+      ast::{
+        Alias, Argument, Arguments, BooleanValue, ConstArgument, ConstArguments, ConstDirective,
+        ConstDirectives, ConstInputValue, ConstList, ConstObject, ConstObjectField,
+        DefaultInputValue, DefinitionOrExtension, Described, DescribedVariableDefinition,
+        Directive, Directives, Document, EnumTypeDefinition, EnumTypeExtension, EnumValue,
+        EnumValuesDefinition, ExecutableDefinition, Field, FieldsDefinition, FloatValue,
+        FragmentName, FragmentSpread, ImplementInterfaces, InlineFragment, InputFieldsDefinition,
+        InputObjectTypeDefinition, InputObjectTypeExtension, InputValue, IntValue,
+        InterfaceTypeDefinition, InterfaceTypeExtension, List, ListType, Location, Name,
+        NamedOperationDefinition, NamedType, NullValue, Object, ObjectField, ObjectTypeDefinition,
+        ObjectTypeExtension, OperationDefinition, OperationType, RootOperationTypeDefinition,
+        RootOperationTypesDefinition, ScalarTypeDefinition, ScalarTypeExtension, SchemaDefinition,
+        SchemaExtension, Selection, SelectionSet, StringValue, Type, TypeCondition, TypeDefinition,
+        TypeExtension, TypeSystemDefinition, TypeSystemExtension, UnionMemberTypes,
+        UnionTypeDefinition, UnionTypeExtension, VariableDefinition, VariableValue,
+        VariablesDefinition,
+      },
+      kinds::SyntaxKind,
+      lossless::{Parse, SyntaxNode, SyntaxToken},
+      syntactic::definition::classify_location,
+    },
+    lossless::project::{extent_of, node_extent, to_range, to_span, verify_slice},
+  },
+};
+
+// Spelled out rather than folded into the group above, so `tests/lossless_isolation.rs`'s source
+// census — which reads `crate::…` prefixes out of the text — can see the edge. These are the
+// **shared, dialect-free** AST carriers: the undescribed cores three `Described<…>` aliases wrap,
+// and the six `…Data` enums an extension's alternatives are encoded in. Neither has a spelling
+// under `graphql::ast`, and a projection has to construct both.
+use crate::parser::type_system::{
+  ArgumentsDefinition, DirectiveDefinition, DirectiveLocations, EnumTypeExtensionData,
+  EnumValueDefinition, FieldDefinition, InputObjectTypeExtensionData, InputValueDefinition,
+  InterfaceTypeExtensionData, ObjectTypeExtensionData, SchemaExtensionData, UnionTypeExtensionData,
+};
+
+use SyntaxKind as K;
+
+/// A refusal from the GraphQL projection, keyed by this dialect's [`SyntaxKind`].
+pub type ProjectError = crate::parser::lossless::project::ProjectError<SyntaxKind>;
+
+/// Why the GraphQL projection refused, keyed by this dialect's [`SyntaxKind`].
+pub type ProjectErrorKind = crate::parser::lossless::project::ProjectErrorKind<SyntaxKind>;
+
+type Out<T> = Result<T, ProjectError>;
+
+/// Project a lossless parse to the AST the syntactic parser produces for `source`.
+///
+/// The root this reads is the mixed [`Document`](SyntaxKind::Document) that
+/// [`parse_document`](super::parse_document) builds.
+///
+/// See the module header for the contract; the short version is: check
+/// [`has_errors`](Parse::has_errors) first, pass the same text the tree was parsed from, and
+/// expect a refusal rather than a guess when the tree carries a hole.
+pub fn project<'src>(parse: &Parse, source: &'src str) -> Out<Document<&'src str>> {
+  let root = parse.syntax();
+  reject_holes(&root)?;
+  let node = root
+    .children()
+    .find(|child| child.kind() == K::Document)
+    .ok_or_else(|| {
+      ProjectError::new(
+        ProjectErrorKind::MissingChild {
+          parent: root.kind(),
+          wanted: "a document",
+        },
+        to_range(root.text_range()),
+      )
+    })?;
+  document(&node, source)
+}
+
+impl super::ast::Document {
+  /// Project this document node to the AST the syntactic parser produces for `source`.
+  ///
+  /// The compositional form of [`project`], for a caller that already holds the typed wrapper.
+  /// Unlike [`project`] it does **not** scan for recovery holes up front — a hole inside the
+  /// subtree still refuses when the walk reaches it, but a hole elsewhere in the parse is not
+  /// this node's business.
+  pub fn to_ast<'src>(&self, source: &'src str) -> Out<Document<&'src str>> {
+    document(self.syntax(), source)
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// refusals
+// ---------------------------------------------------------------------------------------------
+
+/// Refuse a tree that carries any recovery hole or gap tile.
+///
+/// Scanned once over the whole parse rather than per node, so the answer does not depend on
+/// which nodes a particular walk happens to descend into: a hole anywhere is a region of the
+/// document with no AST image, and a projection that silently omitted it would be losing data
+/// under a success type.
+fn reject_holes(root: &SyntaxNode) -> Out<()> {
+  for node in root.descendants() {
+    if matches!(node.kind(), K::Error | K::Gap) {
+      let parent = node.parent().map_or_else(|| node.kind(), |p| p.kind());
+      return Err(ProjectError::new(
+        ProjectErrorKind::UnexpectedChild {
+          parent,
+          found: node.kind(),
+        },
+        to_range(node.text_range()),
+      ));
+    }
+  }
+  Ok(())
+}
+
+fn missing(parent: &SyntaxNode, wanted: &'static str) -> ProjectError {
+  ProjectError::new(
+    ProjectErrorKind::MissingChild {
+      parent: parent.kind(),
+      wanted,
+    },
+    to_range(parent.text_range()),
+  )
+}
+
+fn unexpected(parent: &SyntaxNode, found: SyntaxKind, at: TextRange) -> ProjectError {
+  ProjectError::new(
+    ProjectErrorKind::UnexpectedChild {
+      parent: parent.kind(),
+      found,
+    },
+    to_range(at),
+  )
+}
+
+fn unexpected_node(parent: &SyntaxNode, found: &SyntaxNode) -> ProjectError {
+  unexpected(parent, found.kind(), found.text_range())
+}
+
+// ---------------------------------------------------------------------------------------------
+// the substrate this dialect binds
+// ---------------------------------------------------------------------------------------------
+
+/// The six ignorable token images. The tree keeps them; no AST span may contain one.
+const fn is_trivia(kind: SyntaxKind) -> bool {
+  matches!(
+    kind,
+    K::Space | K::Tab | K::Newline | K::Comma | K::Comment | K::Bom
+  )
+}
+
+/// The token extent of `node`, as an AST span.
+fn extent(node: &SyntaxNode) -> Out<SimpleSpan> {
+  node_extent(node, is_trivia)
+    .map(to_span)
+    .ok_or_else(|| missing(node, "a token"))
+}
+
+/// The token extent of `node` with its leading description excluded.
+///
+/// The inner half of the description hoist — see the module header.
+fn extent_without_description(node: &SyntaxNode) -> Out<SimpleSpan> {
+  extent_of(
+    node
+      .children_with_tokens()
+      .filter(|element| !matches!(element, NodeOrToken::Node(n) if n.kind() == K::Description)),
+    is_trivia,
+  )
+  .map(to_span)
+  .ok_or_else(|| missing(node, "a constituent other than its description"))
+}
+
+fn child(node: &SyntaxNode, kind: SyntaxKind) -> Option<SyntaxNode> {
+  node.children().find(|child| child.kind() == kind)
+}
+
+fn require_child(node: &SyntaxNode, kind: SyntaxKind, wanted: &'static str) -> Out<SyntaxNode> {
+  child(node, kind).ok_or_else(|| missing(node, wanted))
+}
+
+/// This node's own direct `Name` tokens, in document order.
+///
+/// Direct children only: a name inside a child node belongs to that child, and a descendant
+/// scan would let a parent answer with it.
+fn name_tokens(node: &SyntaxNode) -> impl Iterator<Item = SyntaxToken> + '_ {
+  node
+    .children_with_tokens()
+    .filter_map(NodeOrToken::into_token)
+    .filter(|token| token.kind() == K::Name)
+}
+
+fn name_token_at(node: &SyntaxNode, index: usize, wanted: &'static str) -> Out<SyntaxToken> {
+  name_tokens(node)
+    .nth(index)
+    .ok_or_else(|| missing(node, wanted))
+}
+
+fn name<'src>(source: &'src str, token: &SyntaxToken) -> Out<Name<&'src str>> {
+  Ok(Name::new(
+    to_span(token.text_range()),
+    verify_slice(source, token)?,
+  ))
+}
+
+/// The `Name` of a node whose only content is one — `NamedType`, `EnumValue`, `Variable`.
+fn inner_name<'src>(node: &SyntaxNode, source: &'src str) -> Out<Name<&'src str>> {
+  let token = name_token_at(node, 0, "a name")?;
+  name(source, &token)
+}
+
+/// The keyword a `Name` token spells, classified through the lexer's own table.
+fn keyword_of(token: &SyntaxToken) -> Option<ContextualKeyword> {
+  contextual_keyword(token.text().as_bytes())
+}
+
+// ---------------------------------------------------------------------------------------------
+// document
+// ---------------------------------------------------------------------------------------------
+
+fn document<'src>(node: &SyntaxNode, source: &'src str) -> Out<Document<&'src str>> {
+  let span = extent(node)?;
+  let mut definitions = Vec::new();
+  for element in node.children_with_tokens() {
+    match element {
+      // Rubble: the lost-node recovery class drops a failed definition's bytes straight under
+      // the document, where the AST has no place for them.
+      NodeOrToken::Token(token) if !is_trivia(token.kind()) => {
+        return Err(unexpected(node, token.kind(), token.text_range()));
+      }
+      NodeOrToken::Token(_) => {}
+      NodeOrToken::Node(child) => definitions.push(document_entry(&child, source)?),
+    }
+  }
+  Ok(Document::new(span, definitions))
+}
+
+fn document_entry<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<DefinitionOrExtension<&'src str>> {
+  if let Some(extension) = type_system_extension(node, source)? {
+    return Ok(DefinitionOrExtension::Extension(extension));
+  }
+  let outer = extent(node)?;
+  let description = description(node, source)?;
+  let inner = extent_without_description(node)?;
+  let definition = definition(node, inner, source)?;
+  Ok(DefinitionOrExtension::Definition(Described::new(
+    outer,
+    description,
+    definition,
+  )))
+}
+
+fn definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<crate::parser::graphql::ast::Definition<&'src str>> {
+  use crate::parser::graphql::ast::Definition as D;
+
+  Ok(match node.kind() {
+    K::OperationDefinition => D::Executable(ExecutableDefinition::Operation(operation_definition(
+      node, span, source,
+    )?)),
+    K::FragmentDefinition => D::Executable(ExecutableDefinition::Fragment(fragment_definition(
+      node, span, source,
+    )?)),
+    K::ScalarTypeDefinition => D::TypeSystem(TypeSystemDefinition::Type(TypeDefinition::Scalar(
+      scalar_type_definition(node, span, source)?,
+    ))),
+    K::ObjectTypeDefinition => D::TypeSystem(TypeSystemDefinition::Type(TypeDefinition::Object(
+      object_type_definition(node, span, source)?,
+    ))),
+    K::InterfaceTypeDefinition => D::TypeSystem(TypeSystemDefinition::Type(
+      TypeDefinition::Interface(interface_type_definition(node, span, source)?),
+    )),
+    K::UnionTypeDefinition => D::TypeSystem(TypeSystemDefinition::Type(TypeDefinition::Union(
+      union_type_definition(node, span, source)?,
+    ))),
+    K::EnumTypeDefinition => D::TypeSystem(TypeSystemDefinition::Type(TypeDefinition::Enum(
+      enum_type_definition(node, span, source)?,
+    ))),
+    K::InputObjectTypeDefinition => D::TypeSystem(TypeSystemDefinition::Type(
+      TypeDefinition::InputObject(input_object_type_definition(node, span, source)?),
+    )),
+    K::DirectiveDefinition => D::TypeSystem(TypeSystemDefinition::Directive(directive_definition(
+      node, span, source,
+    )?)),
+    K::SchemaDefinition => D::TypeSystem(TypeSystemDefinition::Schema(schema_definition(
+      node, span, source,
+    )?)),
+    found => return Err(unexpected(node, found, node.text_range())),
+  })
+}
+
+/// `Some` when `node` is one of the seven extension kinds, `None` when it is anything else.
+///
+/// An extension carries no description — `extend` heads its own production — so this answers
+/// before the hoist rather than inside it.
+fn type_system_extension<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<TypeSystemExtension<&'src str>>> {
+  let span = |node: &SyntaxNode| extent(node);
+  Ok(Some(match node.kind() {
+    K::ScalarTypeExtension => TypeSystemExtension::Type(TypeExtension::Scalar(
+      scalar_type_extension(node, span(node)?, source)?,
+    )),
+    K::ObjectTypeExtension => TypeSystemExtension::Type(TypeExtension::Object(
+      object_type_extension(node, span(node)?, source)?,
+    )),
+    K::InterfaceTypeExtension => TypeSystemExtension::Type(TypeExtension::Interface(
+      interface_type_extension(node, span(node)?, source)?,
+    )),
+    K::UnionTypeExtension => TypeSystemExtension::Type(TypeExtension::Union(union_type_extension(
+      node,
+      span(node)?,
+      source,
+    )?)),
+    K::EnumTypeExtension => TypeSystemExtension::Type(TypeExtension::Enum(enum_type_extension(
+      node,
+      span(node)?,
+      source,
+    )?)),
+    K::InputObjectTypeExtension => TypeSystemExtension::Type(TypeExtension::InputObject(
+      input_object_type_extension(node, span(node)?, source)?,
+    )),
+    K::SchemaExtension => TypeSystemExtension::Schema(schema_extension(node, span(node)?, source)?),
+    _ => return Ok(None),
+  }))
+}
+
+// ---------------------------------------------------------------------------------------------
+// descriptions
+// ---------------------------------------------------------------------------------------------
+
+fn description<'src>(node: &SyntaxNode, source: &'src str) -> Out<Option<StringValue<&'src str>>> {
+  match child(node, K::Description) {
+    Some(description) => {
+      let token = description
+        .children_with_tokens()
+        .filter_map(NodeOrToken::into_token)
+        .find(|token| matches!(token.kind(), K::String | K::BlockString))
+        .ok_or_else(|| missing(&description, "a string token"))?;
+      Ok(Some(string_value(&token, source)?))
+    }
+    None => Ok(None),
+  }
+}
+
+/// Re-cook a string literal through the **same** door the lexer's payload comes from.
+///
+/// [`LitStr`]'s `TryFrom<&str>` is the string lexer, so the `Plain`/`Complex` discriminant and
+/// the `required_capacity` a consumer allocates against are the lexer's answers rather than a
+/// second implementation of the escape rules. A refusal here means the two disagree about bytes
+/// the lossless lexer already accepted, which is a lexer finding, not a projection one.
+fn string_value<'src>(token: &SyntaxToken, source: &'src str) -> Out<StringValue<&'src str>> {
+  let slice = verify_slice(source, token)?;
+  let lit = LitStr::try_from(slice).map_err(|_| {
+    ProjectError::new(
+      ProjectErrorKind::MalformedToken { kind: token.kind() },
+      to_range(token.text_range()),
+    )
+  })?;
+  Ok(StringValue::new(to_span(token.text_range()), lit))
+}
+
+// ---------------------------------------------------------------------------------------------
+// executable definitions
+// ---------------------------------------------------------------------------------------------
+
+fn operation_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<OperationDefinition<&'src str>> {
+  let selection_set_node = require_child(node, K::SelectionSet, "a selection set")?;
+  let selections = selection_set(&selection_set_node, source)?;
+
+  let Some(operation_type_node) = child(node, K::OperationType) else {
+    // Query shorthand: the definition *is* its selection set, and the AST's span for it is the
+    // selection set's own — which is why this arm ignores the caller's.
+    return Ok(OperationDefinition::Shorthand(selections));
+  };
+
+  let operation_type = operation_type(&operation_type_node, source)?;
+  let name = match name_tokens(node).next() {
+    Some(token) => Some(name(source, &token)?),
+    None => None,
+  };
+  let variables = match child(node, K::VariablesDefinition) {
+    Some(node) => Some(variables_definition(&node, source)?),
+    None => None,
+  };
+  let directives = optional_directives(node, source)?;
+
+  Ok(OperationDefinition::Named(NamedOperationDefinition::new(
+    span,
+    operation_type,
+    name,
+    variables,
+    directives,
+    selections,
+  )))
+}
+
+fn operation_type(node: &SyntaxNode, source: &str) -> Out<OperationType> {
+  let token = name_token_at(node, 0, "an operation keyword")?;
+  verify_slice(source, &token)?;
+  let span = to_span(token.text_range());
+  Ok(match keyword_of(&token) {
+    Some(ContextualKeyword::Query) => OperationType::Query(Query::new(span)),
+    Some(ContextualKeyword::Mutation) => OperationType::Mutation(Mutation::new(span)),
+    Some(ContextualKeyword::Subscription) => OperationType::Subscription(Subscription::new(span)),
+    _ => {
+      return Err(ProjectError::new(
+        ProjectErrorKind::MalformedToken { kind: token.kind() },
+        to_range(token.text_range()),
+      ));
+    }
+  })
+}
+
+fn variables_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<VariablesDefinition<&'src str>> {
+  let span = extent(node)?;
+  let mut definitions = Vec::new();
+  for child in node.children() {
+    match child.kind() {
+      K::VariableDefinition => definitions.push(variable_definition(&child, source)?),
+      _ => return Err(unexpected_node(node, &child)),
+    }
+  }
+  Ok(VariablesDefinition::new(span, definitions))
+}
+
+fn variable_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<DescribedVariableDefinition<&'src str>> {
+  let outer = extent(node)?;
+  let description = description(node, source)?;
+  // The one described node whose inner span excludes the description — see the module header.
+  let inner = extent_without_description(node)?;
+
+  let variable_node = require_child(node, K::Variable, "a variable")?;
+  let variable = variable_value(&variable_node, source)?;
+  let ty = require_type(node, source)?;
+  let default_value = optional_default_value(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+
+  Ok(Described::new(
+    outer,
+    description,
+    VariableDefinition::new(inner, variable, ty, default_value, directives),
+  ))
+}
+
+fn fragment_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<crate::parser::graphql::ast::FragmentDefinition<&'src str>> {
+  // `fragment` is the first `Name` token, the fragment's own name the second, `on` the third.
+  let name_token = name_token_at(node, 1, "a fragment name")?;
+  let name = fragment_name(&name_token, source)?;
+
+  let on_token = name_token_at(node, 2, "an `on` keyword")?;
+  verify_slice(source, &on_token)?;
+  let condition_node = require_child(node, K::NamedType, "a type condition")?;
+  let condition_name = inner_name(&condition_node, source)?;
+  let type_condition = TypeCondition::new(
+    SimpleSpan::new(
+      usize::from(on_token.text_range().start()),
+      condition_name.span().end(),
+    ),
+    condition_name,
+  );
+
+  let directives = optional_directives(node, source)?;
+  let selection_set_node = require_child(node, K::SelectionSet, "a selection set")?;
+  let selections = selection_set(&selection_set_node, source)?;
+
+  Ok(crate::parser::graphql::ast::FragmentDefinition::new(
+    span,
+    name,
+    type_condition,
+    directives,
+    selections,
+  ))
+}
+
+/// A fragment name, with the one semantic rule the tree records only as a diagnostic.
+///
+/// `FragmentName::new` is deliberately crate-private so the syntactic productions are the single
+/// place that establishes `Name but not on`. This is the second custodian, and it exists because
+/// the lossless productions record the violation on the diagnostic channel and still build the
+/// node — so the shape alone cannot tell a legal fragment name from an illegal one.
+fn fragment_name<'src>(token: &SyntaxToken, source: &'src str) -> Out<FragmentName<&'src str>> {
+  let slice = verify_slice(source, token)?;
+  if slice == "on" {
+    return Err(ProjectError::new(
+      ProjectErrorKind::SemanticRule {
+        rule: "a fragment may not be named `on`",
+      },
+      to_range(token.text_range()),
+    ));
+  }
+  Ok(FragmentName::new(to_span(token.text_range()), slice))
+}
+
+// ---------------------------------------------------------------------------------------------
+// selections
+// ---------------------------------------------------------------------------------------------
+
+fn selection_set<'src>(node: &SyntaxNode, source: &'src str) -> Out<SelectionSet<&'src str>> {
+  let span = extent(node)?;
+  let mut selections = Vec::new();
+  for child in node.children() {
+    selections.push(match child.kind() {
+      K::Field => Selection::Field(field(&child, source)?),
+      K::FragmentSpread => Selection::FragmentSpread(fragment_spread(&child, source)?),
+      K::InlineFragment => Selection::InlineFragment(inline_fragment(&child, source)?),
+      _ => return Err(unexpected_node(node, &child)),
+    });
+  }
+  Ok(SelectionSet::new(span, selections))
+}
+
+fn field<'src>(node: &SyntaxNode, source: &'src str) -> Out<Field<&'src str>> {
+  let span = extent(node)?;
+  let alias = match child(node, K::Alias) {
+    Some(alias_node) => Some(Alias::new(
+      // The alias node holds the `:`, and the AST's alias span holds it too.
+      extent(&alias_node)?,
+      inner_name(&alias_node, source)?,
+    )),
+    None => None,
+  };
+  // The alias's own `Name` lives inside the `Alias` node, so a direct scan answers the field's.
+  let name_token = name_token_at(node, 0, "a field name")?;
+  let name = name(source, &name_token)?;
+  let arguments = optional_arguments(node, source)?;
+  let directives = optional_directives(node, source)?;
+  let selections = match child(node, K::SelectionSet) {
+    Some(set) => Some(selection_set(&set, source)?),
+    None => None,
+  };
+  Ok(Field::new(
+    span, alias, name, arguments, directives, selections,
+  ))
+}
+
+fn fragment_spread<'src>(node: &SyntaxNode, source: &'src str) -> Out<FragmentSpread<&'src str>> {
+  let span = extent(node)?;
+  let name_token = name_token_at(node, 0, "a fragment name")?;
+  let name = fragment_name(&name_token, source)?;
+  let directives = optional_directives(node, source)?;
+  Ok(FragmentSpread::new(span, name, directives))
+}
+
+fn inline_fragment<'src>(node: &SyntaxNode, source: &'src str) -> Out<InlineFragment<&'src str>> {
+  let span = extent(node)?;
+  let type_condition = match child(node, K::NamedType) {
+    Some(condition_node) => {
+      let on_token = name_token_at(node, 0, "an `on` keyword")?;
+      verify_slice(source, &on_token)?;
+      let condition_name = inner_name(&condition_node, source)?;
+      Some(TypeCondition::new(
+        SimpleSpan::new(
+          usize::from(on_token.text_range().start()),
+          condition_name.span().end(),
+        ),
+        condition_name,
+      ))
+    }
+    None => None,
+  };
+  let directives = optional_directives(node, source)?;
+  let set = require_child(node, K::SelectionSet, "a selection set")?;
+  let selections = selection_set(&set, source)?;
+  Ok(InlineFragment::new(
+    span,
+    type_condition,
+    directives,
+    selections,
+  ))
+}
+
+// ---------------------------------------------------------------------------------------------
+// type references
+// ---------------------------------------------------------------------------------------------
+
+const TYPE_KINDS: [SyntaxKind; 3] = [K::NamedType, K::ListType, K::NonNullType];
+
+fn type_child(node: &SyntaxNode) -> Option<SyntaxNode> {
+  node
+    .children()
+    .find(|child| TYPE_KINDS.contains(&child.kind()))
+}
+
+fn require_type<'src>(node: &SyntaxNode, source: &'src str) -> Out<Type<Name<&'src str>>> {
+  let child = type_child(node).ok_or_else(|| missing(node, "a type reference"))?;
+  ty(&child, source)
+}
+
+/// The `!` folds into the node it wraps, exactly as the syntactic parser folds it.
+///
+/// A `NonNullType` has no AST image of its own: `T!` is a `NamedType` with `required` set, and
+/// its span is the extent that includes the `!`.
+fn ty<'src>(node: &SyntaxNode, source: &'src str) -> Out<Type<Name<&'src str>>> {
+  let span = extent(node)?;
+  match node.kind() {
+    K::NamedType => Ok(Type::Name(NamedType::new(
+      span,
+      inner_name(node, source)?,
+      false,
+    ))),
+    K::ListType => Ok(Type::List(Box::new(ListType::new(
+      span,
+      require_type(node, source)?,
+      false,
+    )))),
+    K::NonNullType => {
+      let inner = type_child(node).ok_or_else(|| missing(node, "a wrapped type"))?;
+      match inner.kind() {
+        K::NamedType => Ok(Type::Name(NamedType::new(
+          span,
+          inner_name(&inner, source)?,
+          true,
+        ))),
+        K::ListType => Ok(Type::List(Box::new(ListType::new(
+          span,
+          require_type(&inner, source)?,
+          true,
+        )))),
+        // `T!!` has no production, so a nested `NonNullType` is not a shape the AST can hold.
+        found => Err(unexpected(node, found, inner.text_range())),
+      }
+    }
+    found => Err(unexpected(node, found, node.text_range())),
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// directives and arguments
+// ---------------------------------------------------------------------------------------------
+
+/// The `Directives` node exists only where at least one directive was written, and the AST
+/// records an absent run as `None` — so the two agree without a zero-width placeholder.
+fn optional_directives<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<Directives<&'src str>>> {
+  match child(node, K::Directives) {
+    Some(run) => {
+      let span = extent(&run)?;
+      let mut directives = Vec::new();
+      for child in run.children() {
+        match child.kind() {
+          K::Directive => directives.push(directive(&child, source)?),
+          _ => return Err(unexpected_node(&run, &child)),
+        }
+      }
+      Ok(Some(Directives::new(span, directives)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn directive<'src>(node: &SyntaxNode, source: &'src str) -> Out<Directive<&'src str>> {
+  let span = extent(node)?;
+  let name_token = name_token_at(node, 0, "a directive name")?;
+  Ok(Directive::new(
+    span,
+    name(source, &name_token)?,
+    optional_arguments(node, source)?,
+  ))
+}
+
+fn optional_arguments<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<Arguments<&'src str>>> {
+  match child(node, K::Arguments) {
+    Some(list) => {
+      let span = extent(&list)?;
+      let mut arguments = Vec::new();
+      for child in list.children() {
+        match child.kind() {
+          K::Argument => arguments.push(argument(&child, source)?),
+          _ => return Err(unexpected_node(&list, &child)),
+        }
+      }
+      Ok(Some(Arguments::new(span, arguments)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn argument<'src>(node: &SyntaxNode, source: &'src str) -> Out<Argument<&'src str>> {
+  let span = extent(node)?;
+  let name_token = name_token_at(node, 0, "an argument name")?;
+  let value_node = require_value(node)?;
+  Ok(Argument::new(
+    span,
+    name(source, &name_token)?,
+    value(&value_node, source)?,
+  ))
+}
+
+fn optional_const_directives<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<ConstDirectives<&'src str>>> {
+  match child(node, K::Directives) {
+    Some(run) => {
+      let span = extent(&run)?;
+      let mut directives = Vec::new();
+      for child in run.children() {
+        match child.kind() {
+          K::Directive => directives.push(const_directive(&child, source)?),
+          _ => return Err(unexpected_node(&run, &child)),
+        }
+      }
+      Ok(Some(ConstDirectives::new(span, directives)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn const_directive<'src>(node: &SyntaxNode, source: &'src str) -> Out<ConstDirective<&'src str>> {
+  let span = extent(node)?;
+  let name_token = name_token_at(node, 0, "a directive name")?;
+  Ok(ConstDirective::new(
+    span,
+    name(source, &name_token)?,
+    optional_const_arguments(node, source)?,
+  ))
+}
+
+fn optional_const_arguments<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<ConstArguments<&'src str>>> {
+  match child(node, K::Arguments) {
+    Some(list) => {
+      let span = extent(&list)?;
+      let mut arguments = Vec::new();
+      for child in list.children() {
+        match child.kind() {
+          K::Argument => arguments.push(const_argument(&child, source)?),
+          _ => return Err(unexpected_node(&list, &child)),
+        }
+      }
+      Ok(Some(ConstArguments::new(span, arguments)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn const_argument<'src>(node: &SyntaxNode, source: &'src str) -> Out<ConstArgument<&'src str>> {
+  let span = extent(node)?;
+  let name_token = name_token_at(node, 0, "an argument name")?;
+  let value_node = require_value(node)?;
+  Ok(ConstArgument::new(
+    span,
+    name(source, &name_token)?,
+    const_value(&value_node, source)?,
+  ))
+}
+
+// ---------------------------------------------------------------------------------------------
+// values
+// ---------------------------------------------------------------------------------------------
+
+const VALUE_KINDS: [SyntaxKind; 9] = [
+  K::Variable,
+  K::IntValue,
+  K::FloatValue,
+  K::StringValue,
+  K::BooleanValue,
+  K::NullValue,
+  K::EnumValue,
+  K::ListValue,
+  K::ObjectValue,
+];
+
+fn require_value(node: &SyntaxNode) -> Out<SyntaxNode> {
+  node
+    .children()
+    .find(|child| VALUE_KINDS.contains(&child.kind()))
+    .ok_or_else(|| missing(node, "a value"))
+}
+
+fn value<'src>(node: &SyntaxNode, source: &'src str) -> Out<InputValue<&'src str>> {
+  let span = extent(node)?;
+  Ok(match node.kind() {
+    K::Variable => InputValue::Variable(variable_value(node, source)?),
+    K::IntValue => InputValue::Int(IntValue::new(
+      span,
+      literal_slice(node, source, &[K::Int], "an integer literal")?,
+    )),
+    K::FloatValue => InputValue::Float(FloatValue::new(
+      span,
+      literal_slice(node, source, &[K::Float], "a float literal")?,
+    )),
+    K::StringValue => InputValue::String(string_literal(node, source)?),
+    K::BooleanValue => InputValue::Boolean(boolean_literal(node, source)?),
+    K::NullValue => InputValue::Null(NullValue::new(
+      span,
+      literal_slice(node, source, &[K::Name], "a `null` keyword")?,
+    )),
+    K::EnumValue => InputValue::Enum(EnumValue::new(
+      span,
+      literal_slice(node, source, &[K::Name], "an enum value")?,
+    )),
+    K::ListValue => {
+      let mut values = Vec::new();
+      for child in node.children() {
+        values.push(value(&child, source)?);
+      }
+      InputValue::List(List::new(span, values))
+    }
+    K::ObjectValue => {
+      let mut fields = Vec::new();
+      for child in node.children() {
+        match child.kind() {
+          K::ObjectField => fields.push(object_field(&child, source)?),
+          _ => return Err(unexpected_node(node, &child)),
+        }
+      }
+      InputValue::Object(Object::new(span, fields))
+    }
+    found => return Err(unexpected(node, found, node.text_range())),
+  })
+}
+
+/// A constant value position, where the AST's own type system forbids a variable.
+///
+/// [`ConstInputValue`] has no `Variable` variant, so the refusal is not a policy this module
+/// invented: there is nothing to construct.
+fn const_value<'src>(node: &SyntaxNode, source: &'src str) -> Out<ConstInputValue<&'src str>> {
+  let span = extent(node)?;
+  Ok(match node.kind() {
+    // The refusal is attributed to the position, not to the variable: a `Variable` node is
+    // perfectly legal, and what is wrong is the const context that is holding one.
+    K::Variable => {
+      let parent = node.parent();
+      return Err(unexpected(
+        parent.as_ref().unwrap_or(node),
+        K::Variable,
+        node.text_range(),
+      ));
+    }
+    K::IntValue => ConstInputValue::Int(IntValue::new(
+      span,
+      literal_slice(node, source, &[K::Int], "an integer literal")?,
+    )),
+    K::FloatValue => ConstInputValue::Float(FloatValue::new(
+      span,
+      literal_slice(node, source, &[K::Float], "a float literal")?,
+    )),
+    K::StringValue => ConstInputValue::String(string_literal(node, source)?),
+    K::BooleanValue => ConstInputValue::Boolean(boolean_literal(node, source)?),
+    K::NullValue => ConstInputValue::Null(NullValue::new(
+      span,
+      literal_slice(node, source, &[K::Name], "a `null` keyword")?,
+    )),
+    K::EnumValue => ConstInputValue::Enum(EnumValue::new(
+      span,
+      literal_slice(node, source, &[K::Name], "an enum value")?,
+    )),
+    K::ListValue => {
+      let mut values = Vec::new();
+      for child in node.children() {
+        values.push(const_value(&child, source)?);
+      }
+      ConstInputValue::List(ConstList::new(span, values))
+    }
+    K::ObjectValue => {
+      let mut fields = Vec::new();
+      for child in node.children() {
+        match child.kind() {
+          K::ObjectField => fields.push(const_object_field(&child, source)?),
+          _ => return Err(unexpected_node(node, &child)),
+        }
+      }
+      ConstInputValue::Object(ConstObject::new(span, fields))
+    }
+    found => return Err(unexpected(node, found, node.text_range())),
+  })
+}
+
+fn literal_slice<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+  kinds: &[SyntaxKind],
+  wanted: &'static str,
+) -> Out<&'src str> {
+  let token = node
+    .children_with_tokens()
+    .filter_map(NodeOrToken::into_token)
+    .find(|token| kinds.contains(&token.kind()))
+    .ok_or_else(|| missing(node, wanted))?;
+  verify_slice(source, &token)
+}
+
+fn string_literal<'src>(node: &SyntaxNode, source: &'src str) -> Out<StringValue<&'src str>> {
+  let token = node
+    .children_with_tokens()
+    .filter_map(NodeOrToken::into_token)
+    .find(|token| matches!(token.kind(), K::String | K::BlockString))
+    .ok_or_else(|| missing(node, "a string literal"))?;
+  string_value(&token, source)
+}
+
+fn boolean_literal<'src>(node: &SyntaxNode, source: &'src str) -> Out<BooleanValue<&'src str>> {
+  let span = extent(node)?;
+  let slice = literal_slice(node, source, &[K::Name], "a `true` or `false` keyword")?;
+  match slice {
+    "true" => Ok(BooleanValue::new(span, true)),
+    "false" => Ok(BooleanValue::new(span, false)),
+    _ => Err(ProjectError::new(
+      ProjectErrorKind::MalformedToken { kind: K::Name },
+      to_range(node.text_range()),
+    )),
+  }
+}
+
+fn variable_value<'src>(node: &SyntaxNode, source: &'src str) -> Out<VariableValue<&'src str>> {
+  let span = extent(node)?;
+  Ok(VariableValue::new(span, inner_name(node, source)?))
+}
+
+fn object_field<'src>(node: &SyntaxNode, source: &'src str) -> Out<ObjectField<&'src str>> {
+  let span = extent(node)?;
+  let name_token = name_token_at(node, 0, "a field name")?;
+  let value_node = require_value(node)?;
+  Ok(ObjectField::new(
+    span,
+    name(source, &name_token)?,
+    value(&value_node, source)?,
+  ))
+}
+
+fn const_object_field<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<ConstObjectField<&'src str>> {
+  let span = extent(node)?;
+  let name_token = name_token_at(node, 0, "a field name")?;
+  let value_node = require_value(node)?;
+  Ok(ConstObjectField::new(
+    span,
+    name(source, &name_token)?,
+    const_value(&value_node, source)?,
+  ))
+}
+
+fn optional_default_value<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<DefaultInputValue<&'src str>>> {
+  match child(node, K::DefaultValue) {
+    Some(default) => {
+      // The span covers the `=` and the value, which is the node's own token extent.
+      let span = extent(&default)?;
+      let value_node = require_value(&default)?;
+      Ok(Some(DefaultInputValue::new(
+        span,
+        const_value(&value_node, source)?,
+      )))
+    }
+    None => Ok(None),
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// SDL definitions
+// ---------------------------------------------------------------------------------------------
+
+/// The name behind a definition's keyword: `scalar S`, `type T`, `directive @d` all reach it at
+/// index 1 among the node's direct `Name` tokens, the keyword being index 0.
+fn keyword_named<'src>(node: &SyntaxNode, source: &'src str) -> Out<Name<&'src str>> {
+  let token = name_token_at(node, 1, "a name after the keyword")?;
+  name(source, &token)
+}
+
+/// An extension's name is its **third** `Name`: `extend`, the shape keyword, then the name.
+fn extension_named<'src>(node: &SyntaxNode, source: &'src str) -> Out<Name<&'src str>> {
+  let token = name_token_at(node, 2, "an extended type's name")?;
+  name(source, &token)
+}
+
+fn optional_implements<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<ImplementInterfaces<Name<&'src str>>>> {
+  match child(node, K::ImplementsInterfaces) {
+    Some(clause) => {
+      let span = extent(&clause)?;
+      let mut interfaces = Vec::new();
+      for child in clause.children() {
+        match child.kind() {
+          // The AST holds `Name`s, not `NamedType`s: an implemented interface can carry no `!`
+          // and no brackets, so the type-reference level would be a wrapper over nothing.
+          K::NamedType => interfaces.push(inner_name(&child, source)?),
+          _ => return Err(unexpected_node(&clause, &child)),
+        }
+      }
+      Ok(Some(ImplementInterfaces::new(span, interfaces)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn optional_union_members<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<UnionMemberTypes<Name<&'src str>>>> {
+  match child(node, K::UnionMemberTypes) {
+    Some(clause) => {
+      let span = extent(&clause)?;
+      let mut members = Vec::new();
+      for child in clause.children() {
+        match child.kind() {
+          K::NamedType => members.push(inner_name(&child, source)?),
+          _ => return Err(unexpected_node(&clause, &child)),
+        }
+      }
+      Ok(Some(UnionMemberTypes::new(span, members)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn optional_fields_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<FieldsDefinition<&'src str>>> {
+  match child(node, K::FieldsDefinition) {
+    Some(block) => {
+      let span = extent(&block)?;
+      let mut fields = Vec::new();
+      for child in block.children() {
+        match child.kind() {
+          K::FieldDefinition => fields.push(field_definition(&child, source)?),
+          _ => return Err(unexpected_node(&block, &child)),
+        }
+      }
+      Ok(Some(FieldsDefinition::new(span, fields)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn field_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<crate::parser::graphql::ast::FieldDefinition<&'src str>> {
+  // One span for both halves, description included — trunk's rule for this node, see the header.
+  let span = extent(node)?;
+  let description = description(node, source)?;
+  let name_token = name_token_at(node, 0, "a field name")?;
+  let arguments_definition = optional_arguments_definition(node, source)?;
+  let ty = require_type(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  Ok(Described::new(
+    span,
+    description,
+    FieldDefinition::new(
+      span,
+      name(source, &name_token)?,
+      arguments_definition,
+      ty,
+      directives,
+    ),
+  ))
+}
+
+fn optional_arguments_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<crate::parser::graphql::ast::ArgumentsDefinition<&'src str>>> {
+  match child(node, K::ArgumentsDefinition) {
+    Some(block) => {
+      let span = extent(&block)?;
+      let mut definitions = Vec::new();
+      for child in block.children() {
+        match child.kind() {
+          K::InputValueDefinition => definitions.push(input_value_definition(&child, source)?),
+          _ => return Err(unexpected_node(&block, &child)),
+        }
+      }
+      Ok(Some(ArgumentsDefinition::new(span, definitions)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn input_value_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<crate::parser::graphql::ast::InputValueDefinition<&'src str>> {
+  let span = extent(node)?;
+  let description = description(node, source)?;
+  let name_token = name_token_at(node, 0, "an input value name")?;
+  let ty = require_type(node, source)?;
+  let default_value = optional_default_value(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  Ok(Described::new(
+    span,
+    description,
+    InputValueDefinition::new(
+      span,
+      name(source, &name_token)?,
+      ty,
+      default_value,
+      directives,
+    ),
+  ))
+}
+
+fn optional_input_fields_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<InputFieldsDefinition<&'src str>>> {
+  match child(node, K::InputFieldsDefinition) {
+    Some(block) => {
+      let span = extent(&block)?;
+      let mut definitions = Vec::new();
+      for child in block.children() {
+        match child.kind() {
+          K::InputValueDefinition => definitions.push(input_value_definition(&child, source)?),
+          _ => return Err(unexpected_node(&block, &child)),
+        }
+      }
+      Ok(Some(InputFieldsDefinition::new(span, definitions)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn optional_enum_values<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<Option<EnumValuesDefinition<&'src str>>> {
+  match child(node, K::EnumValuesDefinition) {
+    Some(block) => {
+      let span = extent(&block)?;
+      let mut values = Vec::new();
+      for child in block.children() {
+        match child.kind() {
+          K::EnumValueDefinition => values.push(enum_value_definition(&child, source)?),
+          _ => return Err(unexpected_node(&block, &child)),
+        }
+      }
+      Ok(Some(EnumValuesDefinition::new(span, values)))
+    }
+    None => Ok(None),
+  }
+}
+
+fn enum_value_definition<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<crate::parser::graphql::ast::EnumValueDefinition<&'src str>> {
+  let span = extent(node)?;
+  let description = description(node, source)?;
+  // The value's name lives inside the `EnumValue` node the tree opens for it, but the AST holds
+  // a bare `Name` — the enum-value level has nothing else to carry.
+  let value_node = require_child(node, K::EnumValue, "an enum value")?;
+  let value = inner_name(&value_node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  Ok(Described::new(
+    span,
+    description,
+    EnumValueDefinition::new(span, value, directives),
+  ))
+}
+
+fn scalar_type_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<ScalarTypeDefinition<&'src str>> {
+  Ok(ScalarTypeDefinition::new(
+    span,
+    keyword_named(node, source)?,
+    optional_const_directives(node, source)?,
+  ))
+}
+
+fn object_type_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<ObjectTypeDefinition<&'src str>> {
+  Ok(ObjectTypeDefinition::new(
+    span,
+    keyword_named(node, source)?,
+    optional_implements(node, source)?,
+    optional_const_directives(node, source)?,
+    optional_fields_definition(node, source)?,
+  ))
+}
+
+fn interface_type_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<InterfaceTypeDefinition<&'src str>> {
+  Ok(InterfaceTypeDefinition::new(
+    span,
+    keyword_named(node, source)?,
+    optional_implements(node, source)?,
+    optional_const_directives(node, source)?,
+    optional_fields_definition(node, source)?,
+  ))
+}
+
+fn union_type_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<UnionTypeDefinition<&'src str>> {
+  Ok(UnionTypeDefinition::new(
+    span,
+    keyword_named(node, source)?,
+    optional_const_directives(node, source)?,
+    optional_union_members(node, source)?,
+  ))
+}
+
+fn enum_type_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<EnumTypeDefinition<&'src str>> {
+  Ok(EnumTypeDefinition::new(
+    span,
+    keyword_named(node, source)?,
+    optional_const_directives(node, source)?,
+    optional_enum_values(node, source)?,
+  ))
+}
+
+fn input_object_type_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<InputObjectTypeDefinition<&'src str>> {
+  Ok(InputObjectTypeDefinition::new(
+    span,
+    keyword_named(node, source)?,
+    optional_const_directives(node, source)?,
+    optional_input_fields_definition(node, source)?,
+  ))
+}
+
+fn directive_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<crate::parser::graphql::ast::DirectiveDefinition<&'src str>> {
+  let name = keyword_named(node, source)?;
+  let arguments_definition = optional_arguments_definition(node, source)?;
+  // `repeatable` is optional and `on` is not, so the token at index 2 is one or the other. The
+  // spelling is read rather than the count: an index that only counted would answer `on`.
+  let repeatable = name_tokens(node)
+    .nth(2)
+    .is_some_and(|token| keyword_of(&token) == Some(ContextualKeyword::Repeatable));
+  let locations_node = require_child(node, K::DirectiveLocations, "a location list")?;
+  let locations = directive_locations(&locations_node, source)?;
+  Ok(DirectiveDefinition::new(
+    span,
+    name,
+    arguments_definition,
+    repeatable,
+    locations,
+  ))
+}
+
+fn directive_locations(node: &SyntaxNode, source: &str) -> Out<DirectiveLocations<Location>> {
+  let span = extent(node)?;
+  let mut locations = Vec::new();
+  for token in name_tokens(node) {
+    verify_slice(source, &token)?;
+    let location = keyword_of(&token)
+      .and_then(|keyword| classify_location(keyword, to_span(token.text_range())))
+      .ok_or_else(|| {
+        ProjectError::new(
+          ProjectErrorKind::MalformedToken { kind: token.kind() },
+          to_range(token.text_range()),
+        )
+      })?;
+    locations.push(location);
+  }
+  if locations.is_empty() {
+    return Err(missing(node, "a directive location"));
+  }
+  Ok(DirectiveLocations::new(span, locations))
+}
+
+fn schema_definition<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<SchemaDefinition<&'src str>> {
+  let directives = optional_const_directives(node, source)?;
+  let roots_node = require_child(
+    node,
+    K::RootOperationTypeDefinitions,
+    "a root operation types block",
+  )?;
+  Ok(SchemaDefinition::new(
+    span,
+    directives,
+    root_operation_types(&roots_node, source)?,
+  ))
+}
+
+fn root_operation_types<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<RootOperationTypesDefinition<&'src str>> {
+  let span = extent(node)?;
+  let mut roots = Vec::new();
+  for child in node.children() {
+    match child.kind() {
+      K::RootOperationTypeDefinition => roots.push(root_operation_type(&child, source)?),
+      _ => return Err(unexpected_node(node, &child)),
+    }
+  }
+  Ok(RootOperationTypesDefinition::new(span, roots))
+}
+
+fn root_operation_type<'src>(
+  node: &SyntaxNode,
+  source: &'src str,
+) -> Out<RootOperationTypeDefinition<&'src str>> {
+  let span = extent(node)?;
+  let keyword_node = require_child(node, K::OperationType, "an operation keyword")?;
+  let operation_type = operation_type(&keyword_node, source)?;
+  let named = require_child(node, K::NamedType, "a root type name")?;
+  Ok(RootOperationTypeDefinition::new(
+    span,
+    operation_type,
+    inner_name(&named, source)?,
+  ))
+}
+
+// ---------------------------------------------------------------------------------------------
+// SDL extensions
+// ---------------------------------------------------------------------------------------------
+
+fn scalar_type_extension<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<ScalarTypeExtension<&'src str>> {
+  let name = extension_named(node, source)?;
+  // The one extension whose directives the grammar makes mandatory: it has no other tail.
+  let directives = optional_const_directives(node, source)?
+    .ok_or_else(|| missing(node, "the directives a scalar extension must add"))?;
+  Ok(ScalarTypeExtension::new(span, name, directives))
+}
+
+fn object_type_extension<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<ObjectTypeExtension<&'src str>> {
+  let name = extension_named(node, source)?;
+  let implements = optional_implements(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  let fields_definition = optional_fields_definition(node, source)?;
+  let data = match (implements, directives, fields_definition) {
+    (implements, directives, Some(fields_definition)) => ObjectTypeExtensionData::Fields {
+      implements,
+      directives,
+      fields_definition,
+    },
+    (implements, Some(directives), None) => ObjectTypeExtensionData::Directives {
+      implements,
+      directives,
+    },
+    (Some(implements), None, None) => ObjectTypeExtensionData::Implements(implements),
+    (None, None, None) => {
+      return Err(missing(
+        node,
+        "interfaces, directives or fields for the extension to add",
+      ));
+    }
+  };
+  Ok(ObjectTypeExtension::new(span, name, data))
+}
+
+fn interface_type_extension<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<InterfaceTypeExtension<&'src str>> {
+  let name = extension_named(node, source)?;
+  let implements = optional_implements(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  let fields_definition = optional_fields_definition(node, source)?;
+  let data = match (implements, directives, fields_definition) {
+    (implements, directives, Some(fields_definition)) => InterfaceTypeExtensionData::Fields {
+      implements,
+      directives,
+      fields_definition,
+    },
+    (implements, Some(directives), None) => InterfaceTypeExtensionData::Directives {
+      implements,
+      directives,
+    },
+    (Some(implements), None, None) => InterfaceTypeExtensionData::Implements(implements),
+    (None, None, None) => {
+      return Err(missing(
+        node,
+        "interfaces, directives or fields for the extension to add",
+      ));
+    }
+  };
+  Ok(InterfaceTypeExtension::new(span, name, data))
+}
+
+fn union_type_extension<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<UnionTypeExtension<&'src str>> {
+  let name = extension_named(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  let member_types = optional_union_members(node, source)?;
+  let data = match (directives, member_types) {
+    (directives, Some(member_types)) => UnionTypeExtensionData::Members {
+      directives,
+      member_types,
+    },
+    (Some(directives), None) => UnionTypeExtensionData::Directives(directives),
+    (None, None) => {
+      return Err(missing(
+        node,
+        "directives or members for the extension to add",
+      ));
+    }
+  };
+  Ok(UnionTypeExtension::new(span, name, data))
+}
+
+fn enum_type_extension<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<EnumTypeExtension<&'src str>> {
+  let name = extension_named(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  let enum_values_definition = optional_enum_values(node, source)?;
+  let data = match (directives, enum_values_definition) {
+    (directives, Some(enum_values_definition)) => EnumTypeExtensionData::Values {
+      directives,
+      enum_values_definition,
+    },
+    (Some(directives), None) => EnumTypeExtensionData::Directives(directives),
+    (None, None) => {
+      return Err(missing(
+        node,
+        "directives or values for the extension to add",
+      ));
+    }
+  };
+  Ok(EnumTypeExtension::new(span, name, data))
+}
+
+fn input_object_type_extension<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<InputObjectTypeExtension<&'src str>> {
+  let name = extension_named(node, source)?;
+  let directives = optional_const_directives(node, source)?;
+  let fields_definition = optional_input_fields_definition(node, source)?;
+  let data = match (directives, fields_definition) {
+    (directives, Some(fields_definition)) => InputObjectTypeExtensionData::Fields {
+      directives,
+      fields_definition,
+    },
+    (Some(directives), None) => InputObjectTypeExtensionData::Directives(directives),
+    (None, None) => {
+      return Err(missing(
+        node,
+        "directives or fields for the extension to add",
+      ));
+    }
+  };
+  Ok(InputObjectTypeExtension::new(span, name, data))
+}
+
+fn schema_extension<'src>(
+  node: &SyntaxNode,
+  span: SimpleSpan,
+  source: &'src str,
+) -> Out<SchemaExtension<&'src str>> {
+  let directives = optional_const_directives(node, source)?;
+  let roots = match child(node, K::RootOperationTypeDefinitions) {
+    Some(block) => Some(root_operation_types(&block, source)?),
+    None => None,
+  };
+  let data = match (directives, roots) {
+    (directives, Some(root_operation_types_definition)) => SchemaExtensionData::Operations {
+      directives,
+      root_operation_types_definition,
+    },
+    (Some(directives), None) => SchemaExtensionData::Directives(directives),
+    (None, None) => {
+      return Err(missing(
+        node,
+        "directives or root operation types for the extension to add",
+      ));
+    }
+  };
+  Ok(SchemaExtension::new(span, data))
+}

--- a/smear/src/parser/graphql/syntactic/definition/directive.rs
+++ b/smear/src/parser/graphql/syntactic/definition/directive.rs
@@ -2,8 +2,13 @@
 
 use super::*;
 
+/// Maps a location keyword onto its [`Location`], or `None` when the keyword names none.
+///
+/// `pub(crate)` rather than private since #58: the CST-to-AST projection has to answer the same
+/// question off a tree token, and a second copy of this nineteen-arm table is a place the two
+/// layers could disagree about what `INPUT_FIELD_DEFINITION` means.
 #[inline]
-fn classify_location(keyword: ContextualKeyword, span: SimpleSpan) -> Option<Location> {
+pub(crate) fn classify_location(keyword: ContextualKeyword, span: SimpleSpan) -> Option<Location> {
   Some(match keyword {
     ContextualKeyword::QueryLocation => ExecutableDirectiveLocation::query(span).into(),
     ContextualKeyword::MutationLocation => ExecutableDirectiveLocation::mutation(span).into(),

--- a/smear/src/parser/graphql/syntactic/definition/mod.rs
+++ b/smear/src/parser/graphql/syntactic/definition/mod.rs
@@ -214,6 +214,7 @@ pub use input_object::{
 };
 
 mod directive;
+pub(crate) use directive::classify_location;
 pub use directive::{directive_definition, directive_locations, location};
 
 mod schema;

--- a/smear/src/parser/lossless/mod.rs
+++ b/smear/src/parser/lossless/mod.rs
@@ -40,6 +40,8 @@ pub mod coverage;
 #[cfg(any(feature = "graphql", feature = "graphqlx"))]
 mod macros;
 
+pub mod project;
+
 pub mod recover;
 
 pub mod runner;

--- a/smear/src/parser/lossless/project.rs
+++ b/smear/src/parser/lossless/project.rs
@@ -1,0 +1,229 @@
+//! The dialect-free substrate for the CST → AST projection.
+//!
+//! # What a projection is, and why one exists
+//!
+//! A consumer that parsed **losslessly** holds a rowan tree: every byte, every comment, every
+//! comma. A consumer that parsed **syntactically** holds an AST: no trivia, cooked literals,
+//! typed nodes. An editor needs the first (to format, to highlight, to edit incrementally) and
+//! a validator needs the second (issue #85 consumes `ast::ExecutableDocument` directly and
+//! deliberately rejected a shared view trait). A projection is the door between them, so the
+//! IDE path does not have to parse the same bytes twice.
+//!
+//! This module owns everything about that door which is independent of a grammar: the error
+//! type, the span arithmetic, and the slice check. Everything that names a node kind, a
+//! wrapper or an AST target lives in a dialect's own `lossless::project`.
+//!
+//! # The span rule, in one sentence
+//!
+//! **A composite node's span is the extent of the tokens it contains** — its first token's
+//! start to its last token's end, trivia excluded at both ends. That is the syntactic parser's
+//! own rule since #72 (`tests/syntactic_span_extent.rs` pins it over the padded corpus), so a
+//! projection that folds token extents lands on the same numbers the parser does, and the
+//! differential gate compares with plain `==`.
+//!
+//! It is emphatically **not** [`rowan::SyntaxNode::text_range`]. A CST node's range is the
+//! extent of everything committed *inside* it, trivia included: for `"type T  { f : Int }"`
+//! the tree's `FieldDefinition` runs `12..20` — it holds the space after `Int` — where the
+//! AST's is `12..19`. The document node is worse: its range covers the file's leading and
+//! trailing trivia, which no AST span ever does. [`node_extent`] is the correction, and it is
+//! the only span door a projection should use.
+
+use core::{fmt, ops::Range};
+
+use rowan::{Language, SyntaxElement, SyntaxNode, SyntaxToken, TextRange};
+use tokora::SimpleSpan;
+
+/// Why a projection refused.
+///
+/// Positioned, single, and fail-fast. The projection is **not** a diagnostics channel: the
+/// parse's own diagnostics already exist on `Parse`, and a second, subtly different set would
+/// drift from them by construction. One typed refusal, at the first obstruction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ProjectErrorKind<K> {
+  /// A constituent the AST shape requires is absent from the tree.
+  ///
+  /// The recovered-in-place class: `type T { x: }` keeps its `FieldDefinition` node and hangs
+  /// an `Error` hole where the type should be, so the node exists and its type does not.
+  MissingChild {
+    /// The node kind that is missing a constituent.
+    parent: K,
+    /// What was wanted, in the grammar's vocabulary.
+    wanted: &'static str,
+  },
+  /// An element the AST shape has no place for.
+  ///
+  /// Three sources, all real: a recovery hole or gap tile anywhere the projection walks; the
+  /// rubble a failed definition leaves as bare children of the document; and a `Variable` in a
+  /// constant position, which the AST's own type system forbids (`ConstInputValue` has no
+  /// `Variable` variant).
+  UnexpectedChild {
+    /// The node kind whose children were being read.
+    parent: K,
+    /// The kind that has no place there.
+    found: K,
+  },
+  /// A token was present but would not cook.
+  ///
+  /// Today this is reachable only for string literals, which are re-lexed through the same
+  /// `impl TryFrom<&str> for LitStr` door the syntactic lexer's payload comes from. An
+  /// internal-inconsistency class: the lossless lexer already accepted these bytes.
+  MalformedToken {
+    /// The token kind that refused.
+    kind: K,
+  },
+  /// `source` is not the text this tree was parsed from.
+  ///
+  /// Every slice the projection takes is compared against the token's own text before it is
+  /// handed to a constructor, so a mismatched pair is refused rather than silently projected
+  /// into a wrong AST.
+  SourceMismatch,
+  /// A grammar rule the tree records only as a diagnostic.
+  ///
+  /// Today exactly one: a fragment may not be named `on`. The lossless productions record that
+  /// as an error diagnostic and still build the node, so the shape alone cannot tell the two
+  /// apart and the projection re-checks it — the second in-crate custodian of the invariant
+  /// `FragmentName::new` is kept crate-private to protect.
+  SemanticRule {
+    /// The rule, named for a human.
+    rule: &'static str,
+  },
+}
+
+/// A projection refusal, with the byte range of the element that caused it.
+///
+/// `span` uses the same `Range<usize>` vocabulary as `Diagnostic::span`, so a consumer routing
+/// a refusal into an editor's diagnostic channel does not have to convert.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProjectError<K> {
+  kind: ProjectErrorKind<K>,
+  span: Range<usize>,
+}
+
+impl<K> ProjectError<K> {
+  /// Builds a refusal at `span`.
+  #[inline]
+  pub const fn new(kind: ProjectErrorKind<K>, span: Range<usize>) -> Self {
+    Self { kind, span }
+  }
+
+  /// Why the projection refused.
+  #[inline]
+  pub const fn kind(&self) -> &ProjectErrorKind<K> {
+    &self.kind
+  }
+
+  /// The byte range of the obstructing element.
+  #[inline]
+  pub const fn span(&self) -> &Range<usize> {
+    &self.span
+  }
+}
+
+impl<K: fmt::Debug> fmt::Display for ProjectError<K> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let Range { start, end } = self.span;
+    match &self.kind {
+      ProjectErrorKind::MissingChild { parent, wanted } => write!(
+        f,
+        "{start}..{end}: {parent:?} has no {wanted}, so no AST node can be built for it"
+      ),
+      ProjectErrorKind::UnexpectedChild { parent, found } => write!(
+        f,
+        "{start}..{end}: {found:?} has no place inside {parent:?}"
+      ),
+      ProjectErrorKind::MalformedToken { kind } => write!(
+        f,
+        "{start}..{end}: the {kind:?} token did not cook, though the lossless lexer accepted it"
+      ),
+      ProjectErrorKind::SourceMismatch => write!(
+        f,
+        "{start}..{end}: the source text is not what this tree was parsed from"
+      ),
+      ProjectErrorKind::SemanticRule { rule } => write!(f, "{start}..{end}: {rule}"),
+    }
+  }
+}
+
+impl<K: fmt::Debug> core::error::Error for ProjectError<K> {}
+
+/// [`TextRange`] as the AST's span type.
+#[inline]
+pub fn to_span(range: TextRange) -> SimpleSpan {
+  SimpleSpan::new(usize::from(range.start()), usize::from(range.end()))
+}
+
+/// [`TextRange`] as the error vocabulary's byte range.
+#[inline]
+pub fn to_range(range: TextRange) -> Range<usize> {
+  usize::from(range.start())..usize::from(range.end())
+}
+
+/// The token extent of `node` — its first non-trivia token's start to its last one's end.
+///
+/// `None` when the subtree holds no non-trivia token at all, which for a node the grammar
+/// requires to have content is itself a finding and is why this returns an `Option` rather
+/// than falling back on [`SyntaxNode::text_range`].
+///
+/// See this module's header for why the node's own range is the wrong answer.
+#[inline]
+pub fn node_extent<L: Language>(
+  node: &SyntaxNode<L>,
+  is_trivia: impl Fn(L::Kind) -> bool + Copy,
+) -> Option<TextRange> {
+  extent_of(node.children_with_tokens(), is_trivia)
+}
+
+/// The token extent of a run of elements, descending into every node it contains.
+///
+/// The general form [`node_extent`] is written in terms of. A projection that has to exclude
+/// one constituent — the description a definition node holds but the AST hoists out — folds
+/// the filtered child stream through here rather than reaching for the node's range.
+pub fn extent_of<L: Language, I>(
+  elements: I,
+  is_trivia: impl Fn(L::Kind) -> bool + Copy,
+) -> Option<TextRange>
+where
+  I: IntoIterator<Item = SyntaxElement<L>>,
+{
+  let mut extent: Option<TextRange> = None;
+  for element in elements {
+    let piece = match element {
+      SyntaxElement::Token(token) => {
+        if is_trivia(token.kind()) {
+          continue;
+        }
+        Some(token.text_range())
+      }
+      SyntaxElement::Node(node) => node_extent(&node, is_trivia),
+    };
+    if let Some(piece) = piece {
+      extent = Some(match extent {
+        // `cover` rather than `start..piece.end()`: a fold that assumed document order would
+        // produce an inverted range the moment it was handed a stream that was not in it, and
+        // an inverted span is exactly the class `tests/support/span_extent.rs` exists to catch.
+        Some(seen) => seen.cover(piece),
+        None => piece,
+      });
+    }
+  }
+  extent
+}
+
+/// The source text under `token`, checked against the token's own text.
+///
+/// The `(tree, source)` pair is a **caller** obligation — rowan's cursors cannot lend `&str`s
+/// that outlive them, so the AST's slices must come from the caller's buffer — and this is
+/// where that obligation is verified rather than trusted. The cost is a `memcmp` over bytes
+/// the projection was going to copy a pointer to anyway; the alternative is a silently wrong
+/// AST whose spans point into unrelated text.
+pub fn verify_slice<'src, L: Language>(
+  source: &'src str,
+  token: &SyntaxToken<L>,
+) -> Result<&'src str, ProjectError<L::Kind>> {
+  let range = token.text_range();
+  source
+    .get(usize::from(range.start())..usize::from(range.end()))
+    .filter(|slice| *slice == token.text())
+    .ok_or_else(|| ProjectError::new(ProjectErrorKind::SourceMismatch, to_range(range)))
+}

--- a/smear/src/parser/selection.rs
+++ b/smear/src/parser/selection.rs
@@ -17,7 +17,7 @@ use tokora::{
 };
 
 /// A field alias (`Name :`).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Alias<Name, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -83,7 +83,7 @@ impl<Name, Span> IntoComponents for Alias<Name, Span> {
 }
 
 /// A fragment type condition (`on NamedType`).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct TypeCondition<Name, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -133,7 +133,7 @@ impl<Name, Span> IntoComponents for TypeCondition<Name, Span> {
 }
 
 /// A named fragment spread (`... FragmentName Directives?`).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct FragmentSpread<FragmentName, Directives, Span = SimpleSpan> {
   span: Span,
   name: FragmentName,
@@ -200,7 +200,7 @@ impl<FragmentName, Directives, Span> IntoComponents
 }
 
 /// An inline fragment (`... TypeCondition? Directives? SelectionSet`).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct InlineFragment<TypeCondition, Directives, SelectionSet, Span = SimpleSpan> {
   span: Span,
   type_condition: Option<TypeCondition>,
@@ -292,7 +292,7 @@ impl<TypeCondition, Directives, SelectionSet, Span> IntoComponents
 }
 
 /// A nonempty GraphQL selection-set collection.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct SelectionSet<Selection, Span = SimpleSpan, Container = Vec<Selection>> {
   span: Span,
   selections: Container,
@@ -356,7 +356,7 @@ impl<Selection, Span, Container> IntoComponents for SelectionSet<Selection, Span
 }
 
 /// A field (`Alias? Name Arguments? Directives? SelectionSet?`).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Field<Alias, Name, Arguments, Directives, SelectionSet, Span = SimpleSpan> {
   span: Span,
   alias: Option<Alias>,

--- a/smear/src/parser/ty.rs
+++ b/smear/src/parser/ty.rs
@@ -24,7 +24,7 @@ use crate::parser::path::Path;
 /// `graphql`-gated, so under `graphql` alone there is no item in scope to resolve against at all.
 /// A link here is a hard error under `RUSTDOCFLAGS="-D warnings"`, in both configurations.
 #[cfg(feature = "graphql")]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct NamedType<Name, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -89,7 +89,7 @@ impl<Name, Span> NamedType<Name, Span> {
 }
 
 /// A list type reference with an optional non-null modifier.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ListType<Type, Span = SimpleSpan> {
   span: Span,
   ty: Type,
@@ -147,7 +147,7 @@ impl<Type, Span> ListType<Type, Span> {
 
 /// A GraphQLx set type reference with an optional non-null modifier.
 #[cfg(feature = "graphqlx")]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct SetType<Type, Span = SimpleSpan> {
   span: Span,
   ty: Type,
@@ -209,7 +209,7 @@ impl<Type, Span> IntoComponents for SetType<Type, Span> {
 
 /// A GraphQLx map type reference with an optional non-null modifier.
 #[cfg(feature = "graphqlx")]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct MapType<Key, Value, Span = SimpleSpan> {
   span: Span,
   key: Key,

--- a/smear/src/parser/type_system.rs
+++ b/smear/src/parser/type_system.rs
@@ -43,7 +43,7 @@ macro_rules! impl_node_traits {
 }
 
 /// A definition of the arguments accepted by a field or directive.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ArgumentsDefinition<InputValue, Container = Vec<InputValue>, Span = SimpleSpan> {
   span: Span,
   input_value_definitions: Container,
@@ -90,7 +90,7 @@ impl<InputValue, Container, Span> ArgumentsDefinition<InputValue, Container, Spa
 }
 
 /// An input value definition used by a field, directive, or input object.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct InputValueDefinition<Name, Type, DefaultValue, Directives, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -158,7 +158,7 @@ impl<Name, Type, DefaultValue, Directives, Span>
 }
 
 /// A braced collection of input value definitions.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct InputFieldsDefinition<InputValue, Container = Vec<InputValue>, Span = SimpleSpan> {
   span: Span,
   input_value_definitions: Container,
@@ -205,7 +205,7 @@ impl<InputValue, Container, Span> InputFieldsDefinition<InputValue, Container, S
 }
 
 /// A field definition in an object or interface type.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct FieldDefinition<Name, Arguments, Type, Directives, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -273,7 +273,7 @@ impl<Name, Arguments, Type, Directives, Span>
 }
 
 /// A braced collection of field definitions.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct FieldsDefinition<Field, Container = Vec<Field>, Span = SimpleSpan> {
   span: Span,
   field_definitions: Container,
@@ -320,7 +320,7 @@ impl<Field, Container, Span> FieldsDefinition<Field, Container, Span> {
 }
 
 /// A list of interfaces implemented by an object or interface type.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ImplementInterfaces<Name, Container = Vec<Name>, Span = SimpleSpan> {
   span: Span,
   interfaces: Container,
@@ -367,7 +367,7 @@ impl<Name, Container, Span> ImplementInterfaces<Name, Container, Span> {
 }
 
 /// An interface type definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct InterfaceTypeDefinition<Name, Implements, Directives, Fields, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -435,7 +435,7 @@ impl<Name, Implements, Directives, Fields, Span>
 }
 
 /// A scalar type definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ScalarTypeDefinition<Name, Directives, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -479,7 +479,7 @@ impl<Name, Directives, Span> ScalarTypeDefinition<Name, Directives, Span> {
 }
 
 /// A root operation type definition in a schema definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct RootOperationTypeDefinition<Name, OperationType, Span = SimpleSpan> {
   span: Span,
   operation_type: OperationType,
@@ -523,7 +523,7 @@ impl<Name, OperationType, Span> RootOperationTypeDefinition<Name, OperationType,
 }
 
 /// A braced collection of root operation type definitions.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct RootOperationTypesDefinition<
   RootOperation,
   Container = Vec<RootOperation>,
@@ -574,7 +574,7 @@ impl<RootOperation, Container, Span> RootOperationTypesDefinition<RootOperation,
 }
 
 /// An enum value definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct EnumValueDefinition<EnumValue, Directives, Span = SimpleSpan> {
   span: Span,
   value: EnumValue,
@@ -618,7 +618,7 @@ impl<EnumValue, Directives, Span> EnumValueDefinition<EnumValue, Directives, Spa
 }
 
 /// A braced collection of enum value definitions.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct EnumValuesDefinition<EnumValue, Container = Vec<EnumValue>, Span = SimpleSpan> {
   span: Span,
   enum_value_definitions: Container,
@@ -665,7 +665,7 @@ impl<EnumValue, Container, Span> EnumValuesDefinition<EnumValue, Container, Span
 }
 
 /// An enum type definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct EnumTypeDefinition<Name, Directives, EnumValues, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -722,7 +722,7 @@ impl<Name, Directives, EnumValues, Span> EnumTypeDefinition<Name, Directives, En
 }
 
 /// An object type definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ObjectTypeDefinition<Name, Implements, Directives, Fields, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -790,7 +790,7 @@ impl<Name, Implements, Directives, Fields, Span>
 }
 
 /// A list of named union member types.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct UnionMemberTypes<Name, Container = Vec<Name>, Span = SimpleSpan> {
   span: Span,
   members: Container,
@@ -837,7 +837,7 @@ impl<Name, Container, Span> UnionMemberTypes<Name, Container, Span> {
 }
 
 /// A union type definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct UnionTypeDefinition<Name, Directives, MemberTypes, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -1324,7 +1324,7 @@ impl<Span> core::fmt::Display for Location<Span> {
 }
 
 /// A collection of directive locations.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct DirectiveLocations<
   DirectiveLocation,
   Container = Vec<DirectiveLocation>,
@@ -1375,7 +1375,7 @@ impl<DirectiveLocation, Container, Span> DirectiveLocations<DirectiveLocation, C
 }
 
 /// A directive definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct DirectiveDefinition<Name, Arguments, Locations, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -1441,7 +1441,7 @@ impl<Name, Arguments, Locations, Span> DirectiveDefinition<Name, Arguments, Loca
 }
 
 /// A schema definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct SchemaDefinition<Directives, RootOperations, Span = SimpleSpan> {
   span: Span,
   directives: Option<Directives>,
@@ -1489,7 +1489,7 @@ impl<Directives, RootOperations, Span> SchemaDefinition<Directives, RootOperatio
 }
 
 /// An input object type definition.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct InputObjectTypeDefinition<Name, Directives, Fields, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -1548,7 +1548,7 @@ impl<Name, Directives, Fields, Span> InputObjectTypeDefinition<Name, Directives,
 /// The payload contributed by an object or interface type extension.
 ///
 /// Each variant represents one of GraphQL's legal nonempty extension forms.
-#[derive(Debug, Clone, Copy, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IsVariant)]
 pub enum ObjectTypeExtensionData<Implements, Directives, Fields> {
   /// Adds one or more implemented interfaces only.
   Implements(Implements),
@@ -1605,7 +1605,7 @@ impl<Implements, Directives, Fields> ObjectTypeExtensionData<Implements, Directi
 /// An object type extension (`extend type Name …`).
 ///
 /// See the [GraphQL Object Type Extension specification](https://spec.graphql.org/draft/#ObjectTypeExtension).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ObjectTypeExtension<Name, Implements, Directives, Fields, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -1671,7 +1671,7 @@ impl<Name, Implements, Directives, Fields, Span>
 /// The payload contributed by an interface type extension.
 ///
 /// Each variant represents one of GraphQL's legal nonempty extension forms.
-#[derive(Debug, Clone, Copy, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IsVariant)]
 pub enum InterfaceTypeExtensionData<Implements, Directives, Fields> {
   /// Adds one or more implemented interfaces only.
   Implements(Implements),
@@ -1728,7 +1728,7 @@ impl<Implements, Directives, Fields> InterfaceTypeExtensionData<Implements, Dire
 /// An interface type extension (`extend interface Name …`).
 ///
 /// See the [GraphQL Interface Type Extension specification](https://spec.graphql.org/draft/#InterfaceTypeExtension).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct InterfaceTypeExtension<Name, Implements, Directives, Fields, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -1792,7 +1792,7 @@ impl<Name, Implements, Directives, Fields, Span>
 }
 
 /// The payload contributed by a union type extension.
-#[derive(Debug, Clone, Copy, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IsVariant)]
 pub enum UnionTypeExtensionData<Directives, MemberTypes> {
   /// Adds directives only.
   Directives(Directives),
@@ -1828,7 +1828,7 @@ impl<Directives, MemberTypes> UnionTypeExtensionData<Directives, MemberTypes> {
 /// A union type extension (`extend union Name …`).
 ///
 /// See the [GraphQL Union Type Extension specification](https://spec.graphql.org/draft/#UnionTypeExtension).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct UnionTypeExtension<Name, Directives, MemberTypes, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -1884,7 +1884,7 @@ impl<Name, Directives, MemberTypes, Span> UnionTypeExtension<Name, Directives, M
 }
 
 /// The payload contributed by an enum type extension.
-#[derive(Debug, Clone, Copy, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IsVariant)]
 pub enum EnumTypeExtensionData<Directives, Values> {
   /// Adds directives only.
   Directives(Directives),
@@ -1923,7 +1923,7 @@ impl<Directives, Values> EnumTypeExtensionData<Directives, Values> {
 /// An enum type extension (`extend enum Name …`).
 ///
 /// See the [GraphQL Enum Type Extension specification](https://spec.graphql.org/draft/#EnumTypeExtension).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct EnumTypeExtension<Name, Directives, Values, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -1979,7 +1979,7 @@ impl<Name, Directives, Values, Span> EnumTypeExtension<Name, Directives, Values,
 }
 
 /// The payload contributed by an input object type extension.
-#[derive(Debug, Clone, Copy, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IsVariant)]
 pub enum InputObjectTypeExtensionData<Directives, Fields> {
   /// Adds directives only.
   Directives(Directives),
@@ -2017,7 +2017,7 @@ impl<Directives, Fields> InputObjectTypeExtensionData<Directives, Fields> {
 /// An input object type extension (`extend input Name …`).
 ///
 /// See the [GraphQL Input Object Type Extension specification](https://spec.graphql.org/draft/#InputObjectTypeExtension).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct InputObjectTypeExtension<Name, Directives, Fields, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -2073,7 +2073,7 @@ impl<Name, Directives, Fields, Span> InputObjectTypeExtension<Name, Directives, 
 }
 
 /// The payload contributed by a schema extension.
-#[derive(Debug, Clone, Copy, IsVariant)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, IsVariant)]
 pub enum SchemaExtensionData<Directives, RootOperations> {
   /// Adds directives only.
   Directives(Directives),
@@ -2112,7 +2112,7 @@ impl<Directives, RootOperations> SchemaExtensionData<Directives, RootOperations>
 /// A schema extension (`extend schema …`).
 ///
 /// See the [GraphQL Schema Extension specification](https://spec.graphql.org/draft/#SchemaExtension).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct SchemaExtension<Directives, RootOperations, Span = SimpleSpan> {
   span: Span,
   data: SchemaExtensionData<Directives, RootOperations>,
@@ -2159,7 +2159,7 @@ impl<Directives, RootOperations, Span> SchemaExtension<Directives, RootOperation
 /// A scalar type extension (`extend scalar Name Directives`).
 ///
 /// See the [GraphQL Scalar Type Extension specification](https://spec.graphql.org/draft/#ScalarTypeExtension).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ScalarTypeExtension<Name, Directives, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -2203,7 +2203,7 @@ impl<Name, Directives, Span> ScalarTypeExtension<Name, Directives, Span> {
 }
 
 /// One of GraphQL's six named type extension shapes.
-#[derive(Debug, Clone, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum TypeExtension<
@@ -2337,7 +2337,7 @@ where
 }
 
 /// A type-system definition: named type, directive, or schema.
-#[derive(Debug, Clone, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum TypeSystemDefinition<TypeDefinition, DirectiveDefinition, SchemaDefinition> {
@@ -2399,7 +2399,7 @@ impl<TypeDefinition, DirectiveDefinition, SchemaDefinition>
 }
 
 /// A type-system extension: named type or schema.
-#[derive(Debug, Clone, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum TypeSystemExtension<TypeExtension, SchemaExtension> {
@@ -2452,7 +2452,7 @@ impl<TypeExtension, SchemaExtension> TypeSystemExtension<TypeExtension, SchemaEx
 }
 
 /// Either a described type-system definition or a type-system extension.
-#[derive(Debug, Clone, IsVariant, TryUnwrap, Unwrap)]
+#[derive(Debug, Clone, PartialEq, Eq, IsVariant, TryUnwrap, Unwrap)]
 #[unwrap(ref, ref_mut)]
 #[try_unwrap(ref, ref_mut)]
 pub enum TypeSystemDefinitionOrExtension<Definition, Extension> {

--- a/smear/src/parser/value/default_input_value.rs
+++ b/smear/src/parser/value/default_input_value.rs
@@ -5,7 +5,7 @@ use tokora::{
 };
 
 /// A default input value assignment.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct DefaultInputValue<Value, Span = SimpleSpan> {
   span: Span,
   value: Value,

--- a/smear/src/parser/value/list.rs
+++ b/smear/src/parser/value/list.rs
@@ -8,7 +8,7 @@ use tokora::{
 };
 
 /// A list value with its enclosing source span.
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct List<Value, Span = SimpleSpan, Container = Vec<Value>> {
   span: Span,
   values: Container,

--- a/smear/src/parser/value/map.rs
+++ b/smear/src/parser/value/map.rs
@@ -64,7 +64,7 @@ impl<Key, Value, Span> IntoComponents for MapEntry<Key, Value, Span> {
 }
 
 /// A GraphQLx map value with its enclosing source span.
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Map<Key, Value, Span = SimpleSpan, Container = Vec<MapEntry<Key, Value, Span>>> {
   span: Span,
   entries: Container,

--- a/smear/src/parser/value/object.rs
+++ b/smear/src/parser/value/object.rs
@@ -8,7 +8,7 @@ use tokora::{
 };
 
 /// A named field in an input object value.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ObjectField<Name, Value, Span = SimpleSpan> {
   span: Span,
   name: Name,
@@ -65,7 +65,7 @@ impl<Name, Value, Span> IntoComponents for ObjectField<Name, Value, Span> {
 }
 
 /// An input object value with its enclosing source span.
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Object<Name, Value, Span = SimpleSpan, Container = Vec<ObjectField<Name, Value, Span>>> {
   span: Span,
   fields: Container,

--- a/smear/src/parser/value/set.rs
+++ b/smear/src/parser/value/set.rs
@@ -7,7 +7,7 @@ use tokora::{
 };
 
 /// A GraphQLx set value with its enclosing source span.
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Set<Value, Span = SimpleSpan, Container = Vec<Value>> {
   span: Span,
   values: Container,

--- a/smear/tests/lossless_isolation.rs
+++ b/smear/tests/lossless_isolation.rs
@@ -199,6 +199,15 @@ fn the_two_lossless_layers_do_not_reference_each_other() {
 /// does NOT do is let a dialect reach the *other* dialect's lexer through it —
 /// [`FORBIDDEN`]'s `graphql::kinds` / `graphql::lossless` spellings are substring patterns and
 /// match `crate::lexer::graphql::lossless::…` exactly as they matched `smear_lexer::graphql::…`.
+///
+/// `crate::parser::type_system` is #58's entry, and it is on the GraphQL side only because that
+/// is the only dialect with a projection so far. The projection's **target** is the AST, and the
+/// AST's carriers are shared and dialect-free in exactly the way `crate::parser::lossless` is —
+/// this census is about a dialect reaching the *other dialect*, which a shared carrier is not.
+/// The narrow reason it is needed at all: three `Described<…>` aliases and six `…Data` extension
+/// enums have no spelling under `graphql::ast`, and a projection has to construct all nine. Every
+/// other AST type it builds is reached through the dialect's own `ast` module, which is why this
+/// is one root and not eight.
 const ALLOWED_CRATE_ROOTS: &[(&str, &[&str])] = &[
   (
     GRAPHQL,
@@ -207,6 +216,7 @@ const ALLOWED_CRATE_ROOTS: &[(&str, &[&str])] = &[
       "crate::lexer",
       "crate::parser::graphql",
       "crate::parser::lossless",
+      "crate::parser::type_system",
     ],
   ),
   (

--- a/smear/tests/lossless_project.rs
+++ b/smear/tests/lossless_project.rs
@@ -1,0 +1,958 @@
+#![cfg(all(feature = "graphql", feature = "rowan"))]
+
+//! The differential gate for the GraphQL CST → AST projection (issue #58).
+//!
+//! # The claim, and the instrument
+//!
+//! `project(parse_document(src), src) == document(src)` — the projection of a lossless parse is
+//! **the same AST value** the syntactic parser builds for the same bytes. Not "the same shape",
+//! not "the same modulo spans": the derived [`PartialEq`] this issue added across the AST
+//! closure compares every span, every slice, every literal payload, every `Option` presence and
+//! every container order, so the assertion is `assert_eq!` and nothing is discounted.
+//!
+//! # Why plain `==`, and why that is news
+//!
+//! The design for this work (issue #58's comment, written against trunk at `69fd677`) could not
+//! state it that way. It measured the syntactic AST's composite spans as **lookahead artifacts**
+//! — `NamedType` closing at the *next* token's start, the document node opening before its
+//! leading trivia — and worked around them by defining projected spans as normatively
+//! token-extent and comparing through a `normalise_spans` pass, with a self-retirement clause
+//! for the day the parser converged.
+//!
+//! **That day was #72.** It rewrote composite span computation across 44 node types and added
+//! `tests/syntactic_span_extent.rs`, which pins "a composite node's span is the extent of the
+//! tokens it contains" over the same corpus this gate reads, padded with the same eight trivia
+//! forms. Re-measured here on trunk: over `"  type T  { f : Int }  "` the parser now answers
+//! `Document 2..21`, `NamedType 16..19`, `FieldDefinition 12..19` — token extents, all three,
+//! where the design recorded `0..21`, `16..20`, `12..20`.
+//!
+//! So the normaliser is not written. There is no span-normalisation pass in this file, no drift
+//! ledger and no self-retirement test, because there is no residue for them to measure. What
+//! replaces them is [`the_span_rule_the_normaliser_would_have_hidden`], which pins the three
+//! re-measured numbers directly: if composite spans ever drift back off their token extents,
+//! that test names the node and the offset instead of a wall of `assert_eq!` diffs.
+//!
+//! # The three ways a gate like this passes without meaning anything
+//!
+//! 1. **Equality that ignores what matters.** If `PartialEq` compared shapes only, every
+//!    assertion below would hold over a projection that got every span wrong.
+//!    [`the_equality_can_answer_no`] feeds it a document shifted one byte, and a second document
+//!    with the same shape and a different name, and requires both to compare unequal.
+//! 2. **A projection that re-parses the text.** `tree.text() == source` always holds, so
+//!    `|parse, src| syntactic_document(src)` would satisfy every corpus assertion here — it
+//!    would be a re-parse wearing the projection's signature.
+//!    [`a_projection_that_re_parsed_the_source_would_fail_this`] builds a **synthetic green
+//!    tree** whose text re-parses to a different structure and requires the projection to answer
+//!    from the structure it was handed. A tree walk passes; a re-parse cannot.
+//! 3. **Error paths nobody reaches.** [`every_refusal_kind_has_a_witness`] requires each
+//!    [`ProjectErrorKind`] variant to be produced by at least one pinned input, so no refusal
+//!    ships unreachable.
+//!
+//! # The corpus, twice
+//!
+//! Every `valid_` entry in `tests/corpus/`, compact and then padded at every token boundary with
+//! each of `tests/support/span_extent.rs`'s eight ignorable forms — the same corpus and the same
+//! alphabet `lossless_trivia.rs` and `syntactic_span_extent.rs` read. The padded half is not
+//! decoration: on compact input a projection that used [`rowan::SyntaxNode::text_range`] instead
+//! of the token extent would agree with the parser everywhere, because with no trivia the two
+//! rules coincide. Interior trivia is the only material on which that bug can red.
+
+use std::{
+  collections::BTreeSet,
+  path::{Path, PathBuf},
+};
+
+use rowan::{GreenNodeBuilder, Language};
+use smear::parser::{
+  graphql::{
+    GraphQL,
+    ast::Document,
+    error::GraphqlErrors,
+    kinds::{GraphQLLang, SyntaxKind as K},
+    lossless::{
+      ProjectErrorKind, SyntaxNode, ast::Document as DocumentNode, parse_document, project,
+    },
+    syntactic::{GraphqlLexer, document},
+  },
+  lossless::ast::CastNode,
+};
+use tokora::{Parse as _, Parser};
+
+// The span-extent support module, shared with `syntactic_span_extent.rs`. This gate reads only
+// its alphabet, its injector and its `Debug` walk — the four-part checker and the discriminating
+// classifier are that gate's business — so the unused half would be four `dead_code` denials
+// under CI's `-Dwarnings`. Allowed at the include rather than at each item, which would edit a
+// file two other gates own.
+#[allow(dead_code)]
+#[path = "support/span_extent.rs"]
+mod extent;
+
+use extent::{ALPHABET, inject};
+
+/// The smallest number of `valid_` entries this gate is allowed to compare.
+///
+/// The measurement on the day it was written, as a floor. A corpus that shrank below it is a
+/// gate that stopped covering what it claims to.
+const VALID_ENTRY_FLOOR: usize = 56;
+
+/// The smallest number of `invalid_` entries the refusal census runs.
+const INVALID_ENTRY_FLOOR: usize = 31;
+
+/// The smallest number of distinct AST node types the compared documents reach.
+///
+/// Read off the syntactic parse's `Debug` rendering — the same total projection
+/// `tests/support/span_extent.rs` walks — so a corpus that stopped reaching the extensions, or
+/// the value family, is a floor failure rather than a silent narrowing.
+const OWNER_FLOOR: usize = 60;
+
+// ---------------------------------------------------------------------------------------------
+// harnesses
+// ---------------------------------------------------------------------------------------------
+
+/// The syntactic oracle: the shipped, fail-fast document root, exactly as `lossless_parity.rs`
+/// and `syntactic_span_extent.rs` drive it.
+fn oracle(src: &str) -> Result<Document<&str>, GraphqlErrors<&str>> {
+  Parser::with_parser::<'_, GraphqlLexer<'_, str>, Document<&str>, GraphqlErrors<&str>, _, GraphQL>(
+    document,
+  )
+  .parse_str(src)
+}
+
+fn corpus(prefix: &str) -> Vec<(String, String)> {
+  let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    .join("tests")
+    .join("corpus");
+  let mut files: Vec<PathBuf> = std::fs::read_dir(&dir)
+    .unwrap_or_else(|e| panic!("the shared corpus at {} is unreadable: {e}", dir.display()))
+    .map(|entry| entry.expect("a corpus directory entry").path())
+    .filter(|path| path.extension().is_some_and(|ext| ext == "graphql"))
+    .filter(|path| {
+      path
+        .file_name()
+        .is_some_and(|name| name.to_string_lossy().starts_with(prefix))
+    })
+    .collect();
+  files.sort();
+  files.into_iter().map(read_entry).collect()
+}
+
+fn read_entry(path: PathBuf) -> (String, String) {
+  let name = path
+    .file_name()
+    .expect("a corpus entry has a file name")
+    .to_string_lossy()
+    .to_string();
+  let src = std::fs::read_to_string(&path)
+    .unwrap_or_else(|e| panic!("{} is unreadable: {e}", Path::display(&path)));
+  (name, src)
+}
+
+/// Every token boundary in `src`: offset 0, then the end of each lossless token.
+///
+/// Derived from the **tree**, not from a second lexer instantiation, because every entry padded
+/// here has already been parsed losslessly by the caller and the tree's token ends are the same
+/// offsets by construction.
+fn boundaries(src: &str) -> Vec<usize> {
+  let parse = parse_document(src);
+  let mut out = vec![0usize];
+  for element in parse.syntax().descendants_with_tokens() {
+    if let Some(token) = element.into_token() {
+      out.push(usize::from(token.text_range().end()));
+    }
+  }
+  out.sort_unstable();
+  out.dedup();
+  out
+}
+
+/// Every node type named in a `Debug` rendering, as `tests/support/span_extent.rs` reads them.
+fn owners(dump: &str) -> BTreeSet<String> {
+  extent::owners(&extent::spans_of(dump))
+}
+
+// ---------------------------------------------------------------------------------------------
+// the core assertion
+// ---------------------------------------------------------------------------------------------
+
+#[test]
+fn the_projection_equals_the_parse_over_the_shared_corpus() {
+  let entries = corpus("valid_");
+  assert!(
+    entries.len() >= VALID_ENTRY_FLOOR,
+    "only {} valid corpus entries, floor is {VALID_ENTRY_FLOOR}",
+    entries.len()
+  );
+
+  let mut compared = 0usize;
+  let mut padded_compared = 0usize;
+  let mut reached: BTreeSet<String> = BTreeSet::new();
+
+  for (name, src) in &entries {
+    let marks = boundaries(src);
+    assert!(
+      marks.len() >= 3,
+      "{name}: {} token boundaries — a one-token entry cannot exercise an interior junction",
+      marks.len()
+    );
+
+    for (form, source) in std::iter::once(("compact", src.clone())).chain(
+      ALPHABET
+        .iter()
+        .map(|(form, pad)| (*form, inject(src, &marks, pad))),
+    ) {
+      let expected = oracle(&source).unwrap_or_else(|e| {
+        panic!("{name} ({form}): the syntactic parser rejects a valid corpus entry: {e:?}")
+      });
+      let parse = parse_document(&source);
+      assert!(
+        !parse.has_errors(),
+        "{name} ({form}): the lossless parser rejects a valid corpus entry"
+      );
+      let projected = project(&parse, &source)
+        .unwrap_or_else(|e| panic!("{name} ({form}): the projection refused: {e}"));
+
+      assert_eq!(
+        projected, expected,
+        "{name} ({form}): the projection is not the AST the parser builds for the same bytes"
+      );
+
+      reached.extend(owners(&format!("{expected:#?}")));
+      compared += 1;
+      if form != "compact" {
+        padded_compared += 1;
+      }
+    }
+  }
+
+  assert_eq!(
+    compared,
+    entries.len() * (ALPHABET.len() + 1),
+    "the sweep did not run every form over every entry"
+  );
+  assert_eq!(
+    padded_compared,
+    entries.len() * ALPHABET.len(),
+    "the padded half did not run every form over every entry"
+  );
+  assert!(
+    reached.len() >= OWNER_FLOOR,
+    "the compared documents reach only {} node types, floor is {OWNER_FLOOR}: {reached:?}",
+    reached.len()
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// control 1 — the equality can answer no
+// ---------------------------------------------------------------------------------------------
+
+#[test]
+fn the_equality_can_answer_no() {
+  let compact = "type T{f:Int}";
+  let shifted = " type T{f:Int}";
+
+  let a = project(&parse_document(compact), compact).expect("projects");
+  let b = project(&parse_document(shifted), shifted).expect("projects");
+  assert_ne!(
+    a, b,
+    "the same document one byte later compares equal, so the derived PartialEq is not reading \
+     spans and every assertion in this file is discounted by exactly that much"
+  );
+
+  // Same shape, one different name: the slice half of the same control.
+  let renamed = "type U{f:Int}";
+  let c = project(&parse_document(renamed), renamed).expect("projects");
+  assert_ne!(
+    a, c,
+    "two documents differing only in a type name compare equal, so slices are not being compared"
+  );
+
+  // And a positive leg, so the control is not passing merely because everything is unequal.
+  let again = project(&parse_document(compact), compact).expect("projects");
+  assert_eq!(a, again, "the projection is not deterministic");
+}
+
+// ---------------------------------------------------------------------------------------------
+// control 2 — the fraud model
+// ---------------------------------------------------------------------------------------------
+
+/// Build a green tree by hand, so the projection is handed a structure that does **not** match
+/// the structure its own text would parse to.
+struct Tree {
+  builder: GreenNodeBuilder<'static>,
+}
+
+impl Tree {
+  fn new() -> Self {
+    Self {
+      builder: GreenNodeBuilder::new(),
+    }
+  }
+
+  fn open(&mut self, kind: K) -> &mut Self {
+    self.builder.start_node(GraphQLLang::kind_to_raw(kind));
+    self
+  }
+
+  fn close(&mut self) -> &mut Self {
+    self.builder.finish_node();
+    self
+  }
+
+  fn token(&mut self, kind: K, text: &str) -> &mut Self {
+    self.builder.token(GraphQLLang::kind_to_raw(kind), text);
+    self
+  }
+
+  fn finish(self) -> SyntaxNode {
+    SyntaxNode::new_root(self.builder.finish())
+  }
+}
+
+/// Two definitions' worth of text, in **one** definition node.
+///
+/// The text is `type T{f:Int} type U{g:Int}`, which the parser splits into two definitions. This
+/// tree says there is one, and the projection has to believe the tree. A tree walk answers one
+/// definition named `T`; anything that re-derived the structure from the bytes answers two.
+fn two_definitions_in_one_node() -> (SyntaxNode, &'static str) {
+  let text = "type T{f:Int} type U{g:Int}";
+  let mut tree = Tree::new();
+  tree.open(K::Document);
+  tree.open(K::ObjectTypeDefinition);
+  tree.token(K::Name, "type").token(K::Space, " ");
+  tree.token(K::Name, "T");
+  tree.open(K::FieldsDefinition);
+  tree.token(K::LBrace, "{");
+  tree.open(K::FieldDefinition);
+  tree.token(K::Name, "f").token(K::Colon, ":");
+  tree.open(K::NamedType).token(K::Name, "Int").close();
+  tree.close();
+  tree.token(K::RBrace, "}");
+  tree.close();
+  tree.token(K::Space, " ");
+  // The second definition's tokens, swallowed by the first node.
+  tree.token(K::Name, "type").token(K::Space, " ");
+  tree.token(K::Name, "U");
+  tree.open(K::FieldsDefinition);
+  tree.token(K::LBrace, "{");
+  tree.open(K::FieldDefinition);
+  tree.token(K::Name, "g").token(K::Colon, ":");
+  tree.open(K::NamedType).token(K::Name, "Int").close();
+  tree.close();
+  tree.token(K::RBrace, "}");
+  tree.close();
+  tree.close();
+  tree.close();
+  (tree.finish(), text)
+}
+
+/// The described-probe shape, with the description hung as a **sibling** of the definition
+/// rather than as its child.
+///
+/// Its text is `"d" type T{f:Int}`, which the parser attaches — producing
+/// `Described { description: Some(_), … }`. Under this tree the description is loose under the
+/// document, which is rubble the walk has no place for.
+fn description_as_sibling() -> (SyntaxNode, &'static str) {
+  let text = "\"d\" type T{f:Int}";
+  let mut tree = Tree::new();
+  tree.open(K::Document);
+  tree.open(K::Description).token(K::String, "\"d\"").close();
+  tree.token(K::Space, " ");
+  tree.open(K::ObjectTypeDefinition);
+  tree.token(K::Name, "type").token(K::Space, " ");
+  tree.token(K::Name, "T");
+  tree.open(K::FieldsDefinition);
+  tree.token(K::LBrace, "{");
+  tree.open(K::FieldDefinition);
+  tree.token(K::Name, "f").token(K::Colon, ":");
+  tree.open(K::NamedType).token(K::Name, "Int").close();
+  tree.close();
+  tree.token(K::RBrace, "}");
+  tree.close();
+  tree.close();
+  tree.close();
+  (tree.finish(), text)
+}
+
+#[test]
+fn a_projection_that_re_parsed_the_source_would_fail_this() {
+  let (node, text) = two_definitions_in_one_node();
+  assert_eq!(
+    node.text().to_string(),
+    text,
+    "the synthetic tree's text must be the text a re-parse would be handed, or this control \
+     tests nothing"
+  );
+
+  let document = DocumentNode::cast_node(node).expect("the synthetic root is a Document");
+  let from_structure = document
+    .to_ast(text)
+    .expect("the synthetic tree is well-shaped, so it projects");
+  let from_text = project(&parse_document(text), text).expect("the real parse projects");
+
+  assert_ne!(
+    from_structure, from_text,
+    "the projection answered what a re-parse of the same bytes answers, which is exactly what a \
+     projection that ignored the tree it was handed would do"
+  );
+
+  // Pinned both ways, so "differs" cannot be satisfied tomorrow by an arbitrary wrong answer.
+  assert_eq!(
+    from_structure.definitions().len(),
+    1,
+    "the tree says one definition"
+  );
+  assert_eq!(
+    from_text.definitions().len(),
+    2,
+    "the bytes say two; if the parser stopped splitting them this control has nothing to contrast"
+  );
+}
+
+#[test]
+fn a_structure_the_bytes_do_not_imply_is_refused_rather_than_re_derived() {
+  // The second leg, and the sharper one: here the tree is a shape the walk has no place for, so
+  // reading the structure *refuses* where re-parsing the same bytes would happily succeed.
+  let (node, text) = description_as_sibling();
+  assert_eq!(node.text().to_string(), text);
+
+  let document = DocumentNode::cast_node(node).expect("the synthetic root is a Document");
+  let kind = document
+    .to_ast(text)
+    .map(|_| ())
+    .expect_err("a description loose under the document is rubble, not a definition")
+    .kind()
+    .clone();
+  assert_eq!(
+    kind,
+    ProjectErrorKind::UnexpectedChild {
+      parent: K::Description,
+      found: K::Description,
+    },
+    "the walk names the loose node where it sits"
+  );
+
+  // And the re-parse of the same bytes succeeds, which is what makes this a discriminator.
+  project(&parse_document(text), text).expect("the real parse projects");
+}
+
+#[test]
+fn the_sibling_tree_really_is_one_the_parser_would_not_build() {
+  // The other half of the control above: the *real* parse of the same text does attach the
+  // description, so the refusal genuinely comes from a different structure rather than from a
+  // projection bug that happens to refuse.
+  let (_, text) = description_as_sibling();
+  let parsed = project(&parse_document(text), text).expect("projects");
+  let described = parsed.definitions()[0]
+    .try_unwrap_definition_ref()
+    .expect("a definition");
+  assert!(
+    described.description().is_some(),
+    "the parser is expected to attach `\"d\"` to the definition that follows it; if it stopped \
+     doing so the fraud control above has nothing to contrast with"
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// the span rule #72 established, re-measured
+// ---------------------------------------------------------------------------------------------
+
+#[test]
+fn the_span_rule_the_normaliser_would_have_hidden() {
+  // The exact probe the design's M-A measurement used, with the numbers it recorded and the
+  // numbers trunk now answers. If a composite span drifts back onto a lookahead cursor, this
+  // names it; the corpus sweep would only report that two large values differ.
+  let src = "  type T  { f : Int }  ";
+  let ast = oracle(src).expect("parses");
+  let spans = extent::spans_of(&format!("{ast:#?}"));
+
+  let of = |owner: &str| {
+    let found: Vec<_> = spans
+      .iter()
+      .filter(|span| span.owner == owner)
+      .map(|span| (span.start, span.end))
+      .collect();
+    assert_eq!(found.len(), 1, "expected one {owner} span, got {found:?}");
+    found[0]
+  };
+
+  // Token extents. The design measured 0..21, 16..20 and 12..20 respectively, pre-#72.
+  assert_eq!(
+    of("Document"),
+    (2, 21),
+    "the document opens on its first token"
+  );
+  assert_eq!(
+    of("NamedType"),
+    (16, 19),
+    "a named type closes at the end of its own name, not at the next token's start"
+  );
+  assert_eq!(
+    of("FieldDefinition"),
+    (12, 19),
+    "a field definition closes at the end of its type, not on the space after it"
+  );
+
+  // And the tree's own ranges, which are what a projection reaching for `text_range` would use.
+  let parse = parse_document(src);
+  let field = parse
+    .syntax()
+    .descendants()
+    .find(|node| node.kind() == K::FieldDefinition)
+    .expect("a field definition node");
+  assert_eq!(
+    (
+      usize::from(field.text_range().start()),
+      usize::from(field.text_range().end())
+    ),
+    (12, 20),
+    "the CST node range holds the committed space after `Int`, which is why the projection folds \
+     token extents instead of reading it"
+  );
+
+  // The projection agrees with the parser and not with the node range.
+  assert_eq!(project(&parse, src).expect("projects"), ast);
+}
+
+// ---------------------------------------------------------------------------------------------
+// the divergent shapes, each pinned by name
+// ---------------------------------------------------------------------------------------------
+
+#[test]
+fn a_description_hoists_out_of_the_definition_node_it_sits_inside() {
+  let src = "\"doc\" type T { f: Int }";
+  let parse = parse_document(src);
+
+  // The tree keeps it inside.
+  let definition = parse
+    .syntax()
+    .descendants()
+    .find(|node| node.kind() == K::ObjectTypeDefinition)
+    .expect("an object type definition node");
+  assert_eq!(usize::from(definition.text_range().start()), 0);
+  assert!(
+    definition
+      .children()
+      .any(|child| child.kind() == K::Description),
+    "the CST hangs the description inside the definition"
+  );
+
+  // The AST lifts it out, and the inner definition starts after it.
+  let projected = project(&parse, src).expect("projects");
+  let described = projected.definitions()[0]
+    .try_unwrap_definition_ref()
+    .expect("a definition");
+  assert_eq!((described.span().start(), described.span().end()), (0, 23));
+  assert_eq!(
+    described
+      .description()
+      .map(|d| (d.span().start(), d.span().end())),
+    Some((0, 5))
+  );
+  assert_eq!(
+    (
+      described.node().span().start(),
+      described.node().span().end()
+    ),
+    (6, 23),
+    "the inner definition's span is synthesised: it starts after the hoisted description"
+  );
+  assert_eq!(projected, oracle(src).expect("parses"));
+}
+
+#[test]
+fn a_field_definition_keeps_its_description_inside_its_own_span() {
+  // The asymmetry the module header records: `FieldDefinition` gives the wrapper and the inner
+  // node the *same* span, description included, where the document level does not. Reproduced
+  // rather than corrected, and pinned here so a "cleanup" of either side reds.
+  let src = "type T { \"fd\" f: Int }";
+  let projected = project(&parse_document(src), src).expect("projects");
+  assert_eq!(projected, oracle(src).expect("parses"));
+
+  let described = projected.definitions()[0]
+    .try_unwrap_definition_ref()
+    .expect("a definition");
+  let object = described
+    .node()
+    .try_unwrap_type_system_ref()
+    .expect("a type-system definition")
+    .try_unwrap_type_ref()
+    .expect("a type definition")
+    .try_unwrap_object_ref()
+    .expect("an object type");
+  let fields = object.fields_definition().expect("a fields definition");
+  let field = &fields.field_definitions()[0];
+  assert_eq!(
+    (field.span().start(), field.span().end()),
+    (field.node().span().start(), field.node().span().end()),
+    "the field definition's wrapper and inner spans are the same value"
+  );
+  assert_eq!(
+    (field.span().start(), field.span().end()),
+    (9, 20),
+    "and that value includes the description"
+  );
+}
+
+#[test]
+fn the_bang_folds_into_the_node_it_wraps() {
+  // The CST has a `NonNullType` node; the AST has no image for it, only a `required` flag whose
+  // span reaches over the `!`.
+  let src = "type T { f: [Int!]! }";
+  let parse = parse_document(src);
+  assert!(
+    parse
+      .syntax()
+      .descendants()
+      .filter(|node| node.kind() == K::NonNullType)
+      .count()
+      == 2,
+    "the tree opens a NonNullType for each `!`"
+  );
+  assert_eq!(
+    project(&parse, src).expect("projects"),
+    oracle(src).expect("parses")
+  );
+}
+
+#[test]
+fn a_name_is_a_token_and_an_interface_list_holds_names_not_type_references() {
+  // Two shapes at once: the definition's name is the *second* `Name` token under its node (there
+  // is no `Name` node in this kind space), and `implements A & B` holds `NamedType` nodes in the
+  // tree but bare `Name`s in the AST.
+  let src = "type T implements A & B { f: Int }";
+  let parse = parse_document(src);
+  let clause = parse
+    .syntax()
+    .descendants()
+    .find(|node| node.kind() == K::ImplementsInterfaces)
+    .expect("an implements clause");
+  assert_eq!(
+    clause
+      .children()
+      .filter(|child| child.kind() == K::NamedType)
+      .count(),
+    2,
+    "the tree wraps each interface in a NamedType"
+  );
+  assert_eq!(
+    project(&parse, src).expect("projects"),
+    oracle(src).expect("parses")
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// refusals
+// ---------------------------------------------------------------------------------------------
+
+/// One pinned refusal: an input, and the kind the projection must answer with.
+struct Refusal {
+  what: &'static str,
+  kind: fn(&ProjectErrorKind) -> bool,
+  error: ProjectErrorKind,
+}
+
+fn refuse(source: &str) -> ProjectErrorKind {
+  let parse = parse_document(source);
+  project(&parse, source)
+    .map(|_| ())
+    .expect_err("the projection was expected to refuse")
+    .kind()
+    .clone()
+}
+
+#[test]
+fn the_lost_node_class_refuses() {
+  // `invalid_top_level_junk`: bytes a failed definition left as rubble under the document.
+  let (_, src) = read_entry(
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/corpus/invalid_top_level_junk.graphql"),
+  );
+  let kind = refuse(&src);
+  assert!(
+    matches!(kind, ProjectErrorKind::UnexpectedChild { .. }),
+    "expected an UnexpectedChild refusal, got {kind:?}"
+  );
+}
+
+#[test]
+fn the_recovered_in_place_class_refuses() {
+  // `type T { x: }` keeps its field-definition node and hangs an `Error` hole where the type
+  // should be. The hole is the refusal.
+  let kind = refuse("type T { x: }");
+  assert_eq!(
+    kind,
+    ProjectErrorKind::UnexpectedChild {
+      parent: K::FieldDefinition,
+      found: K::Error,
+    },
+    "the hole must be named where it sits"
+  );
+}
+
+#[test]
+fn a_variable_in_a_constant_position_refuses() {
+  // The AST's own type system forbids it: `ConstInputValue` has no `Variable` variant. The
+  // lossless tree keeps the offending node so a diagnostic can point at it, so the refusal is
+  // the projection's, not a cast failure.
+  let src = "type T @d(a: $v) { f: Int }";
+  let parse = parse_document(src);
+  assert!(
+    parse
+      .syntax()
+      .descendants()
+      .any(|node| node.kind() == K::Variable),
+    "the tree is expected to keep the variable node; if it stopped, this pin moved"
+  );
+  let kind = refuse(src);
+  assert_eq!(
+    kind,
+    ProjectErrorKind::UnexpectedChild {
+      parent: K::Argument,
+      found: K::Variable,
+    }
+  );
+}
+
+#[test]
+fn a_fragment_named_on_refuses() {
+  let (_, src) = read_entry(
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .join("tests/corpus/invalid_fragment_named_on.graphql"),
+  );
+  let kind = refuse(&src);
+  assert_eq!(
+    kind,
+    ProjectErrorKind::SemanticRule {
+      rule: "a fragment may not be named `on`",
+    },
+    "the exclusion `FragmentName::new` is kept crate-private to protect has to be re-checked \
+     here, because the tree records it only as a diagnostic"
+  );
+}
+
+#[test]
+fn a_mismatched_source_refuses() {
+  let src = "type T { f: Int }";
+  let parse = parse_document(src);
+  let other = "type U { f: Int }";
+  assert_eq!(
+    src.len(),
+    other.len(),
+    "same length, so every range is in bounds"
+  );
+  let kind = project(&parse, other)
+    .map(|_| ())
+    .expect_err("a tree parsed from other bytes must not project against these")
+    .kind()
+    .clone();
+  assert_eq!(kind, ProjectErrorKind::SourceMismatch);
+
+  // A shorter source is the out-of-bounds leg of the same check.
+  let kind = project(&parse, "type")
+    .map(|_| ())
+    .expect_err("a truncated source must not project")
+    .kind()
+    .clone();
+  assert_eq!(kind, ProjectErrorKind::SourceMismatch);
+}
+
+#[test]
+fn a_missing_constituent_refuses() {
+  // No corpus entry reaches this: every shape the recovery produces either keeps the constituent
+  // or leaves an `Error` hole, which is refused earlier. So the witness is synthetic — a field
+  // definition with a name and no type, the shape a future recovery change could start emitting.
+  let text = "type T{f:}";
+  let mut tree = Tree::new();
+  tree.open(K::Document);
+  tree.open(K::ObjectTypeDefinition);
+  tree.token(K::Name, "type").token(K::Space, " ");
+  tree.token(K::Name, "T");
+  tree.open(K::FieldsDefinition);
+  tree.token(K::LBrace, "{");
+  tree.open(K::FieldDefinition);
+  tree.token(K::Name, "f").token(K::Colon, ":");
+  tree.close();
+  tree.token(K::RBrace, "}");
+  tree.close();
+  tree.close();
+  tree.close();
+  let node = tree.finish();
+  assert_eq!(node.text().to_string(), text);
+
+  let document = DocumentNode::cast_node(node).expect("a Document root");
+  let kind = document
+    .to_ast(text)
+    .map(|_| ())
+    .expect_err("a field definition with no type has no AST image")
+    .kind()
+    .clone();
+  assert_eq!(
+    kind,
+    ProjectErrorKind::MissingChild {
+      parent: K::FieldDefinition,
+      wanted: "a type reference",
+    }
+  );
+}
+
+#[test]
+fn a_token_that_will_not_cook_refuses() {
+  // Same reason as above: the lossless lexer never emits a `String` token it cannot re-lex, so
+  // this class is reachable only by handing the projection a tree that claims one. Its value is
+  // that the refusal exists rather than a panic or a silently truncated literal.
+  let text = "type T{f:Int}\"oops";
+  let mut tree = Tree::new();
+  tree.open(K::Document);
+  tree.open(K::ObjectTypeDefinition);
+  tree.token(K::Name, "type").token(K::Space, " ");
+  tree.token(K::Name, "T");
+  tree.open(K::FieldsDefinition);
+  tree.token(K::LBrace, "{");
+  tree.open(K::FieldDefinition);
+  tree.token(K::Name, "f").token(K::Colon, ":");
+  tree.open(K::NamedType).token(K::Name, "Int").close();
+  tree.close();
+  tree.token(K::RBrace, "}");
+  tree.close();
+  // An unterminated literal, claimed as a description.
+  tree.open(K::Description).token(K::String, "\"oops").close();
+  tree.close();
+  tree.close();
+  let node = tree.finish();
+  assert_eq!(node.text().to_string(), text);
+
+  let document = DocumentNode::cast_node(node).expect("a Document root");
+  let kind = document
+    .to_ast(text)
+    .map(|_| ())
+    .expect_err("an unterminated string literal does not cook")
+    .kind()
+    .clone();
+  assert_eq!(kind, ProjectErrorKind::MalformedToken { kind: K::String });
+}
+
+#[test]
+fn every_refusal_kind_has_a_witness() {
+  // Totality. The list is written out rather than derived, because `ProjectErrorKind` is
+  // `#[non_exhaustive]` and there is no way to enumerate its variants at run time — so adding a
+  // variant without a pin has to be caught by the count below.
+  let src_junk = read_entry(
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/corpus/invalid_top_level_junk.graphql"),
+  )
+  .1;
+  let src_on = read_entry(
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .join("tests/corpus/invalid_fragment_named_on.graphql"),
+  )
+  .1;
+
+  let witnesses: Vec<Refusal> = vec![
+    Refusal {
+      what: "rubble under the document",
+      kind: |k| matches!(k, ProjectErrorKind::UnexpectedChild { .. }),
+      error: refuse(&src_junk),
+    },
+    Refusal {
+      what: "a fragment named `on`",
+      kind: |k| matches!(k, ProjectErrorKind::SemanticRule { .. }),
+      error: refuse(&src_on),
+    },
+    Refusal {
+      what: "a mismatched source",
+      kind: |k| matches!(k, ProjectErrorKind::SourceMismatch),
+      error: {
+        let src = "type T { f: Int }";
+        project(&parse_document(src), "type U { f: Int }")
+          .map(|_| ())
+          .expect_err("refuses")
+          .kind()
+          .clone()
+      },
+    },
+  ];
+
+  for witness in &witnesses {
+    assert!(
+      (witness.kind)(&witness.error),
+      "{}: got {:?}",
+      witness.what,
+      witness.error
+    );
+  }
+
+  // The two synthetic classes are pinned in their own tests above; asserting them here as well
+  // would duplicate the construction without adding a check. What this count owns is the claim
+  // that five variants exist and five are witnessed somewhere in this file.
+  const KIND_COUNT: usize = 5;
+  assert_eq!(
+    witnesses.len() + 2,
+    KIND_COUNT,
+    "ProjectErrorKind has a variant with no witness in this file; add one and raise the count"
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// the shape-faithful boundary, and the invalid half as a census
+// ---------------------------------------------------------------------------------------------
+
+#[test]
+fn the_unclosed_brace_class_projects_although_the_parser_rejects_it() {
+  // The documented boundary of "shape-faithful, not verdict-faithful". Asserted rather than
+  // left implicit so the day it moves is a day somebody is told.
+  let src = "type T {\n  x: Int\n";
+  let parse = parse_document(src);
+  assert!(
+    parse.has_errors(),
+    "the lossless parse reports the missing closer"
+  );
+  assert!(oracle(src).is_err(), "the syntactic parser rejects it");
+  assert!(
+    !parse
+      .syntax()
+      .descendants()
+      .any(|node| matches!(node.kind(), K::Error | K::Gap)),
+    "this class is shape-complete: the tree carries no hole, which is why it projects"
+  );
+  project(&parse, src).expect("a shape-complete tree projects even though the parse was rejected");
+}
+
+#[test]
+fn the_invalid_half_is_a_census_rather_than_a_wall_of_refusals() {
+  // Every `invalid_` entry, classified. No equality claim is possible — there is no oracle AST —
+  // so what this owns is that the split is measured and that neither side is empty.
+  let entries = corpus("invalid_");
+  assert!(
+    entries.len() >= INVALID_ENTRY_FLOOR,
+    "only {} invalid corpus entries, floor is {INVALID_ENTRY_FLOOR}",
+    entries.len()
+  );
+
+  let mut refused: Vec<&str> = Vec::new();
+  let mut projected: Vec<&str> = Vec::new();
+  for (name, src) in &entries {
+    let parse = parse_document(src);
+    assert!(
+      oracle(src).is_err(),
+      "{name}: an `invalid_` entry the syntactic parser accepts is a corpus fault"
+    );
+    match project(&parse, src) {
+      Ok(_) => projected.push(name),
+      Err(_) => refused.push(name),
+    }
+  }
+
+  assert!(
+    refused.len() >= 5,
+    "only {} of {} invalid entries refuse; the refusal paths are barely exercised: {refused:?}",
+    refused.len(),
+    entries.len()
+  );
+  assert!(
+    !projected.is_empty(),
+    "every invalid entry refuses, so the shape-faithful boundary is not being exercised at all \
+     and the contract in the module header is untested"
+  );
+  assert!(
+    projected.contains(&"invalid_unterminated_brace.graphql"),
+    "the unclosed-brace class is the pinned shape-faithful survivor; it now refuses: {projected:?}"
+  );
+}


### PR DESCRIPTION
Phase 1 of #58, and the lossless door #85 depends on.

An editor parses losslessly. The validator consumes `ast::ExecutableDocument<S>` directly and deliberately rejected a shared `DocumentView` trait in favour of projecting — so without this door a consumer holding a rowan tree has no way to reach typed nodes short of parsing the same bytes twice.

```rust
let parse = parse_document(source);
let ast = project(&parse, source)?;   // == document(source), value for value
```

GraphQL only. GraphQLx is a later phase, for the reason the issue gives: 16 of 78 typed wrappers are structurally identical across the dialects, which is precisely the argument for two hand-written per-dialect projections over a dialect-free substrate rather than one parameterised walk — and for not attempting both at once.

## The design was ungated, and trunk overtook two of its measurements

The design in #58's comment was written against `69fd677`, before #72, #79, #82 and #84. Its load-bearing claims were re-verified against trunk before anything was built. Two did not survive, and both make the result **smaller**.

### The span normaliser is retired before it was written

The design measured the syntactic AST's composite spans as lookahead artifacts — over `"  type T  { f : Int }  "` it recorded `Document 0..21`, `NamedType 16..20`, `FieldDefinition 12..20` — and worked around them: projected spans were to be "normatively token-extent", compared through a `normalise_spans` pass, backed by a drift ledger, a leaf-span unit pin and a self-retirement clause for the day the parser converged.

**That day was #72.** It rewrote span computation across 44 node types and added `tests/syntactic_span_extent.rs`, which pins "a composite node's span is the extent of the tokens it contains" over the same corpus, padded with the same eight trivia forms. Re-measured on trunk, the same probe answers `2..21`, `16..19`, `12..19` — token extents, all three.

So this PR contains no normaliser, no drift ledger, no self-retirement test. The gate is plain `assert_eq!`. What replaces the workaround is one test, `the_span_rule_the_normaliser_would_have_hidden`, which pins the three re-measured numbers *and* the CST node range that differs from them (`FieldDefinition@12..20`, holding the committed space after `Int`), so a regression names the node and the offset rather than diffing two very large `Debug` renderings.

### `Name::new` is public now

The design listed `StringValue::new`, `IntValue::new` and `FragmentName::new` as the `pub(crate)` constructors forcing in-crate placement. `Name::new` has since become `pub`; the other three, and every remaining value leaf, are still crate-private, so the conclusion is unchanged and the projection lives at `smear/src/parser/graphql/lossless/project.rs`.

### What still holds, re-verified

| Claim | Verdict |
| --- | --- |
| 16 of 78 wrappers structurally identical, so no single generic projection | holds (taken as given; the per-dialect split is what this implements) |
| `From<CST>` impossible for **any** dialect — two inputs plus fallibility | holds, and independently of 16/78 |
| Composite AST carriers have no `PartialEq` | held: 61 of 96 shared carriers plus 6 dialect enums and the `ty!` macro's three. All derived here |
| Projection must live in `smear/src/parser` — value constructors are `pub(crate)` | holds (minus `Name::new`) |
| `Description` inside the definition node in the CST, outside it in `Described` in the AST | holds, measured again on trunk |

## The API as landed

```rust
// smear::parser::lossless::project — dialect-free
pub struct ProjectError<K> { /* kind + Range<usize> */ }
pub enum  ProjectErrorKind<K> { MissingChild, UnexpectedChild, MalformedToken, SourceMismatch, SemanticRule }
pub fn node_extent<L>(node, is_trivia) -> Option<TextRange>;
pub fn extent_of<L, I>(elements, is_trivia) -> Option<TextRange>;
pub fn verify_slice<'src, L>(source, token) -> Result<&'src str, ProjectError<L::Kind>>;

// smear::parser::graphql::lossless — beside parse_document
pub fn project<'src>(parse: &Parse, source: &'src str) -> Result<Document<&'src str>, ProjectError>;
impl lossless::ast::Document { pub fn to_ast<'src>(&self, source: &'src str) -> …; }
```

- **`source` is a parameter** because rowan cursors cannot lend `&str`s that outlive them, and it is **verified, not trusted**: every slice the projection takes is compared against its token's own text, and a mismatch is `SourceMismatch` rather than a silently wrong AST.
- **Shape-faithful, not verdict-faithful.** It succeeds iff the tree's shape determines a well-formed AST; the acceptance verdict stays `has_errors()`. `type T { x: Int` projects while the parser rejects it — refusing it would mean re-implementing delimiter accounting, i.e. the grammar, i.e. the drift this door exists to avoid. Pinned in both directions, including that the tree for that class carries no hole.
- **Stricter than shape in one place**: a tree carrying an `Error` hole or a `Gap` tile is refused outright, before the walk, because a hole is a region with no AST image and skipping it would be data loss under a success type.
- **Spans are folded token extents, never `text_range()`.** Descriptions hoist and the inner span is synthesised — except in `FieldDefinition`, `InputValueDefinition` and `EnumValueDefinition`, where trunk gives wrapper and inner the *same* span, description included, while `VariableDefinition` does not. Reproduced rather than corrected, and pinned, because the gate compares against the parser.

Public surface is deliberately the document level only. Widening to per-wrapper `to_ast` is semver-additive later; narrowing never is, and every `to_ast` shipped would need its own gate witness today.

## The gate

`smear/tests/lossless_project.rs`, 20 tests.

**Core**: 56 valid corpus entries × (compact + 8 trivia forms) = **504 whole-document `assert_eq!`s** against the syntactic parser, plus a floor of 60 distinct AST node types reached. The padded half is load-bearing, not decoration: on compact input a projection that read `text_range()` instead of folding token extents agrees with the parser everywhere, because with no trivia the two rules coincide.

**Anti-vacuity, the three ways this could pass over nothing:**

1. *Equality that ignores what matters* — `the_equality_can_answer_no`: the same document one byte later, and one with a different type name, must compare unequal, plus a determinism leg so the control is not passing because everything is unequal.
2. *A projection that re-parses* — `tree.text() == source` always holds, so `|_, src| document(src)` would satisfy every corpus assertion. Two hand-built green trees answer it: `two_definitions_in_one_node` packs two definitions' text into one node (the walk answers **1** definition, the re-parse answers **2**), and `description_as_sibling` hangs a description outside the definition (the walk **refuses**, the re-parse **succeeds**, and a third test pins that the parser really does attach it — otherwise there is nothing to contrast with).
3. *Unreachable error paths* — every `ProjectErrorKind` variant is witnessed.

**Refusal pins, by class:**

| Input | Refusal |
| --- | --- |
| `invalid_top_level_junk` (lost-node rubble) | `UnexpectedChild` |
| `type T { x: }` (recovered in place) | `UnexpectedChild { parent: FieldDefinition, found: Error }` |
| `type T @d(a: $v)` (variable in a const position) | `UnexpectedChild { parent: Argument, found: Variable }` |
| `invalid_fragment_named_on` | `SemanticRule { "a fragment may not be named \`on\`" }` |
| a tree projected against different / truncated text | `SourceMismatch` |
| synthetic: a field definition with no type | `MissingChild { parent: FieldDefinition, wanted: "a type reference" }` |
| synthetic: an unterminated string claimed as a description | `MalformedToken { kind: String }` |

The last two are synthetic on purpose and the test says so: no recovery shape reaches them, because every one either keeps the constituent or leaves a hole that is refused earlier. Their value is that the refusal exists rather than a panic or a truncated literal.

**The invalid half is a census, not a wall**: all 31 entries are classified, at least 5 must refuse, the projected set must be non-empty, and `invalid_unterminated_brace` is pinned as the shape-faithful survivor — so the day that boundary moves is a day somebody is told.

**Shaped witnesses**, one per divergent family the issue names: description hoisting (with the CST-inside / AST-outside contrast asserted), the `FieldDefinition` same-span asymmetry, the `!` folding into `required`, and name-as-token plus `implements` holding `Name`s where the tree holds `NamedType`s.

## Two visibility widenings, each avoiding a duplicate table

- `contextual_keyword` and `classify_location` become `pub(crate)`. The projection classifies keywords and directive locations off tree tokens and must answer exactly as the lexer and the productions do; the alternative was a second nineteen-arm copy of the location spelling list.
- `tests/lossless_isolation.rs`'s source census gains **one** root on the GraphQL side, `crate::parser::type_system`, with the reason recorded in its doc comment: three `Described<…>` aliases wrap undescribed cores and six extension `…Data` enums have no spelling under `graphql::ast`, and the projection must construct all nine. Every other AST type it builds is reached through the dialect's own `ast` module, which is why this is one root and not eight. The census is about a dialect reaching the *other dialect*; a shared, dialect-free carrier is not that.

`rowan` is added to `[dev-dependencies]` — the fraud-model witnesses need `GreenNodeBuilder`, and the library re-exports no door to it.

## Gate table

| Gate | Result |
| --- | --- |
| `cargo test -p smear --all-features` | pass — 41 test binaries, 0 failed |
| `cargo test -p smear --features rowan --test lossless_project` | pass — 20 tests, 504 corpus comparisons |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets --all-features` | pass |
| `cargo hack clippy --each-feature` | pass — 17 cells |
| `cargo hack clippy -p smear --each-feature --features parser …` (pass 2) | pass — 9 cells |
| `cargo hack build --each-feature` | pass — 17 cells |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` | pass |
| the four one-dialect-at-a-time doc legs, `-D warnings` | pass |
| `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features` | pass |
| `cargo +nightly check -p smear --tests --all-features` | pass |

All run under `RUSTFLAGS=-Dwarnings` where CI sets it. The four red `miri-*` cells from rowan UB (#77) are pre-existing and untouched.

## Follow-ups, deliberately not in scope

- The GraphQLx projection (phase 2) — the same substrate, forked productions.
- `project_type_system_document` / `project_executable_document` for the two alternate roots #79 promoted. The machinery is shared and each is roughly thirty lines, but each also needs its own corpus leg, and shipping ungated public API is how a gate stops covering what it claims to. #85's lossless door wants the executable root, so this is the first follow-up.
- The per-wrapper `to_ast` tier.

Closes #58 for the GraphQL half.
