### PR TITLE
feat(validator): the rule engine, and every draft §5 rule but 5.3.2

### DIFF
--- a/smear-smoke/src/lib.rs
+++ b/smear-smoke/src/lib.rs
@@ -199,6 +199,99 @@ pub fn validator_source_lattice() {
   assert_lattice_member::<hipstr::HipByt<'static>>();
 }
 
+/// `validator`, the executable half — draft §5 validation reached across the dependency edge.
+///
+/// Returns how many rules fired. The sink is the caller's, which is the whole point of the seam:
+/// this function owns no diagnostic storage and neither does `smear`.
+pub fn graphql_validate(sdl: &str, query: &str) -> u32 {
+  use smear::{
+    parser::graphql::{
+      GraphQL,
+      ast::ExecutableDocument,
+      error::GraphqlErrors,
+      syntactic::{GraphqlLexer, executable_document},
+    },
+    validator::{Budget, Count, Scratch, validate_executable},
+  };
+
+  let schema = graphql_schema(sdl).expect("the probe's SDL is a schema");
+  let document = Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    ExecutableDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(executable_document)
+  .parse_str(query)
+  .expect("the probe's query parses");
+
+  let mut scratch = Scratch::new();
+  let mut sink = Count::new();
+  let _ = validate_executable(
+    &schema,
+    &document,
+    &mut scratch,
+    &Budget::default(),
+    &mut sink,
+  );
+  sink.get()
+}
+
+/// `validator`, the executable bound — asserted over `tokora`'s whole `Source<usize>` lattice.
+///
+/// [`validate_executable`] asks for one bound more than `Schema::build` does: `Clone` as well as
+/// `AsRef<[u8]>`. That is not a convenience. A `Diagnostic` **owns** the document's own spelling
+/// of the name it refused, because the design's escape contract says a diagnostic built from a
+/// refcounted source may outlive the call that produced it — and owning the slice means cloning
+/// it, which is a reborrow on the borrowed tier and a refcount bump on the rest.
+///
+/// So the claim to check is that the wider bound still admits every member. The assertion
+/// instantiates the real entry point at each `Slice` associated type rather than restating its
+/// bound, so it fails in both directions, exactly as its `Schema::build` twin does.
+///
+/// [`validate_executable`]: smear::validator::validate_executable
+pub fn validator_executable_source_lattice() {
+  use smear::{
+    lexer::tokora::Source,
+    parser::graphql::ast::ExecutableDocument,
+    validator::{Budget, Ignore, Invalid, Schema, Scratch, validate_executable},
+  };
+
+  fn assert_lattice_member<Src>()
+  where
+    Src: Source<usize> + ?Sized + 'static,
+    for<'a> <Src as Source<usize>>::Slice<'a>: AsRef<[u8]> + Clone,
+  {
+    fn validates<S: AsRef<[u8]> + Clone>(
+      schema: &Schema,
+      document: &ExecutableDocument<S>,
+      scratch: &mut Scratch,
+    ) -> Result<(), Invalid> {
+      validate_executable(schema, document, scratch, &Budget::default(), &mut Ignore)
+    }
+    let _ = validates::<<Src as Source<usize>>::Slice<'static>>;
+  }
+
+  // Borrowed tier: a diagnostic is pinned to the request buffer and must not escape it.
+  assert_lattice_member::<str>();
+  assert_lattice_member::<[u8]>();
+  assert_lattice_member::<&'static str>();
+  assert_lattice_member::<&'static [u8]>();
+  assert_lattice_member::<bstr::BStr>();
+  assert_lattice_member::<&'static bstr::BStr>();
+
+  // Refcounted tier: a diagnostic may escape, and cloning its subject is a refcount bump.
+  assert_lattice_member::<bytes::Bytes>();
+  assert_lattice_member::<smol_bytes::shared::Bytes>();
+  assert_lattice_member::<smol_bytes::compact::Bytes>();
+  assert_lattice_member::<smol_bytes::Utf8Bytes>();
+  assert_lattice_member::<smol_bytes::compact::Utf8Bytes>();
+
+  // Three-way tier: inline, borrowed, or shared, decided at runtime but pinned by `'h`.
+  assert_lattice_member::<hipstr::HipStr<'static>>();
+  assert_lattice_member::<hipstr::HipByt<'static>>();
+}
+
 /// `smallvec` — the error container is SmallVec-backed rather than `Vec`-backed.
 ///
 /// The coercion is the probe: with the feature off the deref target is a `Vec` and the binding
@@ -338,6 +431,20 @@ mod tests {
 
     let errors = super::graphql_schema("type NotARoot { ok: Int }").expect_err("not a schema");
     assert!(!errors.is_empty());
+  }
+
+  /// The executable entry point's bound, over the same lattice, for the same reason.
+  #[test]
+  fn the_validator_admits_every_source_slice_type_for_documents_too() {
+    super::validator_executable_source_lattice();
+  }
+
+  /// Draft §5 validation, driven end to end across the dependency edge.
+  #[test]
+  fn the_validator_accepts_and_refuses_executable_documents() {
+    const SDL: &str = "type Query { hero: Character } interface Character { name: String! }";
+    assert_eq!(super::graphql_validate(SDL, "{ hero { name } }"), 0);
+    assert_eq!(super::graphql_validate(SDL, "{ hero { nickname } }"), 1);
   }
 
   /// Features named in `smear`'s manifest but deliberately not smoked, each with a written

--- a/smear/src/validator/diagnostic.rs
+++ b/smear/src/validator/diagnostic.rs
@@ -1,0 +1,282 @@
+//! What a rule says when it fires: a plain value, rendered only on demand.
+//!
+//! The two claims this module is built around — that nothing is formatted on the validation path,
+//! and that a diagnostic's escape class is decided by the document's source type — are stated on
+//! [`Diagnostic`] itself, where a reader of the published documentation will find them. This
+//! module is private and its header is not published.
+
+use tokora::SimpleSpan;
+
+use super::{
+  Rule,
+  schema::{DirectiveLocation, PackedType, RootOperation, Schema, Sym},
+};
+
+/// The schema-side half of a diagnostic: what the rule expected, in the schema's own vocabulary.
+///
+/// Everything here is an integer. Names are [`Sym`]s and type references are [`PackedType`]s, so
+/// the whole value is `Copy` and renders only against the [`Schema`] that issued them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Context {
+  /// The rule's spans and subject say everything.
+  None,
+  /// A root operation slot the schema does not fill.
+  Root(RootOperation),
+  /// A schema type — the type in scope, the type a condition names, the input object a literal is
+  /// checked against.
+  Type(Sym),
+  /// A schema-side member of a schema-side owner: an argument of a field or directive, or a field
+  /// of an input object.
+  Member {
+    /// The owning field, directive or input object type.
+    owner: Sym,
+    /// The argument or input field.
+    name: Sym,
+  },
+  /// The grammar location a directive was written at.
+  Location(DirectiveLocation),
+  /// The type expected in the position.
+  Expected(PackedType),
+  /// A variable usage: the variable's declared type against the type its position expects.
+  Usage {
+    /// The type the operation declared the variable with.
+    variable: PackedType,
+    /// The type the position expects.
+    expected: PackedType,
+  },
+  /// A plain count — how many root fields a subscription collected, for instance.
+  Count(u32),
+}
+
+/// One reason a document is invalid.
+///
+/// # Nothing is formatted until somebody asks
+///
+/// A `Diagnostic` is data — a [`Rule`], one or two byte spans, the document's own spelling of the
+/// offending name, and a small [`Context`] of interned schema symbols. No string is built and no
+/// allocation happens, so a server that only needs "is this document valid" pays for none of it.
+/// Rendering is [`Diagnostic::display`], against the schema the diagnostic came from.
+///
+/// # The lifetime contract `S` carries
+///
+/// A `Diagnostic<S>` has exactly `S`'s lifetime class, and that is a contract rather than a note:
+///
+/// - **Borrowed sources** (`&'src str`, `&'src [u8]`) make it **non-escaping**. It must be
+///   rendered or dropped before the request buffer's life ends, and must never cross an FFI
+///   boundary raw. This is the right default for a Sans-I/O server that renders within the
+///   request.
+/// - **Refcounted sources** (`smol-bytes`, `bytes`, `hipstr`'s owned states) make it **escaping**:
+///   `'static`, cheap to clone, and safe to hand to a caller with its own lifetime discipline.
+///
+/// Choose the source type by whether diagnostics escape, not by what looks cheapest. `&[u8]` is
+/// the cheapest-looking choice and is a use-after-free the moment a foreign caller holds a
+/// diagnostic past the buffer.
+///
+/// # A [`Sym`] is meaningless without its schema
+///
+/// [`Context`] carries interned symbols, which are indices into one particular [`Schema`]. An
+/// escaping diagnostic must therefore either be rendered eagerly into owned text or travel with a
+/// handle to the schema that produced it; a raw symbol on its own is an integer with no meaning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Diagnostic<S> {
+  rule: Rule,
+  span: SimpleSpan,
+  related: Option<SimpleSpan>,
+  subject: Option<S>,
+  context: Context,
+}
+
+impl<S> Diagnostic<S> {
+  /// Creates a diagnostic pointing at one position, with no subject and no context.
+  #[inline]
+  pub(crate) const fn new(rule: Rule, span: SimpleSpan) -> Self {
+    Self {
+      rule,
+      span,
+      related: None,
+      subject: None,
+      context: Context::None,
+    }
+  }
+
+  /// Attaches the document's own spelling of the offending name.
+  #[inline]
+  pub(crate) fn subject(mut self, subject: S) -> Self {
+    self.subject = Some(subject);
+    self
+  }
+
+  /// Attaches the schema-side context.
+  #[inline]
+  pub(crate) const fn context(mut self, context: Context) -> Self {
+    self.context = context;
+    self
+  }
+
+  /// Points at a second, related position — the first of two duplicates, say.
+  #[inline]
+  pub(crate) const fn related(mut self, span: SimpleSpan) -> Self {
+    self.related = Some(span);
+    self
+  }
+
+  /// Returns the rule that fired.
+  #[inline]
+  pub const fn rule(&self) -> Rule {
+    self.rule
+  }
+
+  /// Returns the position the rule refused.
+  #[inline]
+  pub const fn span(&self) -> SimpleSpan {
+    self.span
+  }
+
+  /// Returns a second position the diagnostic refers to, when there is one.
+  #[inline]
+  pub const fn related_span(&self) -> Option<SimpleSpan> {
+    self.related
+  }
+
+  /// Returns the document's own spelling of the offending name, when the rule named one.
+  #[inline]
+  pub const fn subject_source(&self) -> Option<&S> {
+    self.subject.as_ref()
+  }
+
+  /// Returns the schema-side context.
+  #[inline]
+  pub const fn context_of(&self) -> Context {
+    self.context
+  }
+
+  /// Renders the diagnostic against the schema that produced it.
+  ///
+  /// This is the only place a diagnostic is turned into text, and it is a caller's decision: the
+  /// validation path itself formats nothing. Passing a *different* schema than the one validation
+  /// ran against renders nonsense — a [`Sym`] belongs to one schema.
+  #[inline]
+  pub const fn display<'a>(&'a self, schema: &'a Schema) -> DiagnosticDisplay<'a, S> {
+    DiagnosticDisplay {
+      diagnostic: self,
+      schema,
+    }
+  }
+}
+
+/// The rendering of a [`Diagnostic`] against its schema, from [`Diagnostic::display`].
+#[derive(Debug, Clone, Copy)]
+pub struct DiagnosticDisplay<'a, S> {
+  diagnostic: &'a Diagnostic<S>,
+  schema: &'a Schema,
+}
+
+impl<S> core::fmt::Display for DiagnosticDisplay<'_, S>
+where
+  S: AsRef<[u8]>,
+{
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let Diagnostic {
+      rule,
+      span,
+      subject,
+      context,
+      ..
+    } = self.diagnostic;
+    write!(f, "{rule}: ")?;
+    match subject {
+      Some(subject) => {
+        f.write_str("`")?;
+        write_lossy(f, subject.as_ref())?;
+        f.write_str("`")?;
+      }
+      None => f.write_str("<here>")?,
+    }
+    match context {
+      Context::None => {}
+      Context::Root(operation) => write!(f, ", no `{operation}` root operation type")?,
+      Context::Type(sym) => write!(f, " on type `{}`", self.schema.name(*sym))?,
+      Context::Member { owner, name } => write!(
+        f,
+        " of `{}.{}`",
+        self.schema.name(*owner),
+        self.schema.name(*name)
+      )?,
+      Context::Location(location) => write!(f, " at {location}")?,
+      Context::Expected(ty) => {
+        f.write_str(", expected `")?;
+        ty.write(f, self.schema.name(ty.base()))?;
+        f.write_str("`")?;
+      }
+      Context::Usage { variable, expected } => {
+        f.write_str(", declared `")?;
+        variable.write(f, self.schema.name(variable.base()))?;
+        f.write_str("` used where `")?;
+        expected.write(f, self.schema.name(expected.base()))?;
+        f.write_str("` is expected")?;
+      }
+      Context::Count(count) => write!(f, ", found {count}")?,
+    }
+    write!(f, " ({}..{})", span.start(), span.end())
+  }
+}
+
+/// Writes possibly-non-UTF-8 source bytes without allocating.
+///
+/// A document's source slice type may be `&[u8]`, so a name is not guaranteed to be text. Valid
+/// runs are written as they are and invalid bytes become the replacement character, which is what
+/// `String::from_utf8_lossy` would produce — except that this builds no `String`, and the hot path
+/// this module exists to keep allocation-free stays that way even while rendering.
+fn write_lossy(f: &mut core::fmt::Formatter<'_>, mut bytes: &[u8]) -> core::fmt::Result {
+  loop {
+    match core::str::from_utf8(bytes) {
+      Ok(text) => return f.write_str(text),
+      Err(error) => {
+        let valid = error.valid_up_to();
+        // `valid_up_to` is a UTF-8 boundary by definition, so this cannot fail.
+        if let Ok(text) = core::str::from_utf8(&bytes[..valid]) {
+          f.write_str(text)?;
+        }
+        f.write_str("\u{FFFD}")?;
+        match error.error_len() {
+          Some(len) => bytes = &bytes[valid + len..],
+          // The trailing bytes are an incomplete sequence; one replacement covers them.
+          None => return Ok(()),
+        }
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::write_lossy;
+  use std::{format, string::String};
+
+  struct Lossy<'a>(&'a [u8]);
+
+  impl core::fmt::Display for Lossy<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+      write_lossy(f, self.0)
+    }
+  }
+
+  #[test]
+  fn lossy_matches_from_utf8_lossy() {
+    for bytes in [
+      &b"plain"[..],
+      &b""[..],
+      &[b'a', 0xff, b'b'][..],
+      &[0xff, 0xfe][..],
+      &[b'x', 0xe2, 0x82][..],
+      "héllo".as_bytes(),
+    ] {
+      assert_eq!(
+        format!("{}", Lossy(bytes)),
+        String::from_utf8_lossy(bytes),
+        "lossy rendering of {bytes:?} diverges"
+      );
+    }
+  }
+}

--- a/smear/src/validator/executable/mod.rs
+++ b/smear/src/validator/executable/mod.rs
@@ -799,8 +799,12 @@ where
       .push(Frame::root(row.definition, NONE, 0));
     let mut current = root_selection_set(document, row.definition);
 
-    let mut first: Option<&'d Name<S>> = None;
-    let mut distinct = 0u32;
+    // The rule only asks whether the collected map is a set of one, so the first response name
+    // seen is all that has to be kept: any later name that differs makes at least two entries.
+    // The *field* name is kept alongside it, because "must not be an introspection field" is a
+    // question about the field and not about the key an alias would give it.
+    let mut first_response: Option<&'d Name<S>> = None;
+    let mut first_field: Option<&'d Name<S>> = None;
     let mut multiple = false;
 
     while let Some(frame) = self.scratch.roots.last().copied() {
@@ -828,13 +832,13 @@ where
 
       match selection {
         Selection::Field(field) => {
-          let name = nodes::response_name(field);
-          match first {
+          let response = nodes::response_name(field);
+          match first_response {
             None => {
-              first = Some(name);
-              distinct = 1;
+              first_response = Some(response);
+              first_field = Some(field.name());
             }
-            Some(seen) if name_bytes(seen) != name_bytes(name) => multiple = true,
+            Some(seen) if name_bytes(seen) != name_bytes(response) => multiple = true,
             Some(_) => {}
           }
         }
@@ -875,17 +879,16 @@ where
     }
 
     if multiple {
-      // The map has at least two entries; the count is not worth a second walk to make exact.
-      self.emit(
-        Diagnostic::new(Rule::SingleRootField, row.span).context(Context::Count(distinct + 1)),
-      )?;
+      // At least two entries. The exact count would cost a second walk and change nothing about
+      // the verdict, so the context reports the bound it established.
+      self.emit(Diagnostic::new(Rule::SingleRootField, row.span).context(Context::Count(2)))?;
     } else {
-      match first {
+      match first_field {
         None => {
           self.emit(Diagnostic::new(Rule::SingleRootField, row.span).context(Context::Count(0)))?;
         }
-        Some(name) if is_reserved(name_bytes(name)) => {
-          self.report_name(Rule::SingleRootField, name, Context::None)?;
+        Some(field) if is_reserved(name_bytes(field)) => {
+          self.report_name(Rule::SingleRootField, field, Context::None)?;
         }
         Some(_) => {}
       }
@@ -935,7 +938,7 @@ where
       };
       self.in_operation = true;
 
-      self.check_variable_definitions(row)?;
+      self.check_variable_definitions()?;
 
       let root = RootOperation::ALL[row.root as usize];
       if let OperationDefinition::Named(named) = operation
@@ -948,7 +951,7 @@ where
       reset_bits(&mut self.scratch.visited, self.scratch.fragments.len());
       self.walk_selections(Frame::root(row.definition, scope, Frame::CHECK))?;
 
-      self.check_variables_used(row)?;
+      self.check_variables_used()?;
 
       self.variables = &[];
       self.in_operation = false;
@@ -1001,10 +1004,9 @@ where
   /// Draft 5.8.1 and 5.8.2, plus the value and directive rules over a variable definition's own
   /// default value and directives — the one place in an executable document where constant values
   /// appear.
-  fn check_variable_definitions(&mut self, row: OperationRow) -> ControlFlow<()> {
+  fn check_variable_definitions(&mut self) -> ControlFlow<()> {
     let definitions = self.variables;
     reset_bits(&mut self.scratch.used, definitions.len());
-    let _ = row;
 
     // 5.8.1 — one type per variable name, per operation.
     if self.on(Rule::VariableUniqueness) {
@@ -1067,8 +1069,7 @@ where
   }
 
   /// Draft 5.8.4, read off the marks the usages left.
-  fn check_variables_used(&mut self, row: OperationRow) -> ControlFlow<()> {
-    let _ = row;
+  fn check_variables_used(&mut self) -> ControlFlow<()> {
     if !self.on(Rule::AllVariablesUsed) {
       return ControlFlow::Continue(());
     }

--- a/smear/src/validator/executable/mod.rs
+++ b/smear/src/validator/executable/mod.rs
@@ -1,0 +1,1159 @@
+//! Executable-document validation: the entry point, and the passes that do not ride the selection
+//! walk.
+//!
+//! # The shape of a run
+//!
+//! 1. **Prep** records the operations and fragments, sorts a fragment index, and collects every
+//!    fragment spread as an edge of the fragment graph. Draft 5.5.1.1 and 5.5.2.1 fall out of it.
+//! 2. **Operation rules** (5.2.1.1, 5.2.2.1, 5.2.3.1) read the operation list.
+//! 3. **Fragment declaration rules** (5.5.1.2, 5.5.1.3) read the fragment table.
+//! 4. **The fragment graph** answers 5.5.2.2 and 5.5.1.4 — with integers, over an explicit stack.
+//!    Cycles are established here, before anything expands a fragment, so no later rule can meet
+//!    an unestablished graph. Unlike apollo-compiler, unused fragments are included: a rule that
+//!    trusts the graph must be able to trust all of it.
+//! 5. **Subscriptions** get 5.2.4.1's own root-field collection.
+//! 6. **One selection walk per operation**, following spreads with a visited bitset, carries every
+//!    remaining rule. Rules that are properties of a *definition* rather than of an operation fire
+//!    the first time that definition is reached and are suppressed afterwards, so a fragment three
+//!    operations share reports its bad field once. Rules that are properties of an *operation* —
+//!    the variable rules — run every time, which is what the specification asks for: the same
+//!    fragment may be valid under one operation's variables and invalid under another's.
+//! 7. **A final pass over fragments no operation reached**, so their structure is validated too.
+//!
+//! # Nothing recurses on document shape
+//!
+//! Selection sets and value literals are both walked with explicit stacks living in the caller's
+//! [`Scratch`]. The frames are coordinates rather than references — a definition index plus the
+//! chain of child indices that reaches a level — which is what lets a stack that knows nothing
+//! about the document's source slice type replace recursion over an attacker-chosen shape.
+
+mod nodes;
+mod selections;
+mod values;
+
+use core::ops::ControlFlow;
+
+use tokora::span::AsSpan;
+
+use crate::parser::graphql::ast::{
+  DescribedVariableDefinition, ExecutableDefinition, ExecutableDocument, Name, OperationDefinition,
+  OperationType, Selection, Type,
+};
+
+use super::{
+  Budget, Diagnostic, Rule, RuleSet, Scratch, Sink,
+  diagnostic::Context,
+  schema::{
+    DirectiveLocation, MAX_WRAPPERS, PackedType, RootOperation, Schema, Sym, TypeId, is_reserved,
+  },
+  scratch::{
+    Edge, FragmentRow, Frame, GraphFrame, NONE, OperationRow, clear_bit, get_bit, reset_bits,
+    set_bit,
+  },
+};
+
+use nodes::{child_selection_set, definition, fragment, name_bytes, operation, root_selection_set};
+use values::ValueLocation;
+
+/// The verdict of a failed validation.
+///
+/// Returned when at least one diagnostic was emitted. What the diagnostics *were* is the sink's
+/// business — this is only the count, and whether the sink asked to stop before the document had
+/// been fully examined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Invalid {
+  emitted: u32,
+  stopped: bool,
+}
+
+impl Invalid {
+  /// Returns how many diagnostics were produced.
+  ///
+  /// This counts what the validator emitted, not what the sink kept: [`Ignore`](super::Ignore)
+  /// discards everything and the count is still right.
+  #[inline]
+  pub const fn emitted(&self) -> u32 {
+    self.emitted
+  }
+
+  /// Returns whether the sink stopped validation before the document was fully examined.
+  ///
+  /// True for [`First`](super::First) on any invalid document. When it is true, the absence of a
+  /// diagnostic says nothing: the rest of the document was never looked at.
+  #[inline]
+  pub const fn stopped(&self) -> bool {
+    self.stopped
+  }
+}
+
+impl core::fmt::Display for Invalid {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let plural = if self.emitted == 1 { "" } else { "s" };
+    write!(f, "{} validation error{plural}", self.emitted)?;
+    if self.stopped {
+      f.write_str(" (validation stopped early)")?;
+    }
+    Ok(())
+  }
+}
+
+impl core::error::Error for Invalid {}
+
+/// Validates an executable document against a schema, checking every draft §5 rule.
+///
+/// `scratch` is the caller's reusable working set and `sink` the caller's diagnostic storage; the
+/// validator owns neither, which is what lets the steady state allocate nothing. `budget` bounds
+/// draft 5.3.2's merge engine.
+///
+/// Returns `Err(Invalid)` when at least one rule fired.
+///
+/// # Example
+///
+/// ```
+/// use smear::{
+///   lexer::tokora::{Parse as _, Parser},
+///   parser::graphql::{
+///     GraphQL,
+///     ast::{ExecutableDocument, TypeSystemDocument},
+///     error::GraphqlErrors,
+///     syntactic::{GraphqlLexer, executable_document, type_system_document},
+///   },
+///   validator::{Budget, First, Schema, Scratch, validate_executable},
+/// };
+///
+/// let schema = Schema::build(
+///   &Parser::with_parser::<GraphqlLexer<'_, str>, TypeSystemDocument<&str>, GraphqlErrors<&str>, _, GraphQL>(
+///     type_system_document,
+///   )
+///   .parse_str("type Query { hero: Character } interface Character { name: String! }")
+///   .expect("the SDL parses"),
+/// )
+/// .expect("the SDL is a schema");
+///
+/// let parse = |src| {
+///   Parser::with_parser::<GraphqlLexer<'_, str>, ExecutableDocument<&str>, GraphqlErrors<&str>, _, GraphQL>(
+///     executable_document,
+///   )
+///   .parse_str(src)
+///   .expect("the query parses")
+/// };
+///
+/// let mut scratch = Scratch::new();
+/// let budget = Budget::default();
+///
+/// let good = parse("{ hero { name } }");
+/// let mut sink = First::new();
+/// assert!(validate_executable(&schema, &good, &mut scratch, &budget, &mut sink).is_ok());
+///
+/// let bad = parse("{ hero { nickname } }");
+/// let mut sink = First::new();
+/// let invalid = validate_executable(&schema, &bad, &mut scratch, &budget, &mut sink)
+///   .expect_err("`nickname` is not on `Character`");
+/// assert_eq!(invalid.emitted(), 1);
+/// assert_eq!(
+///   sink.get().expect("a diagnostic").display(&schema).to_string(),
+///   "5.3.1 Field Selections: `nickname` on type `Character` (9..17)"
+/// );
+/// ```
+pub fn validate_executable<S, K>(
+  schema: &Schema,
+  document: &ExecutableDocument<S>,
+  scratch: &mut Scratch,
+  budget: &Budget,
+  sink: &mut K,
+) -> Result<(), Invalid>
+where
+  S: AsRef<[u8]> + Clone,
+  K: Sink<S>,
+{
+  validate_executable_with(schema, document, scratch, budget, RuleSet::ALL, sink)
+}
+
+/// Validates an executable document against a subset of the rules.
+///
+/// A rule outside `rules` is not evaluated, not merely filtered: a consumer that wants only the
+/// fragment rules does not pay for value coercion. With [`RuleSet::ALL`] this is exactly
+/// [`validate_executable`].
+pub fn validate_executable_with<S, K>(
+  schema: &Schema,
+  document: &ExecutableDocument<S>,
+  scratch: &mut Scratch,
+  budget: &Budget,
+  rules: RuleSet,
+  sink: &mut K,
+) -> Result<(), Invalid>
+where
+  S: AsRef<[u8]> + Clone,
+  K: Sink<S>,
+{
+  // Draft 5.3.2's merge engine is the only reader of the budget, and it lands in its own wave so
+  // that its resource bound is designed rather than bolted on. The parameter is here now because
+  // it is part of the entry point's shape.
+  let _ = budget;
+
+  scratch.reset();
+  let mut validator = Validator {
+    schema,
+    document,
+    scratch,
+    sink,
+    rules,
+    scalars: Scalars::resolve(schema),
+    variables: &[],
+    in_operation: false,
+    emitted: 0,
+    stopped: false,
+  };
+  let _ = validator.run();
+  let (emitted, stopped) = (validator.emitted, validator.stopped);
+  if emitted == 0 {
+    Ok(())
+  } else {
+    Err(Invalid { emitted, stopped })
+  }
+}
+
+/// The five built-in scalar names, resolved against this schema once per run.
+///
+/// Coercion is decided by *name*, not by the built-in flag: a document may spell `scalar String`
+/// out — a printed schema does — and it is still the specification's `String`. Everything else is
+/// a custom scalar, and a custom scalar accepts any literal because only the service knows how to
+/// read it.
+#[derive(Debug, Clone, Copy)]
+struct Scalars {
+  int: Option<Sym>,
+  float: Option<Sym>,
+  string: Option<Sym>,
+  boolean: Option<Sym>,
+  id: Option<Sym>,
+}
+
+impl Scalars {
+  fn resolve(schema: &Schema) -> Self {
+    Self {
+      int: schema.sym(b"Int"),
+      float: schema.sym(b"Float"),
+      string: schema.sym(b"String"),
+      boolean: schema.sym(b"Boolean"),
+      id: schema.sym(b"ID"),
+    }
+  }
+}
+
+/// One validation run.
+struct Validator<'a, 'd, S, K> {
+  schema: &'a Schema,
+  document: &'d ExecutableDocument<S>,
+  scratch: &'a mut Scratch,
+  sink: &'a mut K,
+  rules: RuleSet,
+  scalars: Scalars,
+  /// The variable definitions of the operation being walked; empty outside one.
+  variables: &'d [DescribedVariableDefinition<S>],
+  /// Whether a variable scope is in effect. Distinguishes "an operation with no variables" from
+  /// "a fragment nothing reached", which is the difference between draft 5.8.3 firing and not.
+  in_operation: bool,
+  emitted: u32,
+  stopped: bool,
+}
+
+impl<'d, S, K> Validator<'_, 'd, S, K>
+where
+  S: AsRef<[u8]> + Clone,
+  K: Sink<S>,
+{
+  // -- reporting ------------------------------------------------------------------------------
+
+  /// Returns whether a rule is enabled. Checked before building a diagnostic, so a disabled rule
+  /// costs nothing.
+  #[inline]
+  fn on(&self, rule: Rule) -> bool {
+    self.rules.contains(rule)
+  }
+
+  fn emit(&mut self, diagnostic: Diagnostic<S>) -> ControlFlow<()> {
+    self.emitted = self.emitted.saturating_add(1);
+    match self.sink.diagnostic(diagnostic) {
+      ControlFlow::Continue(()) => ControlFlow::Continue(()),
+      ControlFlow::Break(()) => {
+        self.stopped = true;
+        ControlFlow::Break(())
+      }
+    }
+  }
+
+  /// Emits a diagnostic naming a source spelling, at that spelling's own span.
+  fn report_name(&mut self, rule: Rule, name: &Name<S>, context: Context) -> ControlFlow<()> {
+    let diagnostic = Diagnostic::new(rule, *name.as_span())
+      .subject(name.source().clone())
+      .context(context);
+    self.emit(diagnostic)
+  }
+
+  // -- schema helpers -------------------------------------------------------------------------
+
+  /// Resolves a source name to a schema type.
+  fn type_of(&self, name: &Name<S>) -> Option<TypeId> {
+    self.schema.type_of_sym(self.schema.sym(name_bytes(name))?)
+  }
+
+  /// Flattens an AST type reference into the schema's packed form.
+  ///
+  /// `None` when the base type is not in the schema or the reference nests deeper than the
+  /// representation admits. The walk is iterative for the same reason every other walk here is.
+  fn pack_type(&self, ty: &Type<Name<S>>) -> Option<PackedType> {
+    let mut list_required = [false; MAX_WRAPPERS as usize];
+    let mut depth = 0usize;
+    let mut cursor = ty;
+    let named = loop {
+      match cursor {
+        Type::Name(named) => break named,
+        Type::List(list) => {
+          if depth >= list_required.len() {
+            return None;
+          }
+          list_required[depth] = list.required();
+          depth += 1;
+          cursor = list.ty();
+        }
+      }
+    };
+    let sym = self.schema.sym(name_bytes(named.name()))?;
+    let id = self.schema.type_of_sym(sym)?;
+    let mut packed = PackedType::named(sym, id);
+    if named.required() {
+      packed = packed.push_non_null()?;
+    }
+    for required in list_required[..depth].iter().rev() {
+      packed = packed.push_list()?;
+      if *required {
+        packed = packed.push_non_null()?;
+      }
+    }
+    Some(packed)
+  }
+
+  // -- the run --------------------------------------------------------------------------------
+
+  fn run(&mut self) -> ControlFlow<()> {
+    self.prep()?;
+    self.check_operations()?;
+    self.check_fragment_declarations()?;
+    self.check_fragment_cycles()?;
+    self.check_fragments_used()?;
+    self.check_subscriptions()?;
+    self.walk_operations()?;
+    self.walk_unreached_fragments()
+  }
+
+  // -- 1. prep --------------------------------------------------------------------------------
+
+  fn prep(&mut self) -> ControlFlow<()> {
+    let document = self.document;
+    for (index, described) in document.definitions().iter().enumerate() {
+      let index = index as u32;
+      match described.node() {
+        ExecutableDefinition::Operation(operation) => {
+          let (root, named, span) = match operation {
+            OperationDefinition::Named(named) => (
+              root_operation(named.operation_type()),
+              named.name().is_some(),
+              match named.name() {
+                Some(name) => *name.as_span(),
+                None => *named.operation_type().span(),
+              },
+            ),
+            // Query shorthand: an anonymous query, blamed at its own braces.
+            OperationDefinition::Shorthand(set) => (RootOperation::Query, false, *set.span()),
+          };
+          self.scratch.operations.push(OperationRow {
+            definition: index,
+            root: root.index() as u8,
+            named,
+            span,
+            edges: Default::default(),
+          });
+        }
+        ExecutableDefinition::Fragment(fragment) => {
+          self.scratch.fragments.push(FragmentRow {
+            definition: index,
+            span: *fragment.name().as_span(),
+            group: Default::default(),
+            edges: Default::default(),
+          });
+        }
+      }
+    }
+
+    self.index_fragments()?;
+    self.collect_edges()
+  }
+
+  /// Sorts the fragment ordinals by name, records each name's group, and reports draft 5.5.1.1.
+  fn index_fragments(&mut self) -> ControlFlow<()> {
+    let document = self.document;
+    let count = self.scratch.fragments.len() as u32;
+    {
+      let scratch = &mut *self.scratch;
+      scratch.order.extend(0..count);
+      let rows = &scratch.fragments;
+      // Ties break on the ordinal, so the order is total and the first definition of a name is
+      // always the group's first element — which is the one spreads resolve to.
+      scratch.order.sort_unstable_by(|a, b| {
+        let left = fragment_name(document, rows, *a);
+        let right = fragment_name(document, rows, *b);
+        left.cmp(right).then(a.cmp(b))
+      });
+    }
+
+    let mut start = 0usize;
+    while start < self.scratch.order.len() {
+      let first = self.scratch.order[start];
+      let name = fragment_name(document, &self.scratch.fragments, first);
+      let mut end = start + 1;
+      while end < self.scratch.order.len()
+        && fragment_name(document, &self.scratch.fragments, self.scratch.order[end]) == name
+      {
+        end += 1;
+      }
+      let group = range32(start as u32, end as u32);
+      for slot in start..end {
+        let ordinal = self.scratch.order[slot] as usize;
+        self.scratch.fragments[ordinal].group = group;
+      }
+      if end - start > 1 && self.on(Rule::FragmentNameUniqueness) {
+        let related = self.scratch.fragments[first as usize].span;
+        for slot in start + 1..end {
+          let ordinal = self.scratch.order[slot];
+          let row = self.scratch.fragments[ordinal as usize];
+          let Some(fragment) = fragment(document, row.definition) else {
+            continue;
+          };
+          let diagnostic = Diagnostic::new(Rule::FragmentNameUniqueness, row.span)
+            .subject(fragment.name().source().clone())
+            .related(related);
+          self.emit(diagnostic)?;
+        }
+      }
+      start = end;
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Returns the ordinal a fragment name resolves to — the first definition of that name.
+  fn find_fragment(&self, name: &[u8]) -> Option<u32> {
+    let document = self.document;
+    let rows = &self.scratch.fragments;
+    let order = &self.scratch.order;
+    let slot = order
+      .binary_search_by(|ordinal| fragment_name(document, rows, *ordinal).cmp(name))
+      .ok()?;
+    // Ties are ordered by ordinal, so walking back to the group's start finds the first
+    // definition rather than whichever one the search landed on.
+    let ordinal = order[slot];
+    let group = rows[ordinal as usize].group;
+    order.get(group.start() as usize).copied()
+  }
+
+  /// Walks every definition once, recording its fragment spreads as graph edges and reporting
+  /// draft 5.5.2.1 for the ones that name nothing.
+  fn collect_edges(&mut self) -> ControlFlow<()> {
+    let document = self.document;
+    let total = document.definitions().len() as u32;
+    let mut operations = 0usize;
+    let mut fragments = 0usize;
+    for index in 0..total {
+      let start = self.scratch.edges.len() as u32;
+      self.collect_definition_edges(index)?;
+      let range = range32(start, self.scratch.edges.len() as u32);
+      match definition(document, index) {
+        Some(ExecutableDefinition::Operation(_)) => {
+          self.scratch.operations[operations].edges = range;
+          operations += 1;
+        }
+        Some(ExecutableDefinition::Fragment(_)) => {
+          self.scratch.fragments[fragments].edges = range;
+          fragments += 1;
+        }
+        None => {}
+      }
+    }
+    ControlFlow::Continue(())
+  }
+
+  fn collect_definition_edges(&mut self, index: u32) -> ControlFlow<()> {
+    let document = self.document;
+    self.scratch.frames.clear();
+    self.scratch.frames.push(Frame::root(index, NONE, 0));
+    let mut current = root_selection_set(document, index);
+    while let Some(frame) = self.scratch.frames.last().copied() {
+      let Some(set) = current else {
+        self.scratch.frames.pop();
+        current = selections::resolve(document, &self.scratch.frames);
+        continue;
+      };
+      let selections = set.selections();
+      let Some(selection) = selections.get(frame.cursor as usize) else {
+        self.scratch.frames.pop();
+        current = selections::resolve(document, &self.scratch.frames);
+        continue;
+      };
+      if let Some(top) = self.scratch.frames.last_mut() {
+        top.cursor += 1;
+      }
+      match selection {
+        Selection::FragmentSpread(spread) => {
+          let name = spread.name();
+          let to = self.find_fragment(name_bytes(name));
+          if to.is_none() && self.on(Rule::FragmentSpreadTargetDefined) {
+            let diagnostic = Diagnostic::new(Rule::FragmentSpreadTargetDefined, *name.as_span())
+              .subject(name.source().clone());
+            self.emit(diagnostic)?;
+          }
+          self.scratch.edges.push(Edge {
+            to: to.unwrap_or(NONE),
+            span: *spread.span(),
+          });
+        }
+        _ => {
+          if let Some(child) = child_selection_set(selection) {
+            self
+              .scratch
+              .frames
+              .push(Frame::child(index, frame.cursor, NONE, 0));
+            current = Some(child);
+          }
+        }
+      }
+    }
+    ControlFlow::Continue(())
+  }
+
+  // -- 2. operation rules ---------------------------------------------------------------------
+
+  fn check_operations(&mut self) -> ControlFlow<()> {
+    let document = self.document;
+
+    // 5.2.1.1 — the schema must provide the root operation type the operation needs.
+    if self.on(Rule::OperationTypeExistence) {
+      for index in 0..self.scratch.operations.len() {
+        let row = self.scratch.operations[index];
+        let root = RootOperation::ALL[row.root as usize];
+        if self.schema.root(root).is_none() {
+          let diagnostic =
+            Diagnostic::new(Rule::OperationTypeExistence, row.span).context(Context::Root(root));
+          let diagnostic = match operation_name(document, row.definition) {
+            Some(name) => diagnostic.subject(name.source().clone()),
+            None => diagnostic,
+          };
+          self.emit(diagnostic)?;
+        }
+      }
+    }
+
+    // 5.2.2.1 — named operations must not collide. Sorted index scan, no map.
+    if self.on(Rule::OperationNameUniqueness) {
+      let base = self.scratch.keys.len();
+      for index in 0..self.scratch.operations.len() {
+        if self.scratch.operations[index].named {
+          self.scratch.keys.push(index as u32);
+        }
+      }
+      {
+        let scratch = &mut *self.scratch;
+        let rows = &scratch.operations;
+        // Ties break on the document index, so the first definition of a name is always the
+        // group's first element and every later one is blamed against it.
+        scratch.keys[base..].sort_unstable_by(|a, b| {
+          let left = operation_name_bytes(document, rows, *a);
+          let right = operation_name_bytes(document, rows, *b);
+          left.cmp(right).then(a.cmp(b))
+        });
+      }
+      let mut start = base;
+      while start < self.scratch.keys.len() {
+        let first = self.scratch.keys[start];
+        let name = operation_name_bytes(document, &self.scratch.operations, first);
+        let mut end = start + 1;
+        while end < self.scratch.keys.len()
+          && operation_name_bytes(document, &self.scratch.operations, self.scratch.keys[end])
+            == name
+        {
+          end += 1;
+        }
+        let related = self.scratch.operations[first as usize].span;
+        for slot in start + 1..end {
+          let row = self.scratch.operations[self.scratch.keys[slot] as usize];
+          if let Some(name) = operation_name(document, row.definition) {
+            let diagnostic = Diagnostic::new(Rule::OperationNameUniqueness, row.span)
+              .subject(name.source().clone())
+              .related(related);
+            self.emit(diagnostic)?;
+          }
+        }
+        start = end;
+      }
+      self.scratch.keys.truncate(base);
+    }
+
+    // 5.2.3.1 — an anonymous operation must be the document's only one.
+    if self.on(Rule::LoneAnonymousOperation) && self.scratch.operations.len() > 1 {
+      for index in 0..self.scratch.operations.len() {
+        let row = self.scratch.operations[index];
+        if !row.named {
+          self.emit(
+            Diagnostic::new(Rule::LoneAnonymousOperation, row.span)
+              .context(Context::Count(self.scratch.operations.len() as u32)),
+          )?;
+        }
+      }
+    }
+
+    ControlFlow::Continue(())
+  }
+
+  // -- 3. fragment declaration rules ------------------------------------------------------------
+
+  fn check_fragment_declarations(&mut self) -> ControlFlow<()> {
+    let document = self.document;
+    for ordinal in 0..self.scratch.fragments.len() {
+      let row = self.scratch.fragments[ordinal];
+      let Some(fragment) = fragment(document, row.definition) else {
+        continue;
+      };
+      let condition = fragment.type_condition().name();
+      self.check_type_condition(condition)?;
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Draft 5.5.1.2 and 5.5.1.3, shared by fragment definitions and inline fragments.
+  ///
+  /// Returns the condition's type when it resolved to a composite one, which is also the scope its
+  /// selection set is written against.
+  fn check_type_condition(&mut self, condition: &Name<S>) -> ControlFlow<(), Option<TypeId>> {
+    let Some(id) = self.type_of(condition) else {
+      if self.on(Rule::FragmentSpreadTypeExistence) {
+        self.report_name(Rule::FragmentSpreadTypeExistence, condition, Context::None)?;
+      }
+      return ControlFlow::Continue(None);
+    };
+    if !self.schema.type_def(id).kind().is_composite() {
+      if self.on(Rule::FragmentsOnCompositeTypes) {
+        let context = Context::Type(self.schema.type_def(id).name());
+        self.report_name(Rule::FragmentsOnCompositeTypes, condition, context)?;
+      }
+      return ControlFlow::Continue(None);
+    }
+    ControlFlow::Continue(Some(id))
+  }
+
+  // -- 4. the fragment graph --------------------------------------------------------------------
+
+  /// Draft 5.5.2.2, as an iterative depth-first search over integers.
+  fn check_fragment_cycles(&mut self) -> ControlFlow<()> {
+    if !self.on(Rule::FragmentSpreadsMustNotFormCycles) {
+      return ControlFlow::Continue(());
+    }
+    let count = self.scratch.fragments.len();
+    reset_bits(&mut self.scratch.on_path, count);
+    reset_bits(&mut self.scratch.done, count);
+    for start in 0..count as u32 {
+      if get_bit(&self.scratch.done, start) {
+        continue;
+      }
+      self.scratch.graph.clear();
+      set_bit(&mut self.scratch.on_path, start);
+      self.scratch.graph.push(GraphFrame {
+        fragment: start,
+        edge: self.scratch.fragments[start as usize].edges.start(),
+      });
+      while let Some(top) = self.scratch.graph.last().copied() {
+        let row = self.scratch.fragments[top.fragment as usize];
+        if top.edge >= row.edges.end() {
+          clear_bit(&mut self.scratch.on_path, top.fragment);
+          set_bit(&mut self.scratch.done, top.fragment);
+          self.scratch.graph.pop();
+          continue;
+        }
+        if let Some(frame) = self.scratch.graph.last_mut() {
+          frame.edge += 1;
+        }
+        let edge = self.scratch.edges[top.edge as usize];
+        if edge.to == NONE {
+          continue;
+        }
+        if get_bit(&self.scratch.on_path, edge.to) {
+          let subject = self.scratch.fragments[edge.to as usize];
+          let Some(target) = fragment(self.document, subject.definition) else {
+            continue;
+          };
+          let diagnostic = Diagnostic::new(Rule::FragmentSpreadsMustNotFormCycles, edge.span)
+            .subject(target.name().source().clone())
+            .related(subject.span);
+          self.emit(diagnostic)?;
+          continue;
+        }
+        if get_bit(&self.scratch.done, edge.to) {
+          continue;
+        }
+        set_bit(&mut self.scratch.on_path, edge.to);
+        self.scratch.graph.push(GraphFrame {
+          fragment: edge.to,
+          edge: self.scratch.fragments[edge.to as usize].edges.start(),
+        });
+      }
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Draft 5.5.1.4, as reachability from the operations over the same graph.
+  ///
+  /// Reachability propagates across every definition sharing a name, so one duplicated fragment
+  /// name reports 5.5.1.1 and nothing else — the copy is not also "unused".
+  fn check_fragments_used(&mut self) -> ControlFlow<()> {
+    let count = self.scratch.fragments.len();
+    reset_bits(&mut self.scratch.reachable, count);
+    self.scratch.graph.clear();
+    for index in 0..self.scratch.operations.len() {
+      let edges = self.scratch.operations[index].edges;
+      for slot in edges.start()..edges.end() {
+        let to = self.scratch.edges[slot as usize].to;
+        self.mark_reachable(to);
+      }
+    }
+    while let Some(frame) = self.scratch.graph.pop() {
+      let edges = self.scratch.fragments[frame.fragment as usize].edges;
+      for slot in edges.start()..edges.end() {
+        let to = self.scratch.edges[slot as usize].to;
+        self.mark_reachable(to);
+      }
+    }
+
+    if !self.on(Rule::FragmentsMustBeUsed) {
+      return ControlFlow::Continue(());
+    }
+    for ordinal in 0..count as u32 {
+      if get_bit(&self.scratch.reachable, ordinal) {
+        continue;
+      }
+      let row = self.scratch.fragments[ordinal as usize];
+      let Some(target) = fragment(self.document, row.definition) else {
+        continue;
+      };
+      let diagnostic = Diagnostic::new(Rule::FragmentsMustBeUsed, row.span)
+        .subject(target.name().source().clone());
+      self.emit(diagnostic)?;
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Marks a fragment and every same-named definition reachable, queueing the newly marked.
+  fn mark_reachable(&mut self, ordinal: u32) {
+    if ordinal == NONE {
+      return;
+    }
+    let group = self.scratch.fragments[ordinal as usize].group;
+    for slot in group.start()..group.end() {
+      let member = self.scratch.order[slot as usize];
+      if !set_bit(&mut self.scratch.reachable, member) {
+        self.scratch.graph.push(GraphFrame {
+          fragment: member,
+          edge: 0,
+        });
+      }
+    }
+  }
+
+  // -- 5. subscriptions ---------------------------------------------------------------------------
+
+  fn check_subscriptions(&mut self) -> ControlFlow<()> {
+    if !self.on(Rule::SingleRootField) {
+      return ControlFlow::Continue(());
+    }
+    let Some(root) = self.schema.root(RootOperation::Subscription) else {
+      return ControlFlow::Continue(());
+    };
+    for index in 0..self.scratch.operations.len() {
+      let row = self.scratch.operations[index];
+      if RootOperation::ALL[row.root as usize] != RootOperation::Subscription {
+        continue;
+      }
+      self.check_subscription_roots(row, root)?;
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Draft 5.2.4.1's `CollectSubscriptionFields`, as an explicit walk.
+  ///
+  /// It only has to answer "is the collected map a set of one, and is that one an introspection
+  /// field", so it never builds the map: two distinct response names are enough to fail, and the
+  /// first response name seen is the only one it needs to keep.
+  fn check_subscription_roots(&mut self, row: OperationRow, root: TypeId) -> ControlFlow<()> {
+    let document = self.document;
+    reset_bits(&mut self.scratch.visited, self.scratch.fragments.len());
+    self.scratch.roots.clear();
+    self
+      .scratch
+      .roots
+      .push(Frame::root(row.definition, NONE, 0));
+    let mut current = root_selection_set(document, row.definition);
+
+    let mut first: Option<&'d Name<S>> = None;
+    let mut distinct = 0u32;
+    let mut multiple = false;
+
+    while let Some(frame) = self.scratch.roots.last().copied() {
+      let Some(set) = current else {
+        self.scratch.roots.pop();
+        current = selections::resolve(document, &self.scratch.roots);
+        continue;
+      };
+      let Some(selection) = set.selections().get(frame.cursor as usize) else {
+        self.scratch.roots.pop();
+        current = selections::resolve(document, &self.scratch.roots);
+        continue;
+      };
+      if let Some(top) = self.scratch.roots.last_mut() {
+        top.cursor += 1;
+      }
+
+      // "{selection} must not provide the `@skip`/`@include` directive" — the whole reason this
+      // collection exists is that it has no runtime variables to evaluate them with.
+      if let Some(directive) = self.conditional_directive(selection) {
+        let diagnostic = Diagnostic::new(Rule::SingleRootField, *directive.as_span())
+          .subject(directive.source().clone());
+        self.emit(diagnostic)?;
+      }
+
+      match selection {
+        Selection::Field(field) => {
+          let name = nodes::response_name(field);
+          match first {
+            None => {
+              first = Some(name);
+              distinct = 1;
+            }
+            Some(seen) if name_bytes(seen) != name_bytes(name) => multiple = true,
+            Some(_) => {}
+          }
+        }
+        Selection::InlineFragment(inline) => {
+          let applies = match inline.type_condition() {
+            Some(condition) => self.condition_applies(condition.name(), root),
+            None => true,
+          };
+          if applies {
+            self
+              .scratch
+              .roots
+              .push(Frame::child(frame.definition, frame.cursor, NONE, 0));
+            current = Some(inline.selection_set());
+          }
+        }
+        Selection::FragmentSpread(spread) => {
+          let Some(ordinal) = self.find_fragment(name_bytes(spread.name())) else {
+            continue;
+          };
+          if set_bit(&mut self.scratch.visited, ordinal) {
+            continue;
+          }
+          let target = self.scratch.fragments[ordinal as usize];
+          let Some(body) = fragment(document, target.definition) else {
+            continue;
+          };
+          if !self.condition_applies(body.type_condition().name(), root) {
+            continue;
+          }
+          self
+            .scratch
+            .roots
+            .push(Frame::root(target.definition, NONE, 0));
+          current = Some(body.selection_set());
+        }
+      }
+    }
+
+    if multiple {
+      // The map has at least two entries; the count is not worth a second walk to make exact.
+      self.emit(
+        Diagnostic::new(Rule::SingleRootField, row.span).context(Context::Count(distinct + 1)),
+      )?;
+    } else {
+      match first {
+        None => {
+          self.emit(Diagnostic::new(Rule::SingleRootField, row.span).context(Context::Count(0)))?;
+        }
+        Some(name) if is_reserved(name_bytes(name)) => {
+          self.report_name(Rule::SingleRootField, name, Context::None)?;
+        }
+        Some(_) => {}
+      }
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Returns the `@skip` or `@include` a selection carries, if it carries one.
+  fn conditional_directive(&self, selection: &'d Selection<S>) -> Option<&'d Name<S>> {
+    let directives = match selection {
+      Selection::Field(field) => field.directives(),
+      Selection::FragmentSpread(spread) => spread.directives(),
+      Selection::InlineFragment(inline) => inline.directives(),
+    }?;
+    directives.directives().iter().find_map(|directive| {
+      let name = directive.name();
+      matches!(name_bytes(name), b"skip" | b"include").then_some(name)
+    })
+  }
+
+  /// `DoesFragmentTypeApply` against a known object type.
+  fn condition_applies(&self, condition: &Name<S>, object: TypeId) -> bool {
+    match self.type_of(condition) {
+      // An undefined or non-composite condition is 5.5.1.2/5.5.1.3's business; here it simply
+      // cannot contribute a root field.
+      Some(id) => self.schema.is_possible_object(id, object),
+      None => false,
+    }
+  }
+
+  // -- 6. the per-operation walks ------------------------------------------------------------
+
+  fn walk_operations(&mut self) -> ControlFlow<()> {
+    let document = self.document;
+    for index in 0..self.scratch.operations.len() {
+      let row = self.scratch.operations[index];
+      let Some(operation) = operation(document, row.definition) else {
+        continue;
+      };
+
+      self.variables = match operation {
+        OperationDefinition::Named(named) => match named.variable_definitions() {
+          Some(definitions) => definitions.variable_definitions(),
+          None => &[],
+        },
+        OperationDefinition::Shorthand(_) => &[],
+      };
+      self.in_operation = true;
+
+      self.check_variable_definitions(row)?;
+
+      let root = RootOperation::ALL[row.root as usize];
+      if let OperationDefinition::Named(named) = operation
+        && let Some(directives) = named.directives()
+      {
+        self.check_directives(directives.directives(), directive_location(root), true)?;
+      }
+
+      let scope = self.schema.root(root).map_or(NONE, |id| id.get());
+      reset_bits(&mut self.scratch.visited, self.scratch.fragments.len());
+      self.walk_selections(Frame::root(row.definition, scope, Frame::CHECK))?;
+
+      self.check_variables_used(row)?;
+
+      self.variables = &[];
+      self.in_operation = false;
+    }
+    ControlFlow::Continue(())
+  }
+
+  // -- 7. fragments nothing reached -------------------------------------------------------------
+
+  fn walk_unreached_fragments(&mut self) -> ControlFlow<()> {
+    let document = self.document;
+    for ordinal in 0..self.scratch.fragments.len() {
+      let row = self.scratch.fragments[ordinal];
+      if get_bit(&self.scratch.checked, row.definition) {
+        continue;
+      }
+      let Some(body) = fragment(document, row.definition) else {
+        continue;
+      };
+      // The condition was already reported on, if it needed reporting, by the declaration pass.
+      let scope = self
+        .composite_of(body.type_condition().name())
+        .map_or(NONE, |id| id.get());
+      self.begin_fragment(row.definition)?;
+      self.walk_selections(Frame::root(row.definition, scope, Frame::CHECK))?;
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Records that a fragment's definition-local rules are running now, and checks the directives
+  /// on the definition itself.
+  pub(super) fn begin_fragment(&mut self, index: u32) -> ControlFlow<()> {
+    grow_bits(&mut self.scratch.checked, index as usize + 1);
+    set_bit(&mut self.scratch.checked, index);
+    let Some(body) = fragment(self.document, index) else {
+      return ControlFlow::Continue(());
+    };
+    match body.directives() {
+      Some(directives) => self.check_directives(
+        directives.directives(),
+        DirectiveLocation::FragmentDefinition,
+        true,
+      ),
+      None => ControlFlow::Continue(()),
+    }
+  }
+
+  // -- variables ------------------------------------------------------------------------------
+
+  /// Draft 5.8.1 and 5.8.2, plus the value and directive rules over a variable definition's own
+  /// default value and directives — the one place in an executable document where constant values
+  /// appear.
+  fn check_variable_definitions(&mut self, row: OperationRow) -> ControlFlow<()> {
+    let definitions = self.variables;
+    reset_bits(&mut self.scratch.used, definitions.len());
+    let _ = row;
+
+    // 5.8.1 — one type per variable name, per operation.
+    if self.on(Rule::VariableUniqueness) {
+      let base = self.scratch.keys.len();
+      for index in 0..definitions.len() {
+        self.scratch.keys.push(index as u32);
+      }
+      self.scratch.keys[base..].sort_unstable_by(|a, b| {
+        let left = name_bytes(definitions[*a as usize].node().variable().name());
+        let right = name_bytes(definitions[*b as usize].node().variable().name());
+        left.cmp(right).then(a.cmp(b))
+      });
+      let mut slot = base + 1;
+      while slot < self.scratch.keys.len() {
+        let earlier = self.scratch.keys[slot - 1].min(self.scratch.keys[slot]);
+        let later = self.scratch.keys[slot - 1].max(self.scratch.keys[slot]);
+        let first = definitions[earlier as usize].node().variable();
+        let repeat = definitions[later as usize].node().variable();
+        if name_bytes(first.name()) == name_bytes(repeat.name()) {
+          let diagnostic = Diagnostic::new(Rule::VariableUniqueness, *repeat.span())
+            .subject(repeat.name().source().clone())
+            .related(*first.span());
+          self.emit(diagnostic)?;
+        }
+        slot += 1;
+      }
+      self.scratch.keys.truncate(base);
+    }
+
+    for described in definitions {
+      let definition = described.node();
+      let variable = definition.variable();
+      let declared = self.pack_type(definition.ty());
+
+      // 5.8.2 — objects, interfaces and unions cannot be variable types, and neither can a name
+      // the schema does not have.
+      let is_input =
+        declared.is_some_and(|packed| self.schema.type_def(packed.base_id()).kind().is_input());
+      if !is_input && self.on(Rule::VariablesAreInputTypes) {
+        let context = match declared {
+          Some(packed) => Context::Expected(packed),
+          None => Context::None,
+        };
+        self.report_name(Rule::VariablesAreInputTypes, variable.name(), context)?;
+      }
+
+      if let Some(default) = definition.default_value() {
+        self.walk_value(default.value(), declared, ValueLocation::PLAIN, true)?;
+      }
+
+      if let Some(directives) = definition.directives() {
+        self.check_directives(
+          directives.directives(),
+          DirectiveLocation::VariableDefinition,
+          true,
+        )?;
+      }
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Draft 5.8.4, read off the marks the usages left.
+  fn check_variables_used(&mut self, row: OperationRow) -> ControlFlow<()> {
+    let _ = row;
+    if !self.on(Rule::AllVariablesUsed) {
+      return ControlFlow::Continue(());
+    }
+    for index in 0..self.variables.len() {
+      if get_bit(&self.scratch.used, index as u32) {
+        continue;
+      }
+      let variable = self.variables[index].node().variable();
+      let diagnostic = Diagnostic::new(Rule::AllVariablesUsed, *variable.span())
+        .subject(variable.name().source().clone());
+      self.emit(diagnostic)?;
+    }
+    ControlFlow::Continue(())
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// free helpers
+// ---------------------------------------------------------------------------------------------
+
+/// Builds a table range.
+fn range32(start: u32, end: u32) -> super::schema::Range32 {
+  super::schema::Range32::new(start, end)
+}
+
+/// Grows a bitset to hold at least `bits` bits, preserving what is already set.
+fn grow_bits(words: &mut std::vec::Vec<u64>, bits: usize) {
+  let needed = bits.div_ceil(64);
+  if words.len() < needed {
+    words.resize(needed, 0);
+  }
+}
+
+/// The root operation slot an operation keyword needs.
+fn root_operation(keyword: &OperationType) -> RootOperation {
+  match keyword {
+    OperationType::Query(_) => RootOperation::Query,
+    OperationType::Mutation(_) => RootOperation::Mutation,
+    OperationType::Subscription(_) => RootOperation::Subscription,
+  }
+}
+
+/// The directive location an operation of this kind is.
+fn directive_location(root: RootOperation) -> DirectiveLocation {
+  match root {
+    RootOperation::Query => DirectiveLocation::Query,
+    RootOperation::Mutation => DirectiveLocation::Mutation,
+    RootOperation::Subscription => DirectiveLocation::Subscription,
+  }
+}
+
+/// Returns an operation's name node, when it has one.
+fn operation_name<S>(document: &ExecutableDocument<S>, index: u32) -> Option<&Name<S>> {
+  match operation(document, index)? {
+    OperationDefinition::Named(named) => named.name(),
+    OperationDefinition::Shorthand(_) => None,
+  }
+}
+
+/// Returns an operation's name bytes, or the empty slice when it is anonymous.
+fn operation_name_bytes<'d, S>(
+  document: &'d ExecutableDocument<S>,
+  rows: &[OperationRow],
+  index: u32,
+) -> &'d [u8]
+where
+  S: AsRef<[u8]>,
+{
+  rows
+    .get(index as usize)
+    .and_then(|row| operation_name(document, row.definition))
+    .map_or(&[][..], name_bytes)
+}
+
+/// Returns a fragment's name bytes.
+fn fragment_name<'d, S>(
+  document: &'d ExecutableDocument<S>,
+  rows: &[FragmentRow],
+  ordinal: u32,
+) -> &'d [u8]
+where
+  S: AsRef<[u8]>,
+{
+  rows
+    .get(ordinal as usize)
+    .and_then(|row| fragment(document, row.definition))
+    .map_or(&[][..], |fragment| name_bytes(fragment.name()))
+}

--- a/smear/src/validator/executable/nodes.rs
+++ b/smear/src/validator/executable/nodes.rs
@@ -1,0 +1,454 @@
+//! The two small abstractions the rules need over the syntactic AST, and the accessors that keep
+//! the traversal readable.
+//!
+//! # Why any abstraction at all
+//!
+//! GraphQL writes the same argument and directive grammar twice: once where variables may appear
+//! (fields, spreads, inline fragments, operations, fragment definitions) and once where they may
+//! not (a variable definition's default value and its directives). The AST spells those as two
+//! type families — `InputValue`/`ConstInputValue`, `Directive`/`ConstDirective` — which differ in
+//! exactly one variant. [`ValueLike`] and [`DirectiveLike`] name what the rules use, so draft
+//! 5.4.x, 5.6.x and 5.7.x are written once and instantiated twice instead of being copied and
+//! left to drift.
+//!
+//! Neither trait is public. They abstract over two known types, not over an open set, and the
+//! `Option`-returning shape they have would be wrong for anything else — it exists because a
+//! constant value simply has no variable arm to return.
+
+use tokora::{SimpleSpan, span::AsSpan};
+
+use crate::parser::graphql::ast::{
+  Argument, BooleanValue, ConstArgument, ConstDirective, ConstInputValue, ConstObjectField,
+  Directive, EnumValue, ExecutableDefinition, ExecutableDocument, FloatValue, FragmentDefinition,
+  InputValue, IntValue, Name, ObjectField, OperationDefinition, Selection, SelectionSet,
+  StringValue, VariableValue,
+};
+
+/// A GraphQL input value, whether or not it may contain variables.
+pub(crate) trait ValueLike<S>: Sized {
+  /// The object-field row type an object literal of this family holds.
+  type Field: ObjectFieldLike<S, Value = Self>;
+
+  /// Returns the span covering the value.
+  fn value_span(&self) -> SimpleSpan;
+  /// Returns the variable, when the value is one.
+  ///
+  /// Always `None` for a constant value, which is what makes draft 5.8's rules vanish from the
+  /// constant instantiation rather than needing to be switched off.
+  fn as_variable(&self) -> Option<&VariableValue<S>>;
+  /// Returns whether the value is the `null` literal.
+  fn is_null(&self) -> bool;
+  /// Returns the boolean literal, when the value is one.
+  fn as_boolean(&self) -> Option<&BooleanValue<S>>;
+  /// Returns the integer literal, when the value is one.
+  fn as_int(&self) -> Option<&IntValue<S>>;
+  /// Returns the float literal, when the value is one.
+  fn as_float(&self) -> Option<&FloatValue<S>>;
+  /// Returns the string literal, when the value is one.
+  fn as_string(&self) -> Option<&StringValue<S>>;
+  /// Returns the enum literal, when the value is one.
+  fn as_enum(&self) -> Option<&EnumValue<S>>;
+  /// Returns the list's entries, when the value is a list literal.
+  fn as_list(&self) -> Option<&[Self]>;
+  /// Returns the object's fields, when the value is an object literal.
+  fn as_object(&self) -> Option<&[Self::Field]>;
+}
+
+/// One `Name : Value` row of an object literal.
+pub(crate) trait ObjectFieldLike<S> {
+  /// The value type the row carries.
+  type Value;
+
+  /// Returns the span covering the row.
+  fn field_span(&self) -> SimpleSpan;
+  /// Returns the field's name.
+  fn field_name(&self) -> &Name<S>;
+  /// Returns the field's value.
+  fn field_value(&self) -> &Self::Value;
+}
+
+/// One `Name : Value` argument of a field or directive.
+pub(crate) trait ArgumentLike<S> {
+  /// The value type the argument carries.
+  type Value: ValueLike<S>;
+
+  /// Returns the span covering the argument.
+  fn argument_span(&self) -> SimpleSpan;
+  /// Returns the argument's name.
+  fn argument_name(&self) -> &Name<S>;
+  /// Returns the argument's value.
+  fn argument_value(&self) -> &Self::Value;
+}
+
+impl<S> ObjectFieldLike<S> for ObjectField<S> {
+  type Value = InputValue<S>;
+
+  #[inline]
+  fn field_span(&self) -> SimpleSpan {
+    *self.span()
+  }
+
+  #[inline]
+  fn field_name(&self) -> &Name<S> {
+    self.name()
+  }
+
+  #[inline]
+  fn field_value(&self) -> &Self::Value {
+    self.value()
+  }
+}
+
+impl<S> ObjectFieldLike<S> for ConstObjectField<S> {
+  type Value = ConstInputValue<S>;
+
+  #[inline]
+  fn field_span(&self) -> SimpleSpan {
+    *self.span()
+  }
+
+  #[inline]
+  fn field_name(&self) -> &Name<S> {
+    self.name()
+  }
+
+  #[inline]
+  fn field_value(&self) -> &Self::Value {
+    self.value()
+  }
+}
+
+impl<S> ArgumentLike<S> for Argument<S> {
+  type Value = InputValue<S>;
+
+  #[inline]
+  fn argument_span(&self) -> SimpleSpan {
+    *self.span()
+  }
+
+  #[inline]
+  fn argument_name(&self) -> &Name<S> {
+    self.name()
+  }
+
+  #[inline]
+  fn argument_value(&self) -> &Self::Value {
+    self.value()
+  }
+}
+
+impl<S> ArgumentLike<S> for ConstArgument<S> {
+  type Value = ConstInputValue<S>;
+
+  #[inline]
+  fn argument_span(&self) -> SimpleSpan {
+    *self.span()
+  }
+
+  #[inline]
+  fn argument_name(&self) -> &Name<S> {
+    self.name()
+  }
+
+  #[inline]
+  fn argument_value(&self) -> &Self::Value {
+    self.value()
+  }
+}
+
+impl<S> ValueLike<S> for InputValue<S> {
+  type Field = ObjectField<S>;
+
+  #[inline]
+  fn value_span(&self) -> SimpleSpan {
+    *self.as_span()
+  }
+
+  #[inline]
+  fn as_variable(&self) -> Option<&VariableValue<S>> {
+    match self {
+      Self::Variable(variable) => Some(variable),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn is_null(&self) -> bool {
+    matches!(self, Self::Null(_))
+  }
+
+  #[inline]
+  fn as_boolean(&self) -> Option<&BooleanValue<S>> {
+    match self {
+      Self::Boolean(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_int(&self) -> Option<&IntValue<S>> {
+    match self {
+      Self::Int(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_float(&self) -> Option<&FloatValue<S>> {
+    match self {
+      Self::Float(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_string(&self) -> Option<&StringValue<S>> {
+    match self {
+      Self::String(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_enum(&self) -> Option<&EnumValue<S>> {
+    match self {
+      Self::Enum(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_list(&self) -> Option<&[Self]> {
+    match self {
+      Self::List(list) => Some(list.values()),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_object(&self) -> Option<&[ObjectField<S>]> {
+    match self {
+      Self::Object(object) => Some(object.fields()),
+      _ => None,
+    }
+  }
+}
+
+impl<S> ValueLike<S> for ConstInputValue<S> {
+  type Field = ConstObjectField<S>;
+
+  #[inline]
+  fn value_span(&self) -> SimpleSpan {
+    *self.as_span()
+  }
+
+  #[inline]
+  fn as_variable(&self) -> Option<&VariableValue<S>> {
+    None
+  }
+
+  #[inline]
+  fn is_null(&self) -> bool {
+    matches!(self, Self::Null(_))
+  }
+
+  #[inline]
+  fn as_boolean(&self) -> Option<&BooleanValue<S>> {
+    match self {
+      Self::Boolean(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_int(&self) -> Option<&IntValue<S>> {
+    match self {
+      Self::Int(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_float(&self) -> Option<&FloatValue<S>> {
+    match self {
+      Self::Float(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_string(&self) -> Option<&StringValue<S>> {
+    match self {
+      Self::String(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_enum(&self) -> Option<&EnumValue<S>> {
+    match self {
+      Self::Enum(value) => Some(value),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_list(&self) -> Option<&[Self]> {
+    match self {
+      Self::List(list) => Some(list.values()),
+      _ => None,
+    }
+  }
+
+  #[inline]
+  fn as_object(&self) -> Option<&[ConstObjectField<S>]> {
+    match self {
+      Self::Object(object) => Some(object.fields()),
+      _ => None,
+    }
+  }
+}
+
+/// A GraphQL directive application, whether or not its arguments may contain variables.
+pub(crate) trait DirectiveLike<S> {
+  /// The argument row type this directive holds.
+  type Argument: ArgumentLike<S>;
+
+  /// Returns the span covering the directive.
+  fn directive_span(&self) -> SimpleSpan;
+  /// Returns the directive's name, without the `@`.
+  fn directive_name(&self) -> &Name<S>;
+  /// Returns the directive's arguments; empty when it has none.
+  fn directive_arguments(&self) -> &[Self::Argument];
+}
+
+impl<S> DirectiveLike<S> for Directive<S> {
+  type Argument = Argument<S>;
+
+  #[inline]
+  fn directive_span(&self) -> SimpleSpan {
+    *self.span()
+  }
+
+  #[inline]
+  fn directive_name(&self) -> &Name<S> {
+    self.name()
+  }
+
+  #[inline]
+  fn directive_arguments(&self) -> &[Self::Argument] {
+    match self.arguments() {
+      Some(arguments) => arguments.arguments(),
+      None => &[],
+    }
+  }
+}
+
+impl<S> DirectiveLike<S> for ConstDirective<S> {
+  type Argument = ConstArgument<S>;
+
+  #[inline]
+  fn directive_span(&self) -> SimpleSpan {
+    *self.span()
+  }
+
+  #[inline]
+  fn directive_name(&self) -> &Name<S> {
+    self.name()
+  }
+
+  #[inline]
+  fn directive_arguments(&self) -> &[Self::Argument] {
+    match self.arguments() {
+      Some(arguments) => arguments.arguments(),
+      None => &[],
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// document accessors
+// ---------------------------------------------------------------------------------------------
+
+/// Returns a definition by index, stripped of the description wrapper.
+///
+/// Descriptions on executable definitions are a frozen-parser compatibility affordance and mean
+/// nothing to the specification, so no rule ever sees one.
+#[inline]
+pub(crate) fn definition<S>(
+  document: &ExecutableDocument<S>,
+  index: u32,
+) -> Option<&ExecutableDefinition<S>> {
+  document
+    .definitions()
+    .get(index as usize)
+    .map(|described| described.node())
+}
+
+/// Returns the operation at `index`, or `None` when the definition is a fragment.
+#[inline]
+pub(crate) fn operation<S>(
+  document: &ExecutableDocument<S>,
+  index: u32,
+) -> Option<&OperationDefinition<S>> {
+  match definition(document, index)? {
+    ExecutableDefinition::Operation(operation) => Some(operation),
+    ExecutableDefinition::Fragment(_) => None,
+  }
+}
+
+/// Returns the fragment at `index`, or `None` when the definition is an operation.
+#[inline]
+pub(crate) fn fragment<S>(
+  document: &ExecutableDocument<S>,
+  index: u32,
+) -> Option<&FragmentDefinition<S>> {
+  match definition(document, index)? {
+    ExecutableDefinition::Fragment(fragment) => Some(fragment),
+    ExecutableDefinition::Operation(_) => None,
+  }
+}
+
+/// Returns a definition's own top-level selection set.
+#[inline]
+pub(crate) fn root_selection_set<S>(
+  document: &ExecutableDocument<S>,
+  index: u32,
+) -> Option<&SelectionSet<S>> {
+  Some(match definition(document, index)? {
+    ExecutableDefinition::Operation(OperationDefinition::Named(named)) => named.selection_set(),
+    ExecutableDefinition::Operation(OperationDefinition::Shorthand(set)) => set,
+    ExecutableDefinition::Fragment(fragment) => fragment.selection_set(),
+  })
+}
+
+/// Returns the selection set a selection encloses, when it encloses one.
+///
+/// A fragment spread never does — its body belongs to the definition it names, which is why the
+/// traversal enters a spread by starting a new definition level rather than by descending.
+#[inline]
+pub(crate) fn child_selection_set<S>(selection: &Selection<S>) -> Option<&SelectionSet<S>> {
+  match selection {
+    Selection::Field(field) => field.selection_set(),
+    Selection::InlineFragment(inline) => Some(inline.selection_set()),
+    Selection::FragmentSpread(_) => None,
+  }
+}
+
+/// Returns a name's source bytes.
+#[inline]
+pub(crate) fn name_bytes<S>(name: &Name<S>) -> &[u8]
+where
+  S: AsRef<[u8]>,
+{
+  name.source().as_ref()
+}
+
+/// Returns a field's response name — the alias when it has one, otherwise the field name.
+#[inline]
+pub(crate) fn response_name<S>(field: &crate::parser::graphql::ast::Field<S>) -> &Name<S> {
+  match field.alias() {
+    Some(alias) => alias.name(),
+    None => field.name(),
+  }
+}

--- a/smear/src/validator/executable/selections.rs
+++ b/smear/src/validator/executable/selections.rs
@@ -1,0 +1,304 @@
+//! The selection walk: draft 5.3.1, 5.3.3 and 5.5.2.3, and the traversal every other per-node
+//! rule rides.
+//!
+//! # One walk per operation, and one check per definition
+//!
+//! A fragment reached by three operations is walked three times, because the variable rules are
+//! properties of an operation and the same fragment may be valid under one operation's variables
+//! and invalid under another's. Everything else is a property of the *definition*, so those rules
+//! are gated on [`Frame::CHECK`], which is set the first time a definition is entered and cleared
+//! for every later visit. A fragment with a misspelled field reports it once, not once per caller.
+
+use core::ops::ControlFlow;
+
+use tokora::span::AsSpan;
+
+use crate::parser::graphql::ast::{
+  ExecutableDocument, Field, FragmentSpread, InlineFragment, Selection, SelectionSet,
+};
+
+use super::{
+  Rule, TypeId, Validator,
+  nodes::{child_selection_set, fragment, name_bytes, root_selection_set},
+};
+use crate::validator::{
+  diagnostic::Context,
+  schema::{DirectiveLocation, Schema},
+  scratch::{Frame, NONE, get_bit, set_bit},
+};
+
+/// Locates a selection set by descending from a definition along the frame chain.
+///
+/// The innermost frame with no parent index names the definition to start from — which is how a
+/// fragment body entered through a spread rejoins the same stack without the frames below it
+/// needing to know.
+pub(super) fn resolve<'d, S>(
+  document: &'d ExecutableDocument<S>,
+  frames: &[Frame],
+) -> Option<&'d SelectionSet<S>> {
+  let start = frames.iter().rposition(Frame::is_definition_root)?;
+  let mut set = root_selection_set(document, frames[start].definition)?;
+  for frame in &frames[start + 1..] {
+    let selection = set.selections().get(frame.child as usize)?;
+    set = child_selection_set(selection)?;
+  }
+  Some(set)
+}
+
+impl<'d, S, K> Validator<'_, 'd, S, K>
+where
+  S: AsRef<[u8]> + Clone,
+  K: super::Sink<S>,
+{
+  /// Walks a definition's selections, following fragment spreads when an operation scope is in
+  /// effect.
+  pub(super) fn walk_selections(&mut self, root: Frame) -> ControlFlow<()> {
+    let document = self.document;
+    self.scratch.frames.clear();
+    self.scratch.frames.push(root);
+    let mut current = root_selection_set(document, root.definition);
+
+    while let Some(frame) = self.scratch.frames.last().copied() {
+      let Some(set) = current else {
+        self.scratch.frames.pop();
+        current = resolve(document, &self.scratch.frames);
+        continue;
+      };
+      let Some(selection) = set.selections().get(frame.cursor as usize) else {
+        self.scratch.frames.pop();
+        current = resolve(document, &self.scratch.frames);
+        continue;
+      };
+      if let Some(top) = self.scratch.frames.last_mut() {
+        top.cursor += 1;
+      }
+
+      match selection {
+        Selection::Field(field) => {
+          let scope = self.check_field(field, frame)?;
+          if let Some(child) = field.selection_set() {
+            self.scratch.frames.push(Frame::child(
+              frame.definition,
+              frame.cursor,
+              scope,
+              frame.flags,
+            ));
+            current = Some(child);
+          }
+        }
+        Selection::InlineFragment(inline) => {
+          let scope = self.check_inline_fragment(inline, frame)?;
+          self.scratch.frames.push(Frame::child(
+            frame.definition,
+            frame.cursor,
+            scope,
+            frame.flags,
+          ));
+          current = Some(inline.selection_set());
+        }
+        Selection::FragmentSpread(spread) => {
+          if let Some(entered) = self.check_fragment_spread(spread, frame)? {
+            self.scratch.frames.push(entered.0);
+            current = Some(entered.1);
+          }
+        }
+      }
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Draft 5.3.1 and 5.3.3, plus the field's arguments and directives.
+  ///
+  /// Returns the scope its subselections are written against, or [`NONE`] when there is none to
+  /// know — an unknown field, or a leaf, whose inner selections are then left alone rather than
+  /// reported one by one against a type that cannot have them.
+  fn check_field(&mut self, field: &'d Field<S>, frame: Frame) -> ControlFlow<(), u32> {
+    let check = frame.flags & Frame::CHECK != 0;
+    let name = field.name();
+
+    let definition = match frame.type_id() {
+      Some(parent) => {
+        let found = self
+          .schema
+          .sym(name_bytes(name))
+          .and_then(|sym| self.schema.field(parent, sym))
+          .copied();
+        if found.is_none() && check && self.on(Rule::FieldSelections) {
+          let context = Context::Type(self.schema.type_def(parent).name());
+          self.report_name(Rule::FieldSelections, name, context)?;
+        }
+        found
+      }
+      None => None,
+    };
+
+    let mut scope = NONE;
+    if let Some(definition) = definition {
+      let base = definition.ty().base_id();
+      let composite = self.schema.type_def(base).kind().is_composite();
+      let has_subselection = field.selection_set().is_some();
+      if composite {
+        scope = base.get();
+      }
+      if composite != has_subselection && check && self.on(Rule::LeafFieldSelections) {
+        let context = Context::Expected(definition.ty());
+        self.report_name(Rule::LeafFieldSelections, name, context)?;
+      }
+    }
+
+    let arguments = field
+      .arguments()
+      .map_or(&[][..], |arguments| arguments.arguments());
+    self.check_arguments(
+      arguments,
+      definition.map(|definition| definition.args()),
+      definition.map(|definition| definition.name()),
+      check,
+      *name.as_span(),
+    )?;
+
+    if let Some(directives) = field.directives() {
+      self.check_directives(directives.directives(), DirectiveLocation::Field, check)?;
+    }
+
+    ControlFlow::Continue(scope)
+  }
+
+  /// Draft 5.5.1.2, 5.5.1.3 and 5.5.2.3 at an inline fragment, plus its directives.
+  fn check_inline_fragment(
+    &mut self,
+    inline: &'d InlineFragment<S>,
+    frame: Frame,
+  ) -> ControlFlow<(), u32> {
+    let check = frame.flags & Frame::CHECK != 0;
+    let mut scope = frame.ty;
+
+    if let Some(condition) = inline.type_condition() {
+      let name = condition.name();
+      let resolved = if check {
+        self.check_type_condition(name)?
+      } else {
+        self.composite_of(name)
+      };
+      scope = match resolved {
+        Some(id) => {
+          if check {
+            self.check_spread_possible(name, id, frame)?;
+          }
+          id.get()
+        }
+        None => NONE,
+      };
+    }
+
+    if let Some(directives) = inline.directives() {
+      self.check_directives(
+        directives.directives(),
+        DirectiveLocation::InlineFragment,
+        check,
+      )?;
+    }
+
+    ControlFlow::Continue(scope)
+  }
+
+  /// Draft 5.5.2.3 at a named spread, plus its directives; enters the fragment body when an
+  /// operation scope is in effect and this walk has not entered it yet.
+  #[allow(clippy::type_complexity)]
+  fn check_fragment_spread(
+    &mut self,
+    spread: &'d FragmentSpread<S>,
+    frame: Frame,
+  ) -> ControlFlow<(), Option<(Frame, &'d SelectionSet<S>)>> {
+    let check = frame.flags & Frame::CHECK != 0;
+    let document = self.document;
+    let name = spread.name();
+
+    if let Some(directives) = spread.directives() {
+      self.check_directives(
+        directives.directives(),
+        DirectiveLocation::FragmentSpread,
+        check,
+      )?;
+    }
+
+    // 5.5.2.1 was reported while the graph was collected; here a miss simply has nothing to enter.
+    let Some(ordinal) = self.find_fragment(name_bytes(name)) else {
+      return ControlFlow::Continue(None);
+    };
+    let row = self.scratch.fragments[ordinal as usize];
+    let Some(body) = fragment(document, row.definition) else {
+      return ControlFlow::Continue(None);
+    };
+    let condition = body.type_condition().name();
+    let target = self.composite_of(condition);
+
+    if check && let Some(target) = target {
+      self.check_spread_possible(name, target, frame)?;
+    }
+
+    if !self.in_operation {
+      return ControlFlow::Continue(None);
+    }
+    if set_bit(&mut self.scratch.visited, ordinal) {
+      // Already expanded during this operation's walk. The specification's transitive inclusion
+      // is a set, so a second expansion could only repeat what the first one said — and on a
+      // cyclic graph it would not terminate.
+      return ControlFlow::Continue(None);
+    }
+
+    let enter = !get_bit(&self.scratch.checked, row.definition);
+    if enter {
+      self.begin_fragment(row.definition)?;
+    }
+    let scope = target.map_or(NONE, |id| id.get());
+    let flags = if enter { Frame::CHECK } else { 0 };
+    ControlFlow::Continue(Some((
+      Frame::root(row.definition, scope, flags),
+      body.selection_set(),
+    )))
+  }
+
+  /// Draft 5.5.2.3, all four subsections, as one bitset intersection.
+  fn check_spread_possible(
+    &mut self,
+    name: &crate::parser::graphql::ast::Name<S>,
+    target: TypeId,
+    frame: Frame,
+  ) -> ControlFlow<()> {
+    if !self.on(Rule::FragmentSpreadIsPossible) {
+      return ControlFlow::Continue(());
+    }
+    let Some(parent) = frame.type_id() else {
+      return ControlFlow::Continue(());
+    };
+    if possible(self.schema, target, parent) {
+      return ControlFlow::Continue(());
+    }
+    let context = Context::Type(self.schema.type_def(parent).name());
+    self.report_name(Rule::FragmentSpreadIsPossible, name, context)
+  }
+
+  /// Resolves a type condition without reporting: the reporting pass has already run over every
+  /// fragment declaration, and an inline fragment inside a fragment body must not report twice
+  /// because two operations reached it.
+  pub(super) fn composite_of(
+    &self,
+    condition: &crate::parser::graphql::ast::Name<S>,
+  ) -> Option<TypeId> {
+    let id = self.type_of(condition)?;
+    self.schema.type_def(id).kind().is_composite().then_some(id)
+  }
+}
+
+/// `GetPossibleTypes(fragmentType) ∩ GetPossibleTypes(parentType) ≠ ∅`, with the ecosystem's
+/// self-spread exception.
+///
+/// The exception matters for exactly one shape: an interface with no implementors, spread on
+/// itself. Its possible-object set is empty, so a literal reading of the rule refuses
+/// `fragment F on Empty { ... F }`. graphql-js, apollo-compiler and the graphql-spec#1109
+/// discussion all accept it, and diverging alone would only make a differential comparison noisy
+/// without protecting anybody from anything.
+fn possible(schema: &Schema, target: TypeId, parent: TypeId) -> bool {
+  target == parent || schema.possible_objects_intersect(target, parent)
+}

--- a/smear/src/validator/executable/values.rs
+++ b/smear/src/validator/executable/values.rs
@@ -1,0 +1,877 @@
+//! Arguments, directives, value literals and variable usages — draft 5.4, 5.6, 5.7 and the parts
+//! of 5.8 that fire at a usage site.
+//!
+//! Every rule here is written once and instantiated twice, over the constant and non-constant
+//! value families ([`ValueLike`]). The value walk is iterative for the same reason the selection
+//! walk is: a literal's nesting is chosen by whoever wrote the document.
+
+use core::ops::ControlFlow;
+
+use tokora::{SimpleSpan, span::AsSpan};
+
+use crate::parser::graphql::ast::VariableValue;
+
+use super::{
+  Diagnostic, Rule, TypeId, Validator,
+  nodes::{ArgumentLike, DirectiveLike, ObjectFieldLike, ValueLike, name_bytes},
+};
+use crate::validator::{
+  diagnostic::Context,
+  schema::{DirectiveLocation, PackedType, Range32, Sym, TypeKind},
+  scratch::{NONE, ValueFrame, ValueLevel, set_bit},
+};
+
+/// The position a value sits in, as the two bits draft 5.8.5 asks about.
+///
+/// `IsVariableUsageAllowed` needs to know whether the *location* — the `Argument` or `ObjectField`
+/// the value was written for — declares a default, and whether the enclosing object literal is a
+/// OneOf input object. Neither is derivable from the value or from its expected type, so both are
+/// carried down the walk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ValueLocation(u8);
+
+impl ValueLocation {
+  /// A position with neither property: a list entry, or an argument with no schema default.
+  pub(crate) const PLAIN: Self = Self(0);
+  /// The argument or input field this value was written for declares a default value.
+  pub(crate) const HAS_DEFAULT: u8 = 1 << 0;
+  /// The value is a field of a OneOf input object literal, so its position is non-null whatever
+  /// the field's declared nullability says.
+  pub(crate) const ONE_OF: u8 = 1 << 1;
+
+  #[inline]
+  pub(crate) const fn from_bits(bits: u8) -> Self {
+    Self(bits)
+  }
+
+  #[inline]
+  pub(crate) const fn with_default(self, present: bool) -> Self {
+    if present {
+      Self(self.0 | Self::HAS_DEFAULT)
+    } else {
+      Self(self.0 & !Self::HAS_DEFAULT)
+    }
+  }
+
+  #[inline]
+  pub(crate) const fn has_default(self) -> bool {
+    self.0 & Self::HAS_DEFAULT != 0
+  }
+
+  #[inline]
+  pub(crate) const fn is_one_of(self) -> bool {
+    self.0 & Self::ONE_OF != 0
+  }
+}
+
+impl<'d, S, K> Validator<'_, 'd, S, K>
+where
+  S: AsRef<[u8]> + Clone,
+  K: super::Sink<S>,
+{
+  // -- directives -----------------------------------------------------------------------------
+
+  /// Draft 5.7.1, 5.7.2 and 5.7.3 over one directive list, plus 5.4 and 5.6 over its arguments.
+  pub(super) fn check_directives<D>(
+    &mut self,
+    directives: &'d [D],
+    location: DirectiveLocation,
+    check: bool,
+  ) -> ControlFlow<()>
+  where
+    D: DirectiveLike<S>,
+  {
+    // 5.7.3 — only definitions the schema knows can be known non-repeatable, so an undefined
+    // directive written twice is 5.7.1's business twice over and not also this rule's.
+    if check && self.on(Rule::DirectivesAreUniquePerLocation) {
+      self.check_directive_uniqueness(directives)?;
+    }
+
+    for directive in directives {
+      let name = directive.directive_name();
+      let definition = self
+        .schema
+        .sym(name_bytes(name))
+        .and_then(|sym| self.schema.directive(sym))
+        .copied();
+
+      let Some(definition) = definition else {
+        if check && self.on(Rule::DirectivesAreDefined) {
+          self.report_name(Rule::DirectivesAreDefined, name, Context::None)?;
+        }
+        // The arguments still hold variable usages, and draft 5.8.4 must not call a variable
+        // unused because the directive carrying it was misspelled.
+        self.check_arguments(
+          directive.directive_arguments(),
+          None,
+          None,
+          check,
+          *name.as_span(),
+        )?;
+        continue;
+      };
+
+      if check
+        && self.on(Rule::DirectivesAreInValidLocations)
+        && !definition.locations().contains(location)
+      {
+        self.report_name(
+          Rule::DirectivesAreInValidLocations,
+          name,
+          Context::Location(location),
+        )?;
+      }
+
+      self.check_arguments(
+        directive.directive_arguments(),
+        Some(definition.args()),
+        Some(definition.name()),
+        check,
+        *name.as_span(),
+      )?;
+    }
+    ControlFlow::Continue(())
+  }
+
+  fn check_directive_uniqueness<D>(&mut self, directives: &'d [D]) -> ControlFlow<()>
+  where
+    D: DirectiveLike<S>,
+  {
+    let base = self.scratch.keys.len();
+    for (index, directive) in directives.iter().enumerate() {
+      let sym = self.schema.sym(name_bytes(directive.directive_name()));
+      // A repeatable directive is allowed as many times as it likes, so it never enters the scan.
+      let repeatable = sym
+        .and_then(|sym| self.schema.directive(sym))
+        .is_none_or(|definition| definition.is_repeatable());
+      if !repeatable {
+        self.scratch.keys.push(index as u32);
+      }
+    }
+    sort_keys(&mut self.scratch.keys[base..], |index| {
+      name_bytes(directives[index as usize].directive_name())
+    });
+    let mut slot = base + 1;
+    while slot < self.scratch.keys.len() {
+      let previous = self.scratch.keys[slot - 1];
+      let current = self.scratch.keys[slot];
+      let earlier = previous.min(current);
+      let later = previous.max(current);
+      if name_bytes(directives[earlier as usize].directive_name())
+        == name_bytes(directives[later as usize].directive_name())
+      {
+        let repeat = &directives[later as usize];
+        let diagnostic = Diagnostic::new(
+          Rule::DirectivesAreUniquePerLocation,
+          repeat.directive_span(),
+        )
+        .subject(repeat.directive_name().source().clone())
+        .related(directives[earlier as usize].directive_span());
+        self.emit(diagnostic)?;
+      }
+      slot += 1;
+    }
+    self.scratch.keys.truncate(base);
+    ControlFlow::Continue(())
+  }
+
+  // -- arguments ------------------------------------------------------------------------------
+
+  /// Draft 5.4.1, 5.4.2 and 5.4.3 over one argument set, and the value rules over each value.
+  ///
+  /// `definitions` is `None` when the field or directive itself did not resolve: the argument
+  /// names cannot be checked against anything, but their values are still walked so that a
+  /// variable used inside one is not later reported unused.
+  pub(super) fn check_arguments<A>(
+    &mut self,
+    arguments: &'d [A],
+    definitions: Option<Range32>,
+    owner: Option<Sym>,
+    check: bool,
+    blame: SimpleSpan,
+  ) -> ControlFlow<()>
+  where
+    A: ArgumentLike<S>,
+  {
+    // 5.4.2 — one argument set, one value per name.
+    if check && self.on(Rule::ArgumentUniqueness) {
+      let base = self.scratch.keys.len();
+      for index in 0..arguments.len() {
+        self.scratch.keys.push(index as u32);
+      }
+      sort_keys(&mut self.scratch.keys[base..], |index| {
+        name_bytes(arguments[index as usize].argument_name())
+      });
+      let mut slot = base + 1;
+      while slot < self.scratch.keys.len() {
+        let earlier = self.scratch.keys[slot - 1].min(self.scratch.keys[slot]);
+        let later = self.scratch.keys[slot - 1].max(self.scratch.keys[slot]);
+        if name_bytes(arguments[earlier as usize].argument_name())
+          == name_bytes(arguments[later as usize].argument_name())
+        {
+          let repeat = &arguments[later as usize];
+          let diagnostic = Diagnostic::new(Rule::ArgumentUniqueness, repeat.argument_span())
+            .subject(repeat.argument_name().source().clone())
+            .related(arguments[earlier as usize].argument_span());
+          self.emit(diagnostic)?;
+        }
+        slot += 1;
+      }
+      self.scratch.keys.truncate(base);
+    }
+
+    for argument in arguments {
+      let name = argument.argument_name();
+      let sym = self.schema.sym(name_bytes(name));
+      let definition = match (definitions, sym) {
+        (Some(group), Some(sym)) => self.schema.input(group, sym).copied(),
+        _ => None,
+      };
+
+      if definitions.is_some() && definition.is_none() {
+        if check && self.on(Rule::ArgumentNames) {
+          let context = match owner {
+            Some(owner) => Context::Type(owner),
+            None => Context::None,
+          };
+          self.report_name(Rule::ArgumentNames, name, context)?;
+        }
+        // Unknown argument: no expected type, but the value may still name variables.
+        self.walk_value(argument.argument_value(), None, ValueLocation::PLAIN, check)?;
+        continue;
+      }
+
+      // 5.4.3's explicit-`null` half. Reported here rather than left to 5.6.1 so that one
+      // mistake produces one diagnostic, and it is the rule that names the obligation.
+      if let Some(definition) = definition
+        && definition.is_required()
+        && argument.argument_value().is_null()
+      {
+        if check && self.on(Rule::RequiredArguments) {
+          let context = match owner {
+            Some(owner) => Context::Member {
+              owner,
+              name: definition.name(),
+            },
+            None => Context::Expected(definition.ty()),
+          };
+          self.report_name(Rule::RequiredArguments, name, context)?;
+        }
+        continue;
+      }
+
+      let location = ValueLocation::PLAIN
+        .with_default(definition.is_some_and(|d| d.default_kind().is_present()));
+      self.walk_value(
+        argument.argument_value(),
+        definition.map(|definition| definition.ty()),
+        location,
+        check,
+      )?;
+    }
+
+    // 5.4.3's presence half.
+    if let Some(group) = definitions
+      && check
+      && self.on(Rule::RequiredArguments)
+    {
+      let schema = self.schema;
+      for definition in schema.inputs(group) {
+        if !definition.is_required() {
+          continue;
+        }
+        let supplied = arguments.iter().any(|argument| {
+          schema.sym(name_bytes(argument.argument_name())) == Some(definition.name())
+        });
+        if !supplied {
+          let context = match owner {
+            Some(owner) => Context::Member {
+              owner,
+              name: definition.name(),
+            },
+            None => Context::Expected(definition.ty()),
+          };
+          let diagnostic = Diagnostic::new(Rule::RequiredArguments, blame).context(context);
+          self.emit(diagnostic)?;
+        }
+      }
+    }
+
+    ControlFlow::Continue(())
+  }
+
+  // -- values ---------------------------------------------------------------------------------
+
+  /// Walks one value literal against the type expected in its position.
+  ///
+  /// `expected` is `None` when the position did not resolve — an argument of an unknown field, for
+  /// instance. The walk then does nothing but collect variable usages, which is what keeps draft
+  /// 5.8.4 from reporting a variable unused because of a mistake somewhere else.
+  pub(super) fn walk_value<V>(
+    &mut self,
+    root: &'d V,
+    expected: Option<PackedType>,
+    location: ValueLocation,
+    check: bool,
+  ) -> ControlFlow<()>
+  where
+    V: ValueLike<S>,
+  {
+    let base = self.scratch.values.len();
+    if let Some(frame) = self.visit_value(root, expected, location, check)? {
+      self.scratch.values.push(frame);
+    }
+
+    while self.scratch.values.len() > base {
+      let depth = self.scratch.values.len();
+      let frame = self.scratch.values[depth - 1];
+      let Some(level) = resolve(root, &self.scratch.values[base..depth]) else {
+        self.scratch.values.pop();
+        continue;
+      };
+      let count = match frame.level {
+        ValueLevel::List => level.as_list().map_or(0, <[V]>::len),
+        ValueLevel::Object => level.as_object().map_or(0, <[V::Field]>::len),
+      };
+      if frame.cursor as usize >= count {
+        self.scratch.values.pop();
+        continue;
+      }
+      self.scratch.values[depth - 1].cursor += 1;
+      let index = frame.cursor;
+
+      let next = match frame.level {
+        ValueLevel::List => {
+          let Some(entry) = level.as_list().and_then(|list| list.get(index as usize)) else {
+            continue;
+          };
+          // A list entry is not an argument or an input field, so it has no location default.
+          self.visit_value(entry, frame.expected, ValueLocation::PLAIN, check)?
+        }
+        ValueLevel::Object => {
+          let Some(field) = level
+            .as_object()
+            .and_then(|fields| fields.get(index as usize))
+          else {
+            continue;
+          };
+          let name = field.field_name();
+          let definition = if frame.object == NONE {
+            None
+          } else {
+            let object = TypeId::new(frame.object);
+            self
+              .schema
+              .sym(name_bytes(name))
+              .and_then(|sym| self.schema.input_field(object, sym))
+              .copied()
+          };
+          if definition.is_none() && frame.object != NONE {
+            // 5.6.2 — the input object type is known and does not define this field.
+            if check && self.on(Rule::InputObjectFieldNames) {
+              let context = Context::Type(self.schema.type_def(TypeId::new(frame.object)).name());
+              self.report_name(Rule::InputObjectFieldNames, name, context)?;
+            }
+            self.visit_value(field.field_value(), None, ValueLocation::PLAIN, check)?
+          } else {
+            // 5.6.4's explicit-`null` half, for the same reason 5.4.3 keeps its own.
+            if let Some(definition) = definition
+              && definition.is_required()
+              && field.field_value().is_null()
+            {
+              if check && self.on(Rule::InputObjectRequiredFields) {
+                let context = Context::Member {
+                  owner: self.schema.type_def(TypeId::new(frame.object)).name(),
+                  name: definition.name(),
+                };
+                self.report_name(Rule::InputObjectRequiredFields, name, context)?;
+              }
+              continue;
+            }
+            let one_of = if frame.flags & ValueLocation::ONE_OF != 0 {
+              ValueLocation::ONE_OF
+            } else {
+              0
+            };
+            let location = ValueLocation::from_bits(one_of)
+              .with_default(definition.is_some_and(|d| d.default_kind().is_present()));
+            self.visit_value(
+              field.field_value(),
+              definition.map(|definition| definition.ty()),
+              location,
+              check,
+            )?
+          }
+        }
+      };
+
+      if let Some(mut next) = next {
+        next.child = index;
+        self.scratch.values.push(next);
+      }
+    }
+
+    self.scratch.values.truncate(base);
+    ControlFlow::Continue(())
+  }
+
+  /// Checks one value in place, and returns the level to descend into when it is a container.
+  fn visit_value<V>(
+    &mut self,
+    value: &'d V,
+    expected: Option<PackedType>,
+    location: ValueLocation,
+    check: bool,
+  ) -> ControlFlow<(), Option<ValueFrame>>
+  where
+    V: ValueLike<S>,
+  {
+    if let Some(variable) = value.as_variable() {
+      self.check_variable_usage(variable, expected, location)?;
+      return ControlFlow::Continue(None);
+    }
+
+    let Some(expected) = expected else {
+      // Unknown position: descend only to find variable usages.
+      if value.as_list().is_some() {
+        return ControlFlow::Continue(Some(level_frame(ValueLevel::List, None, NONE, 0)));
+      }
+      if value.as_object().is_some() {
+        return ControlFlow::Continue(Some(level_frame(ValueLevel::Object, None, NONE, 0)));
+      }
+      return ControlFlow::Continue(None);
+    };
+
+    if value.is_null() {
+      if expected.is_non_null() && check && self.on(Rule::ValuesOfCorrectType) {
+        self.report_value(value, Context::Expected(expected))?;
+      }
+      return ControlFlow::Continue(None);
+    }
+
+    // Strip the outer non-null, then apply the specification's singleton-to-list coercion: a
+    // non-list value in a list position is the one-element list containing it, at any depth.
+    let mut expected = expected.nullable();
+    while expected.is_list() && value.as_list().is_none() {
+      let Some(item) = expected.list_item() else {
+        break;
+      };
+      expected = item.nullable();
+    }
+
+    if expected.is_list() {
+      let item = expected.list_item();
+      return ControlFlow::Continue(Some(level_frame(ValueLevel::List, item, NONE, 0)));
+    }
+
+    let base = expected.base_id();
+    let definition = *self.schema.type_def(base);
+    match definition.kind() {
+      TypeKind::InputObject => {
+        let Some(fields) = value.as_object() else {
+          if check && self.on(Rule::ValuesOfCorrectType) {
+            self.report_value(value, Context::Expected(expected))?;
+          }
+          return ControlFlow::Continue(None);
+        };
+        if check {
+          self.check_input_object(value, fields, base, expected)?;
+        }
+        let flags = if definition.is_one_of() {
+          ValueLocation::ONE_OF
+        } else {
+          0
+        };
+        ControlFlow::Continue(Some(level_frame(
+          ValueLevel::Object,
+          None,
+          base.get(),
+          flags,
+        )))
+      }
+      TypeKind::Enum => {
+        let member = value
+          .as_enum()
+          .and_then(|literal| self.schema.sym(literal.source().as_ref()))
+          .is_some_and(|sym| self.schema.has_enum_value(base, sym));
+        if !member && check && self.on(Rule::ValuesOfCorrectType) {
+          self.report_value(value, Context::Expected(expected))?;
+        }
+        ControlFlow::Continue(None)
+      }
+      TypeKind::Scalar => {
+        if !self.scalar_accepts(value, definition.name())
+          && check
+          && self.on(Rule::ValuesOfCorrectType)
+        {
+          self.report_value(value, Context::Expected(expected))?;
+        }
+        ControlFlow::Continue(None)
+      }
+      // An object, interface or union in an input position. `Schema::build` refuses an argument
+      // or input field declared that way, so this is unreachable from a built schema; refusing
+      // rather than accepting keeps it that way if the schema ever gains another door.
+      TypeKind::Object | TypeKind::Interface | TypeKind::Union => {
+        if check && self.on(Rule::ValuesOfCorrectType) {
+          self.report_value(value, Context::Expected(expected))?;
+        }
+        ControlFlow::Continue(None)
+      }
+    }
+  }
+
+  /// Draft 5.6.3, 5.6.4 and the OneOf literal rules, at an object level.
+  fn check_input_object<V>(
+    &mut self,
+    value: &'d V,
+    fields: &'d [V::Field],
+    object: TypeId,
+    expected: PackedType,
+  ) -> ControlFlow<()>
+  where
+    V: ValueLike<S>,
+  {
+    // 5.6.3 — one value per field name.
+    if self.on(Rule::InputObjectFieldUniqueness) {
+      let base = self.scratch.keys.len();
+      for index in 0..fields.len() {
+        self.scratch.keys.push(index as u32);
+      }
+      sort_keys(&mut self.scratch.keys[base..], |index| {
+        name_bytes(fields[index as usize].field_name())
+      });
+      let mut slot = base + 1;
+      while slot < self.scratch.keys.len() {
+        let earlier = self.scratch.keys[slot - 1].min(self.scratch.keys[slot]);
+        let later = self.scratch.keys[slot - 1].max(self.scratch.keys[slot]);
+        if name_bytes(fields[earlier as usize].field_name())
+          == name_bytes(fields[later as usize].field_name())
+        {
+          let repeat = &fields[later as usize];
+          let diagnostic = Diagnostic::new(Rule::InputObjectFieldUniqueness, repeat.field_span())
+            .subject(repeat.field_name().source().clone())
+            .related(fields[earlier as usize].field_span());
+          self.emit(diagnostic)?;
+        }
+        slot += 1;
+      }
+      self.scratch.keys.truncate(base);
+    }
+
+    let definition = *self.schema.type_def(object);
+    if definition.is_one_of() {
+      // 5.6.1's OneOf half: exactly one field, and it is not `null`.
+      if self.on(Rule::ValuesOfCorrectType) {
+        if fields.len() != 1 {
+          self.report_value(value, Context::Expected(expected))?;
+        } else if fields[0].field_value().is_null() {
+          let diagnostic = Diagnostic::new(Rule::ValuesOfCorrectType, fields[0].field_span())
+            .subject(fields[0].field_name().source().clone())
+            .context(Context::Type(definition.name()));
+          self.emit(diagnostic)?;
+        }
+      }
+      // A OneOf input object's fields are all nullable and default-free by construction, so the
+      // required-field rule below has nothing to say about one.
+      return ControlFlow::Continue(());
+    }
+
+    // 5.6.4 — every required field is supplied.
+    if self.on(Rule::InputObjectRequiredFields) {
+      let schema = self.schema;
+      for field_definition in schema.input_fields_of(object) {
+        if !field_definition.is_required() {
+          continue;
+        }
+        let supplied = fields
+          .iter()
+          .any(|field| schema.sym(name_bytes(field.field_name())) == Some(field_definition.name()));
+        if !supplied {
+          let diagnostic = Diagnostic::new(Rule::InputObjectRequiredFields, value.value_span())
+            .context(Context::Member {
+              owner: definition.name(),
+              name: field_definition.name(),
+            });
+          self.emit(diagnostic)?;
+        }
+      }
+    }
+    ControlFlow::Continue(())
+  }
+
+  /// Whether a built-in scalar accepts this literal. Custom scalars accept everything: only the
+  /// service knows how to read one, so a validator that guessed would reject valid documents.
+  fn scalar_accepts<V>(&self, value: &V, name: Sym) -> bool
+  where
+    V: ValueLike<S>,
+  {
+    let name = Some(name);
+    if name == self.scalars.int {
+      return value
+        .as_int()
+        .is_some_and(|int| fits_i32(int.source().as_ref()));
+    }
+    if name == self.scalars.float {
+      // The coercion rules let an Int literal stand for a Float.
+      return match (value.as_float(), value.as_int()) {
+        (Some(float), _) => is_finite(float.source().as_ref()),
+        (None, Some(_)) => true,
+        (None, None) => false,
+      };
+    }
+    if name == self.scalars.string {
+      return value.as_string().is_some();
+    }
+    if name == self.scalars.boolean {
+      return value.as_boolean().is_some();
+    }
+    if name == self.scalars.id {
+      // ID accepts both spellings an identifier is written with.
+      return value.as_string().is_some()
+        || value
+          .as_int()
+          .is_some_and(|int| fits_id(int.source().as_ref()));
+    }
+    true
+  }
+
+  fn report_value<V>(&mut self, value: &V, context: Context) -> ControlFlow<()>
+  where
+    V: ValueLike<S>,
+  {
+    let diagnostic =
+      Diagnostic::new(Rule::ValuesOfCorrectType, value.value_span()).context(context);
+    self.emit(diagnostic)
+  }
+
+  // -- variable usages ------------------------------------------------------------------------
+
+  /// Draft 5.8.3 and 5.8.5 at one usage, and the mark 5.8.4 reads afterwards.
+  fn check_variable_usage(
+    &mut self,
+    variable: &'d VariableValue<S>,
+    expected: Option<PackedType>,
+    location: ValueLocation,
+  ) -> ControlFlow<()> {
+    if !self.in_operation {
+      // A fragment no operation reaches has no variable scope, and the specification scopes both
+      // rules to an operation. apollo-compiler skips such fragments entirely; this one still
+      // validates their structure, but there is nothing to check a variable against.
+      return ControlFlow::Continue(());
+    }
+    let name = variable.name();
+    let bytes = name_bytes(name);
+    // Every definition of the name is marked used, not only the first. A duplicated variable is
+    // 5.8.1's business; calling the copy "never used" as well would report one mistake twice.
+    let variables = self.variables;
+    let mut first = None;
+    for (index, definition) in variables.iter().enumerate() {
+      if name_bytes(definition.node().variable().name()) == bytes {
+        first.get_or_insert(index);
+        set_bit(&mut self.scratch.used, index as u32);
+      }
+    }
+    let Some(index) = first else {
+      if self.on(Rule::AllVariableUsesDefined) {
+        return self.report_name(Rule::AllVariableUsesDefined, name, Context::None);
+      }
+      return ControlFlow::Continue(());
+    };
+
+    if !self.on(Rule::AllVariableUsagesAreAllowed) {
+      return ControlFlow::Continue(());
+    }
+    let Some(expected) = expected else {
+      return ControlFlow::Continue(());
+    };
+    let definition = self.variables[index].node();
+    let Some(declared) = self.pack_type(definition.ty()) else {
+      // The declared type is not in the schema; 5.8.2 has already said so.
+      return ControlFlow::Continue(());
+    };
+
+    let non_null_position = expected.is_non_null() || location.is_one_of();
+    let allowed = if non_null_position && !declared.is_non_null() {
+      let variable_default = definition
+        .default_value()
+        .is_some_and(|default| !default.value().is_null());
+      if !variable_default && !location.has_default() {
+        false
+      } else {
+        are_types_compatible(declared, expected.nullable())
+      }
+    } else {
+      are_types_compatible(declared, expected)
+    };
+
+    if !allowed {
+      return self.report_name(
+        Rule::AllVariableUsagesAreAllowed,
+        name,
+        Context::Usage {
+          variable: declared,
+          expected,
+        },
+      );
+    }
+    ControlFlow::Continue(())
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// free helpers
+// ---------------------------------------------------------------------------------------------
+
+/// Locates a nested value by descending the frame chain from the root value.
+///
+/// This is what buys the explicit stack: a frame stores an index, not a pointer, so the stack can
+/// live in a [`Scratch`](super::Scratch) that is not generic over the document's source type.
+fn resolve<'v, S, V>(root: &'v V, frames: &[ValueFrame]) -> Option<&'v V>
+where
+  V: ValueLike<S>,
+  V::Field: 'v,
+{
+  let mut value = root;
+  for depth in 1..frames.len() {
+    let index = frames[depth].child as usize;
+    value = match frames[depth - 1].level {
+      ValueLevel::List => value.as_list()?.get(index)?,
+      ValueLevel::Object => value.as_object()?.get(index)?.field_value(),
+    };
+  }
+  Some(value)
+}
+
+/// Builds a level frame; the caller fills in the child index when it pushes.
+fn level_frame(
+  level: ValueLevel,
+  expected: Option<PackedType>,
+  object: u32,
+  flags: u8,
+) -> ValueFrame {
+  ValueFrame {
+    child: NONE,
+    cursor: 0,
+    expected,
+    level,
+    object,
+    flags,
+  }
+}
+
+/// Sorts a duplicate-scan segment by name, breaking ties on the source index so the order is
+/// total and the earlier occurrence always sorts first.
+fn sort_keys<'a>(keys: &mut [u32], name: impl Fn(u32) -> &'a [u8]) {
+  keys.sort_unstable_by(|a, b| name(*a).cmp(name(*b)).then(a.cmp(b)));
+}
+
+/// Draft 5.8.5's `AreTypesCompatible`, as an integer walk over two packed references.
+fn are_types_compatible(mut variable: PackedType, mut location: PackedType) -> bool {
+  loop {
+    if location.is_non_null() {
+      if !variable.is_non_null() {
+        return false;
+      }
+      let (Some(next_location), Some(next_variable)) =
+        (location.strip_outer(), variable.strip_outer())
+      else {
+        return false;
+      };
+      location = next_location;
+      variable = next_variable;
+      continue;
+    }
+    if variable.is_non_null() {
+      variable = variable.nullable();
+      continue;
+    }
+    if location.is_list() {
+      let (Some(item_location), Some(item_variable)) = (location.list_item(), variable.list_item())
+      else {
+        return false;
+      };
+      location = item_location;
+      variable = item_variable;
+      continue;
+    }
+    if variable.is_list() {
+      return false;
+    }
+    return variable.base_id() == location.base_id();
+  }
+}
+
+/// Whether an `Int` literal's spelling fits GraphQL's 32-bit signed range.
+///
+/// Ten characters of digits is the first length that can overflow, so the common case is a length
+/// check and nothing else.
+fn fits_i32(spelling: &[u8]) -> bool {
+  let digits = spelling.strip_prefix(b"-").unwrap_or(spelling);
+  if digits.len() <= 9 {
+    return !digits.is_empty();
+  }
+  core::str::from_utf8(spelling).is_ok_and(|text| text.parse::<i32>().is_ok())
+}
+
+/// Whether an `Int` literal may stand for an `ID`.
+///
+/// The specification's `ID` input coercion accepts integer values, and the range that matters is
+/// the one an `Int` literal is allowed to carry in the first place.
+fn fits_id(spelling: &[u8]) -> bool {
+  fits_i32(spelling)
+}
+
+/// Whether a `Float` literal's spelling names a finite double.
+fn is_finite(spelling: &[u8]) -> bool {
+  core::str::from_utf8(spelling).is_ok_and(|text| text.parse::<f64>().is_ok_and(f64::is_finite))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{are_types_compatible, fits_i32, is_finite};
+  use crate::validator::schema::{PackedType, Sym, TypeId};
+
+  fn named(id: u32) -> PackedType {
+    PackedType::named(Sym::new(id), TypeId::new(id))
+  }
+
+  #[test]
+  fn compatibility_follows_the_specification_examples() {
+    let boolean = named(1);
+    let int = named(2);
+    let boolean_nn = boolean.push_non_null().unwrap();
+    let list = boolean.push_list().unwrap();
+    let list_nn = list.push_non_null().unwrap();
+    let list_of_nn = boolean_nn.push_list().unwrap();
+
+    assert!(are_types_compatible(boolean, boolean));
+    assert!(!are_types_compatible(int, boolean));
+    assert!(!are_types_compatible(list, boolean));
+    assert!(!are_types_compatible(boolean, boolean_nn));
+    assert!(are_types_compatible(boolean_nn, boolean));
+    // `[T]!` into `[T]` is fine; `[T]` into `[T]!` and `[T]` into `[T!]` are not.
+    assert!(are_types_compatible(list_nn, list));
+    assert!(!are_types_compatible(list, list_nn));
+    assert!(!are_types_compatible(list, list_of_nn));
+    assert!(are_types_compatible(list_of_nn, list));
+  }
+
+  #[test]
+  fn int_range_uses_the_retained_spelling() {
+    assert!(fits_i32(b"0"));
+    assert!(fits_i32(b"-1"));
+    assert!(fits_i32(b"999999999"));
+    assert!(fits_i32(b"2147483647"));
+    assert!(fits_i32(b"-2147483648"));
+    assert!(!fits_i32(b"2147483648"));
+    assert!(!fits_i32(b"-2147483649"));
+    assert!(!fits_i32(b"99999999999999999999"));
+  }
+
+  #[test]
+  fn float_literals_must_be_finite() {
+    assert!(is_finite(b"1.0"));
+    assert!(is_finite(b"-1.5e3"));
+    assert!(!is_finite(b"1e400"));
+  }
+}

--- a/smear/src/validator/mod.rs
+++ b/smear/src/validator/mod.rs
@@ -4,19 +4,77 @@
 //! types and namespaced paths have no specification semantics to validate against, so nothing in
 //! this module knows about them.
 //!
-//! # What is here now
+//! # What is here
 //!
-//! [`schema`](crate::validator::schema) — the built-once
-//! [`Schema`](crate::validator::schema::Schema) every rule reads, and the draft §3 "Type
-//! Validation" pass that runs while building it. A server rejects a malformed SDL exactly once,
-//! at startup, and never rediscovers it per request.
+//! - [`schema`](crate::validator::schema) — the built-once
+//!   [`Schema`](crate::validator::schema::Schema) every rule reads, and the draft §3 "Type
+//!   Validation" pass that runs while building it. A server rejects a malformed SDL exactly once,
+//!   at startup, and never rediscovers it per request.
+//! - [`validate_executable`](crate::validator::validate_executable) — the draft §5 rules over a
+//!   parsed executable document, reported into the caller's
+//!   [`Sink`](crate::validator::Sink) and worked out in the caller's
+//!   [`Scratch`](crate::validator::Scratch).
 //!
 //! Every link in this module's docs is crate-absolute on purpose. `pub mod validator;` in
 //! `lib.rs` carries an outer doc comment as well, and rustdoc resolves the merged fragments in
 //! the **parent** module's scope — so a `schema`-relative link here reports "no item named
 //! `schema` in module `smear`" under `RUSTDOCFLAGS="-D warnings"`.
 //!
-//! Executable-document validation (draft §5) is built on this substrate and lands separately.
+//! # Validating a request
+//!
+//! ```
+//! use smear::{
+//!   lexer::tokora::{Parse as _, Parser},
+//!   parser::graphql::{
+//!     GraphQL,
+//!     ast::{ExecutableDocument, TypeSystemDocument},
+//!     error::GraphqlErrors,
+//!     syntactic::{GraphqlLexer, executable_document, type_system_document},
+//!   },
+//!   validator::{Budget, First, Rule, Schema, Scratch, validate_executable},
+//! };
+//!
+//! let schema = Schema::build(
+//!   &Parser::with_parser::<GraphqlLexer<'_, str>, TypeSystemDocument<&str>, GraphqlErrors<&str>, _, GraphQL>(
+//!     type_system_document,
+//!   )
+//!   .parse_str("type Query { hero: Character } interface Character { name: String! }")
+//!   .expect("the SDL parses"),
+//! )
+//! .expect("the SDL is a schema");
+//!
+//! // The two the caller owns, created once and reused for every request.
+//! let mut scratch = Scratch::new();
+//! let budget = Budget::default();
+//!
+//! let request = Parser::with_parser::<GraphqlLexer<'_, str>, ExecutableDocument<&str>, GraphqlErrors<&str>, _, GraphQL>(
+//!   executable_document,
+//! )
+//! .parse_str("{ hero { title } }")
+//! .expect("the query parses");
+//!
+//! let mut sink = First::new();
+//! let invalid = validate_executable(&schema, &request, &mut scratch, &budget, &mut sink)
+//!   .expect_err("`title` is not a field of `Character`");
+//! assert_eq!(invalid.emitted(), 1);
+//!
+//! let diagnostic = sink.get().expect("a diagnostic");
+//! assert_eq!(diagnostic.rule(), Rule::FieldSelections);
+//! assert_eq!(diagnostic.subject_source(), Some(&"title"));
+//! ```
+//!
+//! # The three axes
+//!
+//! - **The schema** is built once and read as `&Schema` by an unbounded number of concurrent
+//!   validations.
+//! - **The report** is one seam: [`Sink::diagnostic`](crate::validator::Sink::diagnostic) takes a
+//!   value and returns whether to keep going. [`First`](crate::validator::First),
+//!   [`Collect`](crate::validator::Collect), [`Count`](crate::validator::Count) and
+//!   [`Ignore`](crate::validator::Ignore) mirror `tokora`'s emitter-bundle semantics.
+//! - **The working set** is the caller's [`Scratch`](crate::validator::Scratch), reused across
+//!   requests, and what may be *done* is the caller's [`Budget`](crate::validator::Budget). The
+//!   steady state allocates nothing at all, which `tests/validator_allocation.rs` measures with a
+//!   counting allocator rather than asserting.
 //!
 //! # The shape, and why
 //!
@@ -40,4 +98,15 @@
 
 pub mod schema;
 
+mod diagnostic;
+mod executable;
+mod rule;
+mod scratch;
+mod sink;
+
+pub use diagnostic::{Context, Diagnostic, DiagnosticDisplay};
+pub use executable::{Invalid, validate_executable, validate_executable_with};
+pub use rule::{Rule, RuleSet};
 pub use schema::{Schema, SchemaBuilder, SchemaError, SchemaErrorKind, SchemaErrors};
+pub use scratch::{Budget, Scratch};
+pub use sink::{Collect, Count, First, Ignore, Sink};

--- a/smear/src/validator/rule.rs
+++ b/smear/src/validator/rule.rs
@@ -1,0 +1,413 @@
+//! The rule vocabulary: one identity per draft §5 rule, and a set over them.
+//!
+//! [`Rule`] is a fieldless enum, so a diagnostic names the rule that produced it with one byte and
+//! a consumer matches on it exhaustively. [`Rule::ALL`] enumerates the space, which is what lets
+//! the liveness gate iterate the rules rather than a hand-kept list: a rule added without a
+//! fixture that makes it fire is a failing test, not a silently unexercised branch.
+//!
+//! [`RuleSet`] is the selection door. Validation runs every rule by default; a consumer that wants
+//! a subset — a linter checking only the fragment rules, say — hands one to
+//! [`validate_executable_with`](super::validate_executable_with).
+
+/// One draft §5 validation rule.
+///
+/// Every variant carries its specification section in its documentation, and the section numbers
+/// are the **draft**'s (<https://spec.graphql.org/draft/>), which renumbered §5 after the October
+/// 2021 edition: *Required Arguments* is 5.4.3 rather than 5.4.2.1, and *Operation Type Existence*
+/// (5.2.1.1) did not exist in the 2021 text at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum Rule {
+  // -- 5.2 Operations -------------------------------------------------------------------------
+  /// The schema must define a root operation type of the operation's kind (draft 5.2.1.1).
+  OperationTypeExistence,
+  /// Two operations must not share a name (draft 5.2.2.1).
+  OperationNameUniqueness,
+  /// An anonymous operation must be the document's only operation (draft 5.2.3.1).
+  LoneAnonymousOperation,
+  /// A subscription's root selection set must collect exactly one field, which must not be an
+  /// introspection field, and must not use `@skip` or `@include` (draft 5.2.4.1).
+  SingleRootField,
+
+  // -- 5.3 Fields -----------------------------------------------------------------------------
+  /// A selected field must be defined on the type in scope (draft 5.3.1).
+  ///
+  /// A union defines no fields of its own, so the only field selectable directly on one is
+  /// `__typename` — which falls out of this rule rather than needing one of its own, because the
+  /// schema puts `__typename` in every composite type's field group.
+  FieldSelections,
+  /// A field whose type is a leaf must have no subselection, and a field whose type is composite
+  /// must have one (draft 5.3.3).
+  LeafFieldSelections,
+
+  // -- 5.4 Arguments --------------------------------------------------------------------------
+  /// An argument must be defined by the field or directive it is passed to (draft 5.4.1).
+  ArgumentNames,
+  /// An argument set must not name the same argument twice (draft 5.4.2).
+  ArgumentUniqueness,
+  /// A required argument — non-null type, no default — must be supplied and must not be the
+  /// `null` literal (draft 5.4.3).
+  RequiredArguments,
+
+  // -- 5.5 Fragments --------------------------------------------------------------------------
+  /// Two fragment definitions must not share a name (draft 5.5.1.1).
+  FragmentNameUniqueness,
+  /// A fragment's type condition must name a type the schema defines (draft 5.5.1.2).
+  FragmentSpreadTypeExistence,
+  /// A fragment's type condition must be an object, interface or union type (draft 5.5.1.3).
+  FragmentsOnCompositeTypes,
+  /// Every fragment definition must be spread by some operation, transitively (draft 5.5.1.4).
+  FragmentsMustBeUsed,
+  /// A fragment spread must name a fragment the document defines (draft 5.5.2.1).
+  FragmentSpreadTargetDefined,
+  /// Fragment spreads must not form a cycle (draft 5.5.2.2).
+  ///
+  /// Checked over the whole fragment graph, including fragments no operation reaches: a later
+  /// rule that expands fragments must never meet an unestablished graph.
+  FragmentSpreadsMustNotFormCycles,
+  /// A spread's type condition must be able to apply within the type in scope (draft 5.5.2.3, all
+  /// four subsections).
+  ///
+  /// One deliberate ecosystem deviation is adopted here: a spread whose condition *is* the scope
+  /// is valid even where the possible-object set is empty — an interface with no implementors
+  /// spread on itself. graphql-js, apollo-compiler and the graphql-spec#1109 discussion all land
+  /// there, and a lone strict reading would only make a differential comparison noisy.
+  FragmentSpreadIsPossible,
+
+  // -- 5.6 Values -----------------------------------------------------------------------------
+  /// A literal value must be coercible to the type expected in its position (draft 5.6.1).
+  ///
+  /// Includes the OneOf input object literal rules: exactly one field, and that field's value not
+  /// `null`.
+  ValuesOfCorrectType,
+  /// An input object field must be defined by the input object type expected in its position
+  /// (draft 5.6.2).
+  InputObjectFieldNames,
+  /// An input object literal must not name the same field twice (draft 5.6.3).
+  ///
+  /// apollo-compiler 1.32 does not implement this rule at all, so it is not a reference for what
+  /// this one should do; the draft text is.
+  InputObjectFieldUniqueness,
+  /// A required input field — non-null type, no default — must be supplied and must not be the
+  /// `null` literal (draft 5.6.4).
+  InputObjectRequiredFields,
+
+  // -- 5.7 Directives -------------------------------------------------------------------------
+  /// A directive must be defined by the schema (draft 5.7.1).
+  DirectivesAreDefined,
+  /// A directive must be used at a location its definition declares (draft 5.7.2).
+  DirectivesAreInValidLocations,
+  /// A non-repeatable directive must appear at most once per location (draft 5.7.3).
+  DirectivesAreUniquePerLocation,
+
+  // -- 5.8 Variables --------------------------------------------------------------------------
+  /// An operation must not define the same variable twice (draft 5.8.1).
+  VariableUniqueness,
+  /// A variable's declared type must be an input type (draft 5.8.2).
+  VariablesAreInputTypes,
+  /// Every variable used by an operation, or by a fragment it transitively spreads, must be
+  /// defined by that operation (draft 5.8.3).
+  AllVariableUsesDefined,
+  /// Every variable an operation defines must be used by it, or by a fragment it transitively
+  /// spreads (draft 5.8.4).
+  AllVariablesUsed,
+  /// A variable usage must be allowed in the position it appears in — `IsVariableUsageAllowed`,
+  /// in every position, including inside list and object literals (draft 5.8.5).
+  AllVariableUsagesAreAllowed,
+}
+
+impl Rule {
+  /// Every rule, in specification order.
+  ///
+  /// The liveness gate iterates this rather than a hand-kept list, so a rule added without a
+  /// document that makes it fire fails a test instead of shipping unexercised.
+  pub const ALL: &'static [Self] = &[
+    Self::OperationTypeExistence,
+    Self::OperationNameUniqueness,
+    Self::LoneAnonymousOperation,
+    Self::SingleRootField,
+    Self::FieldSelections,
+    Self::LeafFieldSelections,
+    Self::ArgumentNames,
+    Self::ArgumentUniqueness,
+    Self::RequiredArguments,
+    Self::FragmentNameUniqueness,
+    Self::FragmentSpreadTypeExistence,
+    Self::FragmentsOnCompositeTypes,
+    Self::FragmentsMustBeUsed,
+    Self::FragmentSpreadTargetDefined,
+    Self::FragmentSpreadsMustNotFormCycles,
+    Self::FragmentSpreadIsPossible,
+    Self::ValuesOfCorrectType,
+    Self::InputObjectFieldNames,
+    Self::InputObjectFieldUniqueness,
+    Self::InputObjectRequiredFields,
+    Self::DirectivesAreDefined,
+    Self::DirectivesAreInValidLocations,
+    Self::DirectivesAreUniquePerLocation,
+    Self::VariableUniqueness,
+    Self::VariablesAreInputTypes,
+    Self::AllVariableUsesDefined,
+    Self::AllVariablesUsed,
+    Self::AllVariableUsagesAreAllowed,
+  ];
+
+  /// Returns the rule's bit position in a [`RuleSet`].
+  ///
+  /// It is the rule's index in [`Rule::ALL`], which is why that list is the enumeration and this
+  /// is derived from it rather than the other way round.
+  #[inline]
+  pub const fn bit(self) -> u32 {
+    // A `const fn` cannot iterate a slice of `Self`, so the mapping is spelled out. The
+    // `bits_match_all_order` test pins it against `ALL`.
+    match self {
+      Self::OperationTypeExistence => 0,
+      Self::OperationNameUniqueness => 1,
+      Self::LoneAnonymousOperation => 2,
+      Self::SingleRootField => 3,
+      Self::FieldSelections => 4,
+      Self::LeafFieldSelections => 5,
+      Self::ArgumentNames => 6,
+      Self::ArgumentUniqueness => 7,
+      Self::RequiredArguments => 8,
+      Self::FragmentNameUniqueness => 9,
+      Self::FragmentSpreadTypeExistence => 10,
+      Self::FragmentsOnCompositeTypes => 11,
+      Self::FragmentsMustBeUsed => 12,
+      Self::FragmentSpreadTargetDefined => 13,
+      Self::FragmentSpreadsMustNotFormCycles => 14,
+      Self::FragmentSpreadIsPossible => 15,
+      Self::ValuesOfCorrectType => 16,
+      Self::InputObjectFieldNames => 17,
+      Self::InputObjectFieldUniqueness => 18,
+      Self::InputObjectRequiredFields => 19,
+      Self::DirectivesAreDefined => 20,
+      Self::DirectivesAreInValidLocations => 21,
+      Self::DirectivesAreUniquePerLocation => 22,
+      Self::VariableUniqueness => 23,
+      Self::VariablesAreInputTypes => 24,
+      Self::AllVariableUsesDefined => 25,
+      Self::AllVariablesUsed => 26,
+      Self::AllVariableUsagesAreAllowed => 27,
+    }
+  }
+
+  /// Returns the draft specification section the rule comes from.
+  #[inline]
+  pub const fn section(self) -> &'static str {
+    match self {
+      Self::OperationTypeExistence => "5.2.1.1",
+      Self::OperationNameUniqueness => "5.2.2.1",
+      Self::LoneAnonymousOperation => "5.2.3.1",
+      Self::SingleRootField => "5.2.4.1",
+      Self::FieldSelections => "5.3.1",
+      Self::LeafFieldSelections => "5.3.3",
+      Self::ArgumentNames => "5.4.1",
+      Self::ArgumentUniqueness => "5.4.2",
+      Self::RequiredArguments => "5.4.3",
+      Self::FragmentNameUniqueness => "5.5.1.1",
+      Self::FragmentSpreadTypeExistence => "5.5.1.2",
+      Self::FragmentsOnCompositeTypes => "5.5.1.3",
+      Self::FragmentsMustBeUsed => "5.5.1.4",
+      Self::FragmentSpreadTargetDefined => "5.5.2.1",
+      Self::FragmentSpreadsMustNotFormCycles => "5.5.2.2",
+      Self::FragmentSpreadIsPossible => "5.5.2.3",
+      Self::ValuesOfCorrectType => "5.6.1",
+      Self::InputObjectFieldNames => "5.6.2",
+      Self::InputObjectFieldUniqueness => "5.6.3",
+      Self::InputObjectRequiredFields => "5.6.4",
+      Self::DirectivesAreDefined => "5.7.1",
+      Self::DirectivesAreInValidLocations => "5.7.2",
+      Self::DirectivesAreUniquePerLocation => "5.7.3",
+      Self::VariableUniqueness => "5.8.1",
+      Self::VariablesAreInputTypes => "5.8.2",
+      Self::AllVariableUsesDefined => "5.8.3",
+      Self::AllVariablesUsed => "5.8.4",
+      Self::AllVariableUsagesAreAllowed => "5.8.5",
+    }
+  }
+
+  /// Returns the specification's own title for the rule.
+  #[inline]
+  pub const fn title(self) -> &'static str {
+    match self {
+      Self::OperationTypeExistence => "Operation Type Existence",
+      Self::OperationNameUniqueness => "Operation Name Uniqueness",
+      Self::LoneAnonymousOperation => "Lone Anonymous Operation",
+      Self::SingleRootField => "Single Root Field",
+      Self::FieldSelections => "Field Selections",
+      Self::LeafFieldSelections => "Leaf Field Selections",
+      Self::ArgumentNames => "Argument Names",
+      Self::ArgumentUniqueness => "Argument Uniqueness",
+      Self::RequiredArguments => "Required Arguments",
+      Self::FragmentNameUniqueness => "Fragment Name Uniqueness",
+      Self::FragmentSpreadTypeExistence => "Fragment Spread Type Existence",
+      Self::FragmentsOnCompositeTypes => "Fragments on Object, Interface or Union Types",
+      Self::FragmentsMustBeUsed => "Fragments Must Be Used",
+      Self::FragmentSpreadTargetDefined => "Fragment Spread Target Defined",
+      Self::FragmentSpreadsMustNotFormCycles => "Fragment Spreads Must Not Form Cycles",
+      Self::FragmentSpreadIsPossible => "Fragment Spread Is Possible",
+      Self::ValuesOfCorrectType => "Values of Correct Type",
+      Self::InputObjectFieldNames => "Input Object Field Names",
+      Self::InputObjectFieldUniqueness => "Input Object Field Uniqueness",
+      Self::InputObjectRequiredFields => "Input Object Required Fields",
+      Self::DirectivesAreDefined => "Directives Are Defined",
+      Self::DirectivesAreInValidLocations => "Directives Are in Valid Locations",
+      Self::DirectivesAreUniquePerLocation => "Directives Are Unique per Location",
+      Self::VariableUniqueness => "Variable Uniqueness",
+      Self::VariablesAreInputTypes => "Variables Are Input Types",
+      Self::AllVariableUsesDefined => "All Variable Uses Defined",
+      Self::AllVariablesUsed => "All Variables Used",
+      Self::AllVariableUsagesAreAllowed => "All Variable Usages Are Allowed",
+    }
+  }
+}
+
+impl core::fmt::Display for Rule {
+  #[inline]
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    write!(f, "{} {}", self.section(), self.title())
+  }
+}
+
+/// A set of [`Rule`]s, as a bitmask.
+///
+/// The default is [`RuleSet::ALL`] — validation checks everything unless a caller narrows it.
+/// Narrowing does not merely filter diagnostics: a rule that is off is not evaluated, so a
+/// consumer that only wants, say, the fragment rules does not pay for value coercion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct RuleSet(u64);
+
+impl RuleSet {
+  /// The empty set. Validation with it emits nothing and is always `Ok`.
+  pub const EMPTY: Self = Self(0);
+
+  /// Every rule.
+  pub const ALL: Self = {
+    // `Rule::ALL.len()` low bits set. Written as a shift so adding a rule cannot leave it stale.
+    let count = Rule::ALL.len() as u32;
+    Self(if count >= 64 {
+      u64::MAX
+    } else {
+      (1u64 << count) - 1
+    })
+  };
+
+  /// Returns the set containing exactly `rule`.
+  #[inline]
+  pub const fn only(rule: Rule) -> Self {
+    Self(1u64 << rule.bit())
+  }
+
+  /// Returns the raw mask.
+  #[inline]
+  pub const fn bits(self) -> u64 {
+    self.0
+  }
+
+  /// Returns the set with `rule` added.
+  #[inline]
+  pub const fn with(self, rule: Rule) -> Self {
+    Self(self.0 | (1u64 << rule.bit()))
+  }
+
+  /// Returns the set with `rule` removed.
+  #[inline]
+  pub const fn without(self, rule: Rule) -> Self {
+    Self(self.0 & !(1u64 << rule.bit()))
+  }
+
+  /// Returns the union of two sets.
+  #[inline]
+  pub const fn union(self, other: Self) -> Self {
+    Self(self.0 | other.0)
+  }
+
+  /// Returns the intersection of two sets.
+  #[inline]
+  pub const fn intersection(self, other: Self) -> Self {
+    Self(self.0 & other.0)
+  }
+
+  /// Returns whether the set contains `rule`.
+  #[inline]
+  pub const fn contains(self, rule: Rule) -> bool {
+    self.0 & (1u64 << rule.bit()) != 0
+  }
+
+  /// Returns whether the set is empty.
+  #[inline]
+  pub const fn is_empty(self) -> bool {
+    self.0 == 0
+  }
+
+  /// Returns how many rules the set contains.
+  #[inline]
+  pub const fn len(self) -> u32 {
+    self.0.count_ones()
+  }
+
+  /// Iterates the set's rules in specification order.
+  pub fn iter(self) -> impl Iterator<Item = Rule> {
+    Rule::ALL.iter().copied().filter(move |r| self.contains(*r))
+  }
+}
+
+impl Default for RuleSet {
+  #[inline]
+  fn default() -> Self {
+    Self::ALL
+  }
+}
+
+impl FromIterator<Rule> for RuleSet {
+  fn from_iter<T: IntoIterator<Item = Rule>>(iter: T) -> Self {
+    iter.into_iter().fold(Self::EMPTY, Self::with)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Rule, RuleSet};
+
+  /// [`Rule::bit`] is spelled out because a `const fn` cannot search [`Rule::ALL`]. This is what
+  /// keeps the two from drifting: a rule inserted in the middle of `ALL` without renumbering
+  /// `bit` fails here rather than silently aliasing another rule's bit.
+  #[test]
+  fn bits_match_all_order() {
+    for (index, rule) in Rule::ALL.iter().enumerate() {
+      assert_eq!(
+        rule.bit() as usize,
+        index,
+        "{rule:?} is at index {index} of Rule::ALL but reports bit {}",
+        rule.bit()
+      );
+    }
+    assert_eq!(
+      RuleSet::ALL.len() as usize,
+      Rule::ALL.len(),
+      "RuleSet::ALL does not cover every rule"
+    );
+  }
+
+  #[test]
+  fn every_rule_is_addressable_alone() {
+    for rule in Rule::ALL {
+      let set = RuleSet::only(*rule);
+      assert_eq!(set.len(), 1);
+      assert!(set.contains(*rule));
+      assert_eq!(set.iter().collect::<std::vec::Vec<_>>(), [*rule]);
+      assert!(RuleSet::ALL.without(*rule).len() as usize == Rule::ALL.len() - 1);
+    }
+  }
+
+  #[test]
+  fn sections_and_titles_are_distinct() {
+    for (i, a) in Rule::ALL.iter().enumerate() {
+      for b in &Rule::ALL[i + 1..] {
+        assert_ne!(a.section(), b.section(), "{a:?} and {b:?} share a section");
+        assert_ne!(a.title(), b.title(), "{a:?} and {b:?} share a title");
+      }
+    }
+  }
+}

--- a/smear/src/validator/scratch.rs
+++ b/smear/src/validator/scratch.rs
@@ -1,0 +1,471 @@
+//! The caller-held working set, and the policy that bounds work.
+//!
+//! # Why the caller holds it
+//!
+//! Validation is a pure function of `(schema, document)`, but it needs somewhere to put a
+//! fragment index, a few bitsets and two explicit traversal stacks. Allocating those per request
+//! would put a handful of `malloc`s on the hot path of a server that otherwise makes none, so the
+//! buffers live in a [`Scratch`] the caller owns and reuses: [`Scratch::reset`] clears without
+//! freeing, capacity survives, and the steady state allocates nothing at all.
+//!
+//! This is `mdns-proto`'s caller-held `Pool` idea in the shape validation actually needs. It is a
+//! concrete struct rather than a pluggable container trait because the buffers are heterogeneous
+//! and internal to the algorithms — a trait would push generic parameters through every rule to
+//! let a caller swap something that is not policy. What *is* policy is [`Budget`].
+//!
+//! # Nothing in here is source-dependent
+//!
+//! Every buffer holds integers, so one `Scratch` serves documents whose source slice types differ
+//! and can be reused across them. That is also why the two traversal stacks are *coordinates*
+//! rather than node references: a frame names a definition and the chain of child indices that
+//! reaches it, which is what lets an explicit stack replace recursion over document shape without
+//! the stack itself becoming generic.
+
+use std::vec::Vec;
+
+use tokora::SimpleSpan;
+
+use super::schema::{PackedType, Range32, TypeId};
+
+/// How much work draft 5.3.2's merge engine may do before a document is refused.
+///
+/// Both knobs are **absolute**, never proportional to the input: an attacker chooses the input,
+/// so a proportional bound is not a bound. On a trip the engine emits its own rule and fails the
+/// document — never "passes unvalidated", never panics.
+///
+/// This is a *validation* budget and has nothing to do with the parser's recursion budget. They
+/// bound different resources — parse-time nesting against merge-time work — and are set
+/// independently.
+///
+/// # Status
+///
+/// `OverlappingFieldsCanBeMerged` (draft 5.3.2) is the only rule that reads these knobs, and it
+/// lands in its own wave so that its resource bound is designed rather than bolted on. The type
+/// is here now because it is part of the entry point's shape, and moving that later would move it
+/// under callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Budget {
+  merge_depth: u32,
+  merge_work: u32,
+}
+
+impl Budget {
+  /// The default response-shape nesting bound inside the merge recursion.
+  ///
+  /// 128, matching apollo-compiler's serde_json-derived limit.
+  pub const DEFAULT_MERGE_DEPTH: u32 = 128;
+
+  /// The default bound on total expanded field rows plus pair comparisons.
+  ///
+  /// Depth alone does not bound the merge engine — breadth times fragment reuse does — so the
+  /// work counter is the knob that actually caps the worst case.
+  pub const DEFAULT_MERGE_WORK: u32 = 65_536;
+
+  /// Creates a budget from both knobs.
+  #[inline]
+  pub const fn new(merge_depth: u32, merge_work: u32) -> Self {
+    Self {
+      merge_depth,
+      merge_work,
+    }
+  }
+
+  /// Returns the response-shape nesting bound.
+  #[inline]
+  pub const fn merge_depth(&self) -> u32 {
+    self.merge_depth
+  }
+
+  /// Returns the total-work bound.
+  #[inline]
+  pub const fn merge_work(&self) -> u32 {
+    self.merge_work
+  }
+
+  /// Returns the budget with a different nesting bound.
+  #[inline]
+  pub const fn with_merge_depth(mut self, merge_depth: u32) -> Self {
+    self.merge_depth = merge_depth;
+    self
+  }
+
+  /// Returns the budget with a different work bound.
+  #[inline]
+  pub const fn with_merge_work(mut self, merge_work: u32) -> Self {
+    self.merge_work = merge_work;
+    self
+  }
+}
+
+impl Default for Budget {
+  #[inline]
+  fn default() -> Self {
+    Self::new(Self::DEFAULT_MERGE_DEPTH, Self::DEFAULT_MERGE_WORK)
+  }
+}
+
+/// The sentinel a `u32` field uses for "absent".
+pub(crate) const NONE: u32 = u32::MAX;
+
+/// One operation definition, as the prep sweep recorded it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OperationRow {
+  /// Index into the document's definition list.
+  pub(crate) definition: u32,
+  /// The root operation slot the operation needs, as [`RootOperation::index`].
+  ///
+  /// [`RootOperation::index`]: super::schema::RootOperation::index
+  pub(crate) root: u8,
+  /// Whether the operation carries a name.
+  pub(crate) named: bool,
+  /// The span to blame for an operation-level diagnostic.
+  pub(crate) span: SimpleSpan,
+  /// The operation's outgoing fragment-spread edges, into [`Scratch::edges`].
+  pub(crate) edges: Range32,
+}
+
+/// One fragment definition, as the prep sweep recorded it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FragmentRow {
+  /// Index into the document's definition list.
+  pub(crate) definition: u32,
+  /// The span of the fragment's name.
+  pub(crate) span: SimpleSpan,
+  /// Every fragment sharing this one's name, as a range into [`Scratch::order`].
+  ///
+  /// The group's first element is the definition every spread of that name resolves to, and
+  /// reachability propagates across the whole group — so one duplicated name reports 5.5.1.1 and
+  /// does not also read as an unused fragment.
+  pub(crate) group: Range32,
+  /// The fragment's outgoing fragment-spread edges, into [`Scratch::edges`].
+  pub(crate) edges: Range32,
+}
+
+/// One fragment spread, as an edge of the fragment graph.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Edge {
+  /// The fragment ordinal the spread names, or [`NONE`] when no fragment has that name.
+  pub(crate) to: u32,
+  /// The spread's span.
+  pub(crate) span: SimpleSpan,
+}
+
+/// One level of the explicit selection-set walk.
+///
+/// A frame is a *coordinate*, not a reference: `definition` plus the `child` chain of the frames
+/// beneath it locates the selection set by descent. That is what lets the stack live in a
+/// [`Scratch`] that knows nothing about the document's source slice type.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Frame {
+  /// Index into the document's definition list of the definition this level lives in.
+  pub(crate) definition: u32,
+  /// Index in the parent level's selection list that led here, or [`NONE`] at a definition root.
+  pub(crate) child: u32,
+  /// The next selection index to visit at this level.
+  pub(crate) cursor: u32,
+  /// The type this level's selections are written against, or [`NONE`] when it did not resolve.
+  pub(crate) ty: u32,
+  /// See the `frame` flag constants.
+  pub(crate) flags: u8,
+}
+
+impl Frame {
+  /// The level's definition-local rules run here.
+  ///
+  /// Off when the level is a fragment body some earlier operation already checked: those rules
+  /// are properties of the fragment, not of the operation that reached it, so they fire once.
+  pub(crate) const CHECK: u8 = 1 << 0;
+
+  /// Creates the root frame of a definition's own selection set.
+  #[inline]
+  pub(crate) const fn root(definition: u32, ty: u32, flags: u8) -> Self {
+    Self {
+      definition,
+      child: NONE,
+      cursor: 0,
+      ty,
+      flags,
+    }
+  }
+
+  /// Creates the frame for a selection set nested inside the level above it.
+  #[inline]
+  pub(crate) const fn child(definition: u32, child: u32, ty: u32, flags: u8) -> Self {
+    Self {
+      definition,
+      child,
+      cursor: 0,
+      ty,
+      flags,
+    }
+  }
+
+  /// Returns whether this frame begins a definition rather than continuing one.
+  #[inline]
+  pub(crate) const fn is_definition_root(&self) -> bool {
+    self.child == NONE
+  }
+
+  /// Returns the level's type, or `None` when it did not resolve.
+  #[inline]
+  pub(crate) const fn type_id(&self) -> Option<TypeId> {
+    if self.ty == NONE {
+      None
+    } else {
+      Some(TypeId::new(self.ty))
+    }
+  }
+}
+
+/// What a value-walk level is descending through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValueLevel {
+  /// The level's children are a list literal's entries.
+  List,
+  /// The level's children are an object literal's field values.
+  Object,
+}
+
+/// One level of the explicit value-literal walk.
+///
+/// The same coordinate idea as [`Frame`], one tree down: the root value is held by the caller for
+/// the duration of the walk and a frame names the chain of list indices and object-field indices
+/// that reaches a nested value.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ValueFrame {
+  /// Index in the parent level that led here, or [`NONE`] at the root value.
+  pub(crate) child: u32,
+  /// The next child index to visit at this level.
+  pub(crate) cursor: u32,
+  /// For a list level, the type each entry is expected to have; unused for an object level, whose
+  /// children take their types from the schema. `None` when the position did not resolve.
+  pub(crate) expected: Option<PackedType>,
+  /// Whether the level's children are list entries or object field values.
+  pub(crate) level: ValueLevel,
+  /// The input object type this level's fields belong to, when [`ValueFrame::level`] is
+  /// [`ValueLevel::Object`]; [`NONE`] when it did not resolve.
+  pub(crate) object: u32,
+  /// The position bits, as `ValueLocation` spells them.
+  pub(crate) flags: u8,
+}
+
+/// One level of the fragment-graph depth-first search.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GraphFrame {
+  /// The fragment ordinal being explored.
+  pub(crate) fragment: u32,
+  /// The next outgoing edge index to follow.
+  pub(crate) edge: u32,
+}
+
+/// The caller-held working set.
+///
+/// Create one, hand it to every call, and reuse it. It grows to the high-water mark of the
+/// documents it has seen and never shrinks on its own, so the second and every later request
+/// allocate nothing.
+///
+/// ```
+/// # use smear::validator::Scratch;
+/// let mut scratch = Scratch::new();
+/// // … validate_executable(&schema, &document, &mut scratch, &budget, &mut sink) …
+/// scratch.reset(); // clears, keeps capacity
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct Scratch {
+  /// The document's operations, in source order.
+  pub(crate) operations: Vec<OperationRow>,
+  /// The document's fragments, in source order; the index is the fragment ordinal.
+  pub(crate) fragments: Vec<FragmentRow>,
+  /// Fragment ordinals sorted by name bytes, for lookup by binary search.
+  pub(crate) order: Vec<u32>,
+  /// Every fragment spread in the document, grouped by the definition that wrote it.
+  pub(crate) edges: Vec<Edge>,
+  /// The selection-set walk's frame stack.
+  pub(crate) frames: Vec<Frame>,
+  /// The subscription root-field collection walk's frame stack.
+  ///
+  /// Separate from [`Scratch::frames`] because draft 5.2.4.1 runs its own collection with its own
+  /// rules about what it may descend into.
+  pub(crate) roots: Vec<Frame>,
+  /// The value-literal walk's frame stack.
+  pub(crate) values: Vec<ValueFrame>,
+  /// The fragment-graph search's frame stack.
+  pub(crate) graph: Vec<GraphFrame>,
+  /// The duplicate-scan index permutation.
+  ///
+  /// Argument sets, variable lists, directive lists and input object literals are all short, so
+  /// duplicate detection sorts a segment of indices in place and scans neighbours rather than
+  /// building a map. Comparison is always on the *bytes*: interning the names first would collapse
+  /// every name the schema does not know onto one sentinel, and two distinct undefined names would
+  /// read as duplicates of each other.
+  ///
+  /// Segments stack — a scan pushes at `len`, sorts its own slice and truncates back — so an input
+  /// object literal nested inside an argument list does not disturb the scan above it.
+  pub(crate) keys: Vec<u32>,
+  /// Fragment ordinals reachable from some operation (draft 5.5.1.4).
+  pub(crate) reachable: Vec<u64>,
+  /// Fragment ordinals already entered during the current walk.
+  pub(crate) visited: Vec<u64>,
+  /// Fragment ordinals on the current fragment-graph search path (draft 5.5.2.2).
+  pub(crate) on_path: Vec<u64>,
+  /// Fragment ordinals whose fragment-graph search has finished.
+  pub(crate) done: Vec<u64>,
+  /// Definition indices whose definition-local rules have already run.
+  pub(crate) checked: Vec<u64>,
+  /// Variable-definition indices used by the operation being walked (draft 5.8.4).
+  pub(crate) used: Vec<u64>,
+}
+
+impl Scratch {
+  /// Creates an empty working set.
+  ///
+  /// It allocates on its first use, not here, so a server can build one per connection cheaply and
+  /// let the sizes settle.
+  #[inline]
+  pub const fn new() -> Self {
+    Self {
+      operations: Vec::new(),
+      fragments: Vec::new(),
+      order: Vec::new(),
+      edges: Vec::new(),
+      frames: Vec::new(),
+      roots: Vec::new(),
+      values: Vec::new(),
+      graph: Vec::new(),
+      keys: Vec::new(),
+      reachable: Vec::new(),
+      visited: Vec::new(),
+      on_path: Vec::new(),
+      done: Vec::new(),
+      checked: Vec::new(),
+      used: Vec::new(),
+    }
+  }
+
+  /// Empties every buffer, keeping every allocation.
+  ///
+  /// `validate_executable` calls this itself on entry, so a caller never has to remember; it is
+  /// public for the case where a caller wants the memory quiet between bursts without dropping
+  /// the value.
+  pub fn reset(&mut self) {
+    self.operations.clear();
+    self.fragments.clear();
+    self.order.clear();
+    self.edges.clear();
+    self.frames.clear();
+    self.roots.clear();
+    self.values.clear();
+    self.graph.clear();
+    self.keys.clear();
+    self.reachable.clear();
+    self.visited.clear();
+    self.on_path.clear();
+    self.done.clear();
+    self.checked.clear();
+    self.used.clear();
+  }
+
+  /// Returns a rough count of the rows the working set is currently holding.
+  ///
+  /// Exposed so a test can show that reuse is real — that the second validation of the same
+  /// document grows nothing — rather than asserting it from the outside.
+  pub fn capacity(&self) -> usize {
+    self.operations.capacity()
+      + self.fragments.capacity()
+      + self.order.capacity()
+      + self.edges.capacity()
+      + self.frames.capacity()
+      + self.roots.capacity()
+      + self.values.capacity()
+      + self.graph.capacity()
+      + self.keys.capacity()
+      + self.reachable.capacity()
+      + self.visited.capacity()
+      + self.on_path.capacity()
+      + self.done.capacity()
+      + self.checked.capacity()
+      + self.used.capacity()
+  }
+}
+
+/// Sizes a bitset to hold `bits` bits and clears it, without freeing.
+pub(crate) fn reset_bits(words: &mut Vec<u64>, bits: usize) {
+  let needed = bits.div_ceil(64);
+  words.clear();
+  words.resize(needed, 0);
+}
+
+/// Returns whether bit `index` is set.
+#[inline]
+pub(crate) fn get_bit(words: &[u64], index: u32) -> bool {
+  let word = (index / 64) as usize;
+  words
+    .get(word)
+    .is_some_and(|bits| bits & (1u64 << (index % 64)) != 0)
+}
+
+/// Sets bit `index`, returning whether it was already set.
+#[inline]
+pub(crate) fn set_bit(words: &mut [u64], index: u32) -> bool {
+  let word = (index / 64) as usize;
+  match words.get_mut(word) {
+    Some(bits) => {
+      let mask = 1u64 << (index % 64);
+      let was = *bits & mask != 0;
+      *bits |= mask;
+      was
+    }
+    None => true,
+  }
+}
+
+/// Clears bit `index`.
+#[inline]
+pub(crate) fn clear_bit(words: &mut [u64], index: u32) {
+  let word = (index / 64) as usize;
+  if let Some(bits) = words.get_mut(word) {
+    *bits &= !(1u64 << (index % 64));
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{Budget, Scratch, get_bit, reset_bits, set_bit};
+  use std::vec::Vec;
+
+  #[test]
+  fn budget_defaults_are_the_designed_numbers() {
+    let budget = Budget::default();
+    assert_eq!(budget.merge_depth(), 128);
+    assert_eq!(budget.merge_work(), 65_536);
+    assert_eq!(budget.with_merge_depth(8).merge_depth(), 8);
+    assert_eq!(budget.with_merge_work(9).merge_work(), 9);
+    // The knobs are independent; setting one must not disturb the other.
+    assert_eq!(budget.with_merge_depth(8).merge_work(), 65_536);
+  }
+
+  #[test]
+  fn reset_keeps_capacity() {
+    let mut scratch = Scratch::new();
+    scratch.order.extend(0..64u32);
+    let capacity = scratch.capacity();
+    assert!(capacity >= 64);
+    scratch.reset();
+    assert!(scratch.order.is_empty());
+    assert_eq!(scratch.capacity(), capacity, "reset must not free");
+  }
+
+  #[test]
+  fn bitsets_round_trip_and_report_previous_state() {
+    let mut words = Vec::new();
+    reset_bits(&mut words, 130);
+    assert_eq!(words.len(), 3);
+    assert!(!get_bit(&words, 129));
+    assert!(!set_bit(&mut words, 129));
+    assert!(set_bit(&mut words, 129));
+    assert!(get_bit(&words, 129));
+    // Out of range reads as unset and refuses to record, rather than panicking mid-traversal.
+    assert!(!get_bit(&words, 1_000));
+    assert!(set_bit(&mut words, 1_000));
+  }
+}

--- a/smear/src/validator/sink.rs
+++ b/smear/src/validator/sink.rs
@@ -1,0 +1,196 @@
+//! The one seam between the validator and the caller's diagnostic storage.
+//!
+//! # The validator owns nothing
+//!
+//! There is no diagnostic buffer inside `validate_executable`. The caller passes a [`Sink`], the
+//! validator hands it values, and the sink decides what happens to them — the obligation pattern
+//! `hick`/`mdns-proto` uses for I/O, applied to reporting. That is what makes the fast path free:
+//! with [`First`] the compiler can see that no collection is ever built, and a server that only
+//! needs a verdict allocates nothing at all.
+//!
+//! # One method, not a trait family
+//!
+//! `tokora`'s parser has an emitter bundle per error kind because parsing has many kinds with
+//! different recovery decisions. Validation has one diagnostic family and exactly one decision —
+//! keep going, or stop — so the whole seam is one method returning [`ControlFlow`]. The four
+//! provided implementations mirror the *semantics* of `tokora`'s `Fatal`, `Verbose`, `Silent` and
+//! `Ignored` bundles:
+//!
+//! | this module | `tokora` | behaviour |
+//! |---|---|---|
+//! | [`First`] | `Fatal` | keep the first diagnostic, stop validating |
+//! | [`Collect`] | `Verbose` | append to the caller's `Vec`, keep going |
+//! | [`Count`] | `Silent` | count, keep nothing, keep going |
+//! | [`Ignore`] | `Ignored` | discard, keep going |
+
+use core::ops::ControlFlow;
+
+use std::vec::Vec;
+
+use super::Diagnostic;
+
+/// Caller-provided diagnostic storage.
+///
+/// Returning [`ControlFlow::Break`] stops validation; the entry point then reports that it
+/// stopped early through [`Invalid::stopped`](super::Invalid::stopped). Returning
+/// [`ControlFlow::Continue`] asks for the rest of the document's diagnostics.
+pub trait Sink<S> {
+  /// Accepts one diagnostic, and says whether validation should continue.
+  fn diagnostic(&mut self, diagnostic: Diagnostic<S>) -> ControlFlow<()>;
+}
+
+impl<S, K> Sink<S> for &mut K
+where
+  K: Sink<S> + ?Sized,
+{
+  #[inline]
+  fn diagnostic(&mut self, diagnostic: Diagnostic<S>) -> ControlFlow<()> {
+    (**self).diagnostic(diagnostic)
+  }
+}
+
+/// Keeps the first diagnostic and stops — the server default.
+///
+/// This is the sink the zero-allocation path is built around: it holds one `Option`, never a
+/// collection, and it breaks immediately, so an invalid document costs one partial traversal
+/// rather than a full one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct First<S> {
+  first: Option<Diagnostic<S>>,
+}
+
+impl<S> First<S> {
+  /// Creates an empty sink.
+  #[inline]
+  pub const fn new() -> Self {
+    Self { first: None }
+  }
+
+  /// Returns the diagnostic that stopped validation, if any.
+  #[inline]
+  pub const fn get(&self) -> Option<&Diagnostic<S>> {
+    self.first.as_ref()
+  }
+
+  /// Takes the diagnostic out, leaving the sink empty and reusable.
+  #[inline]
+  pub fn take(&mut self) -> Option<Diagnostic<S>> {
+    self.first.take()
+  }
+
+  /// Consumes the sink and returns the diagnostic.
+  #[inline]
+  pub fn into_inner(self) -> Option<Diagnostic<S>> {
+    self.first
+  }
+
+  /// Empties the sink so it can be reused for the next request.
+  #[inline]
+  pub fn clear(&mut self) {
+    self.first = None;
+  }
+}
+
+impl<S> Default for First<S> {
+  #[inline]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<S> Sink<S> for First<S> {
+  #[inline]
+  fn diagnostic(&mut self, diagnostic: Diagnostic<S>) -> ControlFlow<()> {
+    if self.first.is_none() {
+      self.first = Some(diagnostic);
+    }
+    ControlFlow::Break(())
+  }
+}
+
+/// Appends to a `Vec` the caller owns — the tooling default.
+///
+/// The borrow is what keeps the storage the caller's: capacity survives between requests because
+/// the `Vec` does, and a caller who pre-sizes it keeps the whole path allocation-free.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Collect<'a, S> {
+  into: &'a mut Vec<Diagnostic<S>>,
+}
+
+impl<'a, S> Collect<'a, S> {
+  /// Wraps the caller's storage.
+  #[inline]
+  pub fn new(into: &'a mut Vec<Diagnostic<S>>) -> Self {
+    Self { into }
+  }
+
+  /// Returns what has been collected so far.
+  #[inline]
+  pub fn diagnostics(&self) -> &[Diagnostic<S>] {
+    self.into
+  }
+}
+
+impl<'a, S> From<&'a mut Vec<Diagnostic<S>>> for Collect<'a, S> {
+  #[inline]
+  fn from(into: &'a mut Vec<Diagnostic<S>>) -> Self {
+    Self::new(into)
+  }
+}
+
+impl<S> Sink<S> for Collect<'_, S> {
+  #[inline]
+  fn diagnostic(&mut self, diagnostic: Diagnostic<S>) -> ControlFlow<()> {
+    self.into.push(diagnostic);
+    ControlFlow::Continue(())
+  }
+}
+
+/// Counts diagnostics and keeps none.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Count {
+  count: u32,
+}
+
+impl Count {
+  /// Creates a sink at zero.
+  #[inline]
+  pub const fn new() -> Self {
+    Self { count: 0 }
+  }
+
+  /// Returns how many diagnostics have been accepted.
+  #[inline]
+  pub const fn get(&self) -> u32 {
+    self.count
+  }
+
+  /// Resets the counter so the sink can be reused.
+  #[inline]
+  pub const fn clear(&mut self) {
+    self.count = 0;
+  }
+}
+
+impl<S> Sink<S> for Count {
+  #[inline]
+  fn diagnostic(&mut self, _: Diagnostic<S>) -> ControlFlow<()> {
+    self.count = self.count.saturating_add(1);
+    ControlFlow::Continue(())
+  }
+}
+
+/// Discards every diagnostic and keeps validating.
+///
+/// The verdict still comes back: `validate_executable` counts what it emitted regardless of what
+/// the sink did with it, so `Ignore` reports "invalid, and I am not telling you why" — useful for
+/// a warm-up pass or a conformance harness that only wants the boolean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Ignore;
+
+impl<S> Sink<S> for Ignore {
+  #[inline]
+  fn diagnostic(&mut self, _: Diagnostic<S>) -> ControlFlow<()> {
+    ControlFlow::Continue(())
+  }
+}

--- a/smear/tests/validator_allocation.rs
+++ b/smear/tests/validator_allocation.rs
@@ -1,0 +1,356 @@
+//! The steady state allocates nothing, measured rather than asserted.
+//!
+//! # What is being claimed
+//!
+//! `validate_executable` owns no storage. The working set is the caller's [`Scratch`] and the
+//! diagnostics are the caller's sink, so once both have seen a request the size of the ones to
+//! come, a validation performs **zero heap allocations** — not "few", not "amortised".
+//!
+//! # How it is measured
+//!
+//! A counting global allocator, and a thread-local counter so that a test running beside this one
+//! on another thread cannot perturb the reading. The corpus is warmed once — which is where the
+//! `Scratch`'s buffers and the collecting sink's `Vec` reach their high-water marks — and every
+//! validation after that is measured with the counter.
+//!
+//! [`the_gate_counts`] is the discrimination check: it shows the allocator is installed and the
+//! counter moves, so a green reading below means "nothing allocated" rather than "nothing was
+//! looking".
+
+#![allow(missing_docs)]
+
+use std::{
+  alloc::{GlobalAlloc, Layout, System},
+  cell::Cell,
+  vec::Vec,
+};
+
+use smear::{
+  lexer::tokora::{Parse as _, Parser},
+  parser::graphql::{
+    GraphQL,
+    ast::{ExecutableDocument, TypeSystemDocument},
+    error::GraphqlErrors,
+    syntactic::{GraphqlLexer, executable_document, type_system_document},
+  },
+  validator::{
+    Budget, Collect, Count, Diagnostic, First, Ignore, Schema, Scratch, validate_executable,
+  },
+};
+
+// ---------------------------------------------------------------------------------------------
+// the counting allocator
+// ---------------------------------------------------------------------------------------------
+
+thread_local! {
+  /// Allocation events on this thread. `alloc`, `alloc_zeroed` and a growing `realloc` all count.
+  static ALLOCATIONS: Cell<u64> = const { Cell::new(0) };
+}
+
+struct Counting;
+
+/// Counts every allocation event and forwards to the system allocator.
+///
+/// The counter is thread-local and updated through `try_with`, so an allocation made while the
+/// thread's local storage is being set up or torn down is simply not counted rather than
+/// re-entering it.
+unsafe impl GlobalAlloc for Counting {
+  unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+    bump();
+    unsafe { System.alloc(layout) }
+  }
+
+  unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+    bump();
+    unsafe { System.alloc_zeroed(layout) }
+  }
+
+  unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+    bump();
+    unsafe { System.realloc(ptr, layout, new_size) }
+  }
+
+  unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    unsafe { System.dealloc(ptr, layout) }
+  }
+}
+
+#[global_allocator]
+static ALLOCATOR: Counting = Counting;
+
+fn bump() {
+  let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+}
+
+/// Runs `body` and returns how many allocation events it caused on this thread.
+fn allocations(body: impl FnOnce()) -> u64 {
+  let before = ALLOCATIONS.with(Cell::get);
+  body();
+  ALLOCATIONS.with(Cell::get) - before
+}
+
+// ---------------------------------------------------------------------------------------------
+// the corpus
+// ---------------------------------------------------------------------------------------------
+
+const SCHEMA: &str = r#"
+type Query {
+  hero(episode: Episode): Character
+  droid(id: ID!): Droid
+  search(text: String, filter: SearchFilter): [SearchResult]
+}
+
+interface Character {
+  id: ID!
+  name: String!
+  friends: [Character]
+  appearsIn: [Episode]!
+}
+
+type Human implements Character {
+  id: ID!
+  name: String!
+  friends: [Character]
+  appearsIn: [Episode]!
+  homePlanet: String
+  height(unit: LengthUnit = METER): Float
+}
+
+type Droid implements Character {
+  id: ID!
+  name: String!
+  friends: [Character]
+  appearsIn: [Episode]!
+  primaryFunction: String
+}
+
+union SearchResult = Human | Droid
+
+enum Episode { NEWHOPE EMPIRE JEDI }
+enum LengthUnit { METER FOOT }
+
+input SearchFilter {
+  episode: Episode
+  nameContains: String
+  limit: Int = 10
+}
+"#;
+
+/// Documents a server would actually see: valid ones, and ones that fail at the first thing a
+/// server would notice.
+const CORPUS: &[&str] = &[
+  // A realistic request with variables, fragments, aliases, directives and input objects.
+  r#"query HeroComparison($ep: Episode, $withFriends: Boolean!, $filter: SearchFilter) {
+       left: hero(episode: $ep) { ...characterFields }
+       right: hero { ...characterFields }
+       results: search(text: "r2", filter: $filter) {
+         ... on Droid { primaryFunction }
+         ... on Human { homePlanet height(unit: FOOT) }
+       }
+     }
+     fragment characterFields on Character {
+       id
+       name
+       appearsIn
+       friends @include(if: $withFriends) { name }
+     }"#,
+  // The smallest useful request.
+  "{ hero { name } }",
+  // Introspection, which is an ordinary document against the injected meta-schema.
+  "{ __schema { queryType { name } types { name kind } } }",
+  // A deeply reused fragment graph, so the reachability and visited bitsets are exercised.
+  "query Deep { hero { ...a } }
+   fragment a on Character { name ...b ...c }
+   fragment b on Character { id friends { ...c } }
+   fragment c on Character { appearsIn }",
+  // Invalid, and invalid early: an unknown field on the first selection.
+  "{ heroo { name } }",
+  // Invalid deeper in, past the fragment machinery.
+  "query Bad($ep: Episode) { hero(episode: $ep) { ...frag } }
+   fragment frag on Character { name midichlorians }",
+  // Invalid in a value literal, so the value walk is on the measured path.
+  r#"{ search(text: 1, filter: { limit: "ten", nope: true }) { __typename } }"#,
+];
+
+fn build() -> Schema {
+  let document = Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    TypeSystemDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(type_system_document)
+  .parse_str(SCHEMA)
+  .expect("the corpus SDL parses");
+  Schema::build(&document).expect("the corpus SDL is a schema")
+}
+
+fn parse(source: &'static str) -> ExecutableDocument<&'static str> {
+  Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    ExecutableDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(executable_document)
+  .parse_str(source)
+  .unwrap_or_else(|errors| panic!("corpus query does not parse: {errors:?}\n---\n{source}"))
+}
+
+// ---------------------------------------------------------------------------------------------
+// the gate
+// ---------------------------------------------------------------------------------------------
+
+/// The measurement discriminates: an allocation inside the window is seen.
+///
+/// Without this, a zero reading below would be indistinguishable from an allocator that was never
+/// installed.
+#[test]
+fn the_gate_counts() {
+  // Warm the thread-local itself, so its own setup is not what is being measured.
+  let _ = allocations(|| {});
+  let counted = allocations(|| {
+    let buffer: Vec<u8> = Vec::with_capacity(4096);
+    std::hint::black_box(&buffer);
+  });
+  assert!(
+    counted >= 1,
+    "the counting allocator saw nothing; the gate below would pass vacuously"
+  );
+}
+
+/// Steady-state validation allocates nothing, for every sink that is not asked to grow storage.
+#[test]
+fn steady_state_validation_allocates_nothing() {
+  let schema = build();
+  let budget = Budget::default();
+  let documents: Vec<_> = CORPUS
+    .iter()
+    .map(|source| (*source, parse(source)))
+    .collect();
+
+  let mut scratch = Scratch::new();
+  let mut collected: Vec<Diagnostic<&'static str>> = Vec::with_capacity(64);
+
+  // One warm pass over the whole corpus: this is where the working set and the caller's sink
+  // reach the sizes the steady state reuses.
+  for (_, document) in &documents {
+    let mut first = First::new();
+    let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut first);
+    collected.clear();
+    let mut collect = Collect::new(&mut collected);
+    let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut collect);
+    let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut Count::new());
+    let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut Ignore);
+  }
+  let _ = allocations(|| {});
+
+  // Ten rounds, so a "first call after the warm-up" fluke cannot pass.
+  for _ in 0..10 {
+    for (source, document) in &documents {
+      let mut first = First::new();
+      let counted = allocations(|| {
+        let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut first);
+      });
+      assert_eq!(counted, 0, "`First` allocated {counted} times on\n{source}");
+
+      collected.clear();
+      let counted = allocations(|| {
+        let mut collect = Collect::new(&mut collected);
+        let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut collect);
+      });
+      assert_eq!(
+        counted, 0,
+        "a pre-sized `Collect` allocated {counted} times on\n{source}"
+      );
+
+      let counted = allocations(|| {
+        let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut Count::new());
+      });
+      assert_eq!(counted, 0, "`Count` allocated {counted} times on\n{source}");
+
+      let counted = allocations(|| {
+        let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut Ignore);
+      });
+      assert_eq!(
+        counted, 0,
+        "`Ignore` allocated {counted} times on\n{source}"
+      );
+    }
+  }
+}
+
+/// The claim survives a fresh `Scratch` meeting the corpus in a different order.
+///
+/// The high-water mark is what the warm-up establishes, so the largest document must be the one
+/// that sets it — whichever position it is in.
+#[test]
+fn the_order_of_the_warm_up_does_not_matter() {
+  let schema = build();
+  let budget = Budget::default();
+  let mut documents: Vec<_> = CORPUS
+    .iter()
+    .map(|source| (*source, parse(source)))
+    .collect();
+  documents.reverse();
+
+  let mut scratch = Scratch::new();
+  for (_, document) in &documents {
+    let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut Ignore);
+  }
+  let _ = allocations(|| {});
+
+  for (source, document) in &documents {
+    let counted = allocations(|| {
+      let _ = validate_executable(&schema, document, &mut scratch, &budget, &mut Ignore);
+    });
+    assert_eq!(counted, 0, "allocated {counted} times on\n{source}");
+  }
+}
+
+/// Rendering a diagnostic into a caller's buffer is the only thing that allocates, and it is the
+/// caller's decision.
+///
+/// The point of the split: the validation path formats nothing, so a server that only needs a
+/// verdict never pays for a message it will not read.
+#[test]
+fn only_rendering_allocates() {
+  use core::fmt::Write as _;
+
+  let schema = build();
+  let budget = Budget::default();
+  let document = parse("{ heroo { name } }");
+  let mut scratch = Scratch::new();
+
+  let mut first = First::new();
+  let _ = validate_executable(&schema, &document, &mut scratch, &budget, &mut first);
+  let mut rendered = std::string::String::with_capacity(256);
+  let _ = write!(
+    rendered,
+    "{}",
+    first.get().expect("a diagnostic").display(&schema)
+  );
+  rendered.clear();
+  let _ = allocations(|| {});
+
+  let mut first = First::new();
+  let validating = allocations(|| {
+    let _ = validate_executable(&schema, &document, &mut scratch, &budget, &mut first);
+  });
+  assert_eq!(validating, 0);
+
+  // Into a pre-sized buffer, even rendering allocates nothing.
+  let diagnostic = *first.get().expect("a diagnostic");
+  let rendering = allocations(|| {
+    let _ = write!(rendered, "{}", diagnostic.display(&schema));
+  });
+  assert_eq!(rendering, 0, "rendering into a pre-sized buffer allocated");
+  assert!(rendered.contains("5.3.1"));
+
+  // And into a fresh `String`, it does — which is the discrimination for this test.
+  let rendering = allocations(|| {
+    let owned = diagnostic.display(&schema).to_string();
+    std::hint::black_box(&owned);
+  });
+  assert!(rendering >= 1, "`to_string` should allocate");
+}

--- a/smear/tests/validator_rules.rs
+++ b/smear/tests/validator_rules.rs
@@ -973,6 +973,8 @@ fn subscription_roots_are_collected_without_runtime_values() {
     "subscription requiresRuntime($bool: Boolean!) \
      { newMessage @include(if: $bool) { body } }",
     "subscription introspects { __typename }",
+    // The rule is about the *field*, not the response key, so an alias does not launder it.
+    "subscription aliased { alias: __typename }",
     "subscription throughFragment { ...two } \
      fragment two on Subscription { newMessage { body } disallowedSecondRootField }",
   ] {
@@ -982,6 +984,12 @@ fn subscription_roots_are_collected_without_runtime_values() {
       "5.2.4.1 did not fire for\n---\n{source}\n--- got {rules:?}"
     );
   }
+
+  // And the aliased case names the field it refused, not the key the alias gave it — which is
+  // what distinguishes reading the rule as written from reading it off the response name.
+  let aliased = diagnose(&schema, "subscription aliased { alias: __typename }");
+  assert_eq!(aliased.len(), 1);
+  assert_eq!(aliased[0].subject_source(), Some(&"__typename"));
 }
 
 /// Draft 5.5.2.2 runs over the whole fragment graph, including fragments no operation reaches —

--- a/smear/tests/validator_rules.rs
+++ b/smear/tests/validator_rules.rs
@@ -1,0 +1,1296 @@
+//! Draft §5 executable-document validation: the per-rule liveness floor, and what it does not
+//! cover.
+//!
+//! # The floor
+//!
+//! [`liveness_floor`] iterates `Rule::ALL` and asserts that every rule has an entry in
+//! [`FIXTURES`] holding a document that makes it **fire**, together with the **exact** set of
+//! rules that document produces, and a valid twin that produces none. A rule added without a
+//! document that exercises it fails; a document that starts tripping a second rule fails; a rule
+//! that stops firing fails. Thirty rules and a corpus that never reaches twenty of them is the
+//! failure this suite exists to make impossible, so the census is mechanical rather than
+//! reviewed-in.
+//!
+//! Two further gates ride the same table: [`every_rule_is_independently_addressable`] runs each
+//! fixture with only its own rule enabled, proving the `RuleSet` door is real and that no rule
+//! depends on another having run; and [`every_valid_twin_is_valid_under_every_rule`] runs the
+//! twins with the full set, which is what makes "produces none" mean something.
+
+#![allow(missing_docs)]
+
+use std::vec::Vec;
+
+use smear::{
+  lexer::tokora::{Parse as _, Parser, SimpleSpan},
+  parser::graphql::{
+    GraphQL,
+    ast::{
+      Argument, ArgumentList, Described, ExecutableDefinition, ExecutableDocument, Field,
+      InputValue, Name, Object, ObjectField, OperationDefinition, Selection, SelectionSet,
+      TypeSystemDocument,
+    },
+    error::GraphqlErrors,
+    syntactic::{GraphqlLexer, executable_document, type_system_document},
+  },
+  validator::{
+    Budget, Collect, Context, Count, Diagnostic, First, Ignore, Rule, RuleSet, Schema, Scratch,
+    validate_executable, validate_executable_with,
+  },
+};
+
+// ---------------------------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------------------------
+
+/// The schema every fixture without an override validates against.
+///
+/// It is the specification's own example type system — the dog, cat, human and alien menagerie of
+/// §5 — extended with the argument, input object and directive shapes the later rules need. Using
+/// the specification's schema means the fixtures below are mostly its own counter-examples.
+const SCHEMA: &str = r#"
+type Query {
+  dog: Dog
+  human: Human
+  pet: Pet
+  catOrDog: CatOrDog
+  empty: Empty
+  arguments: Arguments
+  findDog(searchBy: FindDogInput): Dog
+  booleanList(booleanListArg: [Boolean!]): Boolean
+  requiredInput(input: RequiredInput!): Boolean
+  nest: Nest
+  recursive(input: Recursive): Boolean
+}
+
+# Two self-referential shapes, one per tree, so the depth gate can nest as far as it likes.
+type Nest {
+  nest: Nest
+  leaf: Int
+}
+
+input Recursive {
+  rec: Recursive
+  n: Int
+}
+
+type Mutation {
+  addPet(pet: PetInput!): Pet
+  addPets(pets: [PetInput!]!): [Pet]
+}
+
+type Subscription {
+  newMessage: Message
+  disallowedSecondRootField: Boolean
+}
+
+type Message {
+  body: String
+  sender: String
+}
+
+interface Sentient {
+  name: String!
+}
+
+interface Pet {
+  name: String!
+}
+
+# An interface with no implementors: the empty possible-object set draft 5.5.2.3's ecosystem
+# exception exists for.
+interface Empty {
+  nothing: Int
+}
+
+type Alien implements Sentient {
+  name: String!
+  homePlanet: String
+}
+
+type Human implements Sentient {
+  name: String!
+  pets: [Pet]
+}
+
+enum DogCommand {
+  SIT
+  DOWN
+  HEEL
+}
+
+type Dog implements Pet {
+  name: String!
+  nickname: String
+  barkVolume: Int
+  doesKnowCommand(dogCommand: DogCommand!): Boolean!
+  isHouseTrained(atOtherHomes: Boolean): Boolean!
+  owner: Human
+}
+
+enum CatCommand {
+  JUMP
+}
+
+type Cat implements Pet {
+  name: String!
+  nickname: String
+  doesKnowCommand(catCommand: CatCommand!): Boolean!
+  meowVolume: Int
+}
+
+union CatOrDog = Cat | Dog
+union HumanOrAlien = Human | Alien
+
+scalar CustomScalar
+
+type Arguments {
+  multipleRequirements(x: Int!, y: Int!): Int!
+  booleanArgField(booleanArg: Boolean): Boolean
+  floatArgField(floatArg: Float): Float
+  intArgField(intArg: Int): Int
+  idArgField(idArg: ID): ID
+  stringArgField(stringArg: String): String
+  enumArgField(enumArg: DogCommand): Boolean
+  customScalarArgField(customArg: CustomScalar): Boolean
+  nonNullBooleanArgField(nonNullBooleanArg: Boolean!): Boolean!
+  booleanListArgField(booleanListArg: [Boolean]!): [Boolean]
+  optionalNonNullBooleanArgField(optionalBooleanArg: Boolean! = false): Boolean!
+}
+
+input FindDogInput {
+  name: String
+  owner: String
+}
+
+input RequiredInput {
+  req: Int!
+  opt: Int
+}
+
+input CatInput {
+  name: String!
+}
+
+input DogInput {
+  name: String!
+}
+
+input PetInput @oneOf {
+  cat: CatInput
+  dog: DogInput
+}
+
+directive @onQuery on QUERY
+directive @repeatableField repeatable on FIELD
+"#;
+
+fn build(sdl: &str) -> Schema {
+  let document = Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    TypeSystemDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(type_system_document)
+  .parse_str(sdl)
+  .unwrap_or_else(|errors| panic!("fixture SDL does not parse: {errors:?}\n---\n{sdl}"));
+  Schema::build(&document)
+    .unwrap_or_else(|errors| panic!("fixture SDL is not a schema:\n{errors}\n---\n{sdl}"))
+}
+
+fn parse(source: &str) -> ExecutableDocument<&str> {
+  Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    ExecutableDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(executable_document)
+  .parse_str(source)
+  .unwrap_or_else(|errors| panic!("fixture query does not parse: {errors:?}\n---\n{source}"))
+}
+
+/// Validates `source` against `schema` with every rule on, returning the diagnostics.
+fn diagnose<'a>(schema: &Schema, source: &'a str) -> Vec<Diagnostic<&'a str>> {
+  diagnose_with(schema, source, RuleSet::ALL)
+}
+
+fn diagnose_with<'a>(schema: &Schema, source: &'a str, rules: RuleSet) -> Vec<Diagnostic<&'a str>> {
+  let document = parse(source);
+  let mut scratch = Scratch::new();
+  let mut collected = Vec::new();
+  let mut sink = Collect::new(&mut collected);
+  let result = validate_executable_with(
+    schema,
+    &document,
+    &mut scratch,
+    &Budget::default(),
+    rules,
+    &mut sink,
+  );
+  assert_eq!(
+    result.is_err(),
+    !collected.is_empty(),
+    "the verdict and the diagnostics disagree\n---\n{source}"
+  );
+  collected
+}
+
+/// The set of rules a document fires, sorted and deduplicated.
+fn fired(schema: &Schema, source: &str) -> Vec<Rule> {
+  let mut rules: Vec<_> = diagnose(schema, source)
+    .iter()
+    .map(Diagnostic::rule)
+    .collect();
+  rules.sort_unstable();
+  rules.dedup();
+  rules
+}
+
+fn sorted(rules: &[Rule]) -> Vec<Rule> {
+  let mut rules = rules.to_vec();
+  rules.sort_unstable();
+  rules.dedup();
+  rules
+}
+
+// ---------------------------------------------------------------------------------------------
+// the fixture table
+// ---------------------------------------------------------------------------------------------
+
+/// One rule's liveness evidence.
+struct Fixture {
+  /// The rule this entry exists for.
+  rule: Rule,
+  /// An SDL override, when the standard schema cannot express the failure.
+  schema: Option<&'static str>,
+  /// A document that makes [`Fixture::rule`] fire.
+  invalid: &'static str,
+  /// The **complete** set of rules [`Fixture::invalid`] fires.
+  fires: &'static [Rule],
+  /// A document as close to it as possible that fires nothing at all.
+  valid: &'static str,
+}
+
+/// A schema with no mutation root, so an operation can ask for one that is not there.
+const QUERY_ONLY: &str = "type Query { ok: Int }";
+
+const FIXTURES: &[Fixture] = &[
+  // -- 5.2 operations -------------------------------------------------------------------------
+  Fixture {
+    rule: Rule::OperationTypeExistence,
+    schema: Some(QUERY_ONLY),
+    invalid: "mutation goodbyeMutation { goodbye }",
+    fires: &[Rule::OperationTypeExistence],
+    valid: "query helloQuery { ok }",
+  },
+  Fixture {
+    rule: Rule::OperationNameUniqueness,
+    schema: None,
+    invalid: "query getName { dog { name } } query getName { dog { nickname } }",
+    fires: &[Rule::OperationNameUniqueness],
+    valid: "query getName { dog { name } } query getNickname { dog { nickname } }",
+  },
+  Fixture {
+    rule: Rule::LoneAnonymousOperation,
+    schema: None,
+    invalid: "{ dog { name } } query getName { dog { nickname } }",
+    fires: &[Rule::LoneAnonymousOperation],
+    valid: "{ dog { name } }",
+  },
+  Fixture {
+    rule: Rule::SingleRootField,
+    schema: None,
+    invalid: "subscription sub { newMessage { body } disallowedSecondRootField }",
+    fires: &[Rule::SingleRootField],
+    valid: "subscription sub { newMessage { body } }",
+  },
+  // -- 5.3 fields -----------------------------------------------------------------------------
+  Fixture {
+    rule: Rule::FieldSelections,
+    schema: None,
+    invalid: "{ dog { meowVolume } }",
+    fires: &[Rule::FieldSelections],
+    valid: "{ dog { barkVolume } }",
+  },
+  Fixture {
+    rule: Rule::LeafFieldSelections,
+    schema: None,
+    invalid: "{ dog { barkVolume { sinceWhen } } }",
+    fires: &[Rule::LeafFieldSelections],
+    valid: "{ dog { barkVolume } }",
+  },
+  // -- 5.4 arguments --------------------------------------------------------------------------
+  Fixture {
+    rule: Rule::ArgumentNames,
+    schema: None,
+    invalid: "{ dog { isHouseTrained(atOtherHomes: true, unless: false) } }",
+    fires: &[Rule::ArgumentNames],
+    valid: "{ dog { isHouseTrained(atOtherHomes: true) } }",
+  },
+  Fixture {
+    rule: Rule::ArgumentUniqueness,
+    schema: None,
+    invalid: "{ dog { isHouseTrained(atOtherHomes: true, atOtherHomes: false) } }",
+    fires: &[Rule::ArgumentUniqueness],
+    valid: "{ dog { isHouseTrained(atOtherHomes: true) } }",
+  },
+  Fixture {
+    rule: Rule::RequiredArguments,
+    schema: None,
+    invalid: "{ dog { doesKnowCommand } }",
+    fires: &[Rule::RequiredArguments],
+    valid: "{ dog { doesKnowCommand(dogCommand: SIT) } }",
+  },
+  // -- 5.5 fragments --------------------------------------------------------------------------
+  Fixture {
+    rule: Rule::FragmentNameUniqueness,
+    schema: None,
+    invalid: "{ dog { ...part } } fragment part on Dog { name } fragment part on Dog { nickname }",
+    fires: &[Rule::FragmentNameUniqueness],
+    valid: "{ dog { ...part ...other } } fragment part on Dog { name } \
+            fragment other on Dog { nickname }",
+  },
+  Fixture {
+    rule: Rule::FragmentSpreadTypeExistence,
+    schema: None,
+    invalid: "{ dog { ...part } } fragment part on NotInSchema { name }",
+    fires: &[Rule::FragmentSpreadTypeExistence],
+    valid: "{ dog { ...part } } fragment part on Dog { name }",
+  },
+  Fixture {
+    rule: Rule::FragmentsOnCompositeTypes,
+    schema: None,
+    invalid: "{ dog { ...part } } fragment part on Int { something }",
+    fires: &[Rule::FragmentsOnCompositeTypes],
+    valid: "{ dog { ...part } } fragment part on Dog { name }",
+  },
+  Fixture {
+    rule: Rule::FragmentsMustBeUsed,
+    schema: None,
+    invalid: "{ dog { name } } fragment nameFragment on Dog { name }",
+    fires: &[Rule::FragmentsMustBeUsed],
+    valid: "{ dog { ...nameFragment } } fragment nameFragment on Dog { name }",
+  },
+  Fixture {
+    rule: Rule::FragmentSpreadTargetDefined,
+    schema: None,
+    invalid: "{ dog { ...undefinedFragment } }",
+    fires: &[Rule::FragmentSpreadTargetDefined],
+    valid: "{ dog { ...definedFragment } } fragment definedFragment on Dog { name }",
+  },
+  Fixture {
+    rule: Rule::FragmentSpreadsMustNotFormCycles,
+    schema: None,
+    invalid: "{ dog { ...nameFragment } } fragment nameFragment on Dog { name ...barkFragment } \
+              fragment barkFragment on Dog { barkVolume ...nameFragment }",
+    fires: &[Rule::FragmentSpreadsMustNotFormCycles],
+    valid: "{ dog { ...nameFragment } } fragment nameFragment on Dog { name ...barkFragment } \
+            fragment barkFragment on Dog { barkVolume }",
+  },
+  Fixture {
+    rule: Rule::FragmentSpreadIsPossible,
+    schema: None,
+    invalid: "{ catOrDog { ... on Cat { ...dogFragment } } } \
+              fragment dogFragment on Dog { barkVolume }",
+    fires: &[Rule::FragmentSpreadIsPossible],
+    valid: "{ catOrDog { ... on Dog { ...dogFragment } } } \
+            fragment dogFragment on Dog { barkVolume }",
+  },
+  // -- 5.6 values -----------------------------------------------------------------------------
+  Fixture {
+    rule: Rule::ValuesOfCorrectType,
+    schema: None,
+    invalid: r#"{ arguments { intArgField(intArg: "123") } }"#,
+    fires: &[Rule::ValuesOfCorrectType],
+    valid: "{ arguments { intArgField(intArg: 123) } }",
+  },
+  Fixture {
+    rule: Rule::InputObjectFieldNames,
+    schema: None,
+    invalid: r#"{ findDog(searchBy: { favoriteCookieFlavor: "Bacon" }) { name } }"#,
+    fires: &[Rule::InputObjectFieldNames],
+    valid: r#"{ findDog(searchBy: { name: "Fido" }) { name } }"#,
+  },
+  Fixture {
+    rule: Rule::InputObjectFieldUniqueness,
+    schema: None,
+    invalid: r#"{ findDog(searchBy: { name: "Fido", name: "Milou" }) { name } }"#,
+    fires: &[Rule::InputObjectFieldUniqueness],
+    valid: r#"{ findDog(searchBy: { name: "Fido" }) { name } }"#,
+  },
+  Fixture {
+    rule: Rule::InputObjectRequiredFields,
+    schema: None,
+    invalid: "{ requiredInput(input: { opt: 1 }) }",
+    fires: &[Rule::InputObjectRequiredFields],
+    valid: "{ requiredInput(input: { req: 1 }) }",
+  },
+  // -- 5.7 directives -------------------------------------------------------------------------
+  Fixture {
+    rule: Rule::DirectivesAreDefined,
+    schema: None,
+    invalid: "{ dog { name @undefinedDirective } }",
+    fires: &[Rule::DirectivesAreDefined],
+    valid: "{ dog { name @skip(if: true) } }",
+  },
+  Fixture {
+    rule: Rule::DirectivesAreInValidLocations,
+    schema: None,
+    invalid: "query getName @skip(if: true) { dog { name } }",
+    fires: &[Rule::DirectivesAreInValidLocations],
+    valid: "query getName @onQuery { dog { name } }",
+  },
+  Fixture {
+    rule: Rule::DirectivesAreUniquePerLocation,
+    schema: None,
+    invalid: "{ dog { name @skip(if: true) @skip(if: false) } }",
+    fires: &[Rule::DirectivesAreUniquePerLocation],
+    valid: "{ dog { name @repeatableField @repeatableField } }",
+  },
+  // -- 5.8 variables --------------------------------------------------------------------------
+  Fixture {
+    rule: Rule::VariableUniqueness,
+    schema: None,
+    invalid: "query houseTrained($atOtherHomes: Boolean, $atOtherHomes: Boolean) \
+              { dog { isHouseTrained(atOtherHomes: $atOtherHomes) } }",
+    fires: &[Rule::VariableUniqueness],
+    valid: "query houseTrained($atOtherHomes: Boolean) \
+            { dog { isHouseTrained(atOtherHomes: $atOtherHomes) } }",
+  },
+  Fixture {
+    rule: Rule::VariablesAreInputTypes,
+    schema: None,
+    // The variable is also unused, and cannot be otherwise: no argument anywhere can have an
+    // object type, so there is no position a `Cat` variable could legally be used in.
+    invalid: "query takesCat($cat: Cat) { dog { name } }",
+    fires: &[Rule::VariablesAreInputTypes, Rule::AllVariablesUsed],
+    valid: "query takesBoolean($atOtherHomes: Boolean) \
+            { dog { isHouseTrained(atOtherHomes: $atOtherHomes) } }",
+  },
+  Fixture {
+    rule: Rule::AllVariableUsesDefined,
+    schema: None,
+    invalid: "query variableIsNotDefined { dog { isHouseTrained(atOtherHomes: $atOtherHomes) } }",
+    fires: &[Rule::AllVariableUsesDefined],
+    valid: "query variableIsDefined($atOtherHomes: Boolean) \
+            { dog { isHouseTrained(atOtherHomes: $atOtherHomes) } }",
+  },
+  Fixture {
+    rule: Rule::AllVariablesUsed,
+    schema: None,
+    invalid: "query variableUnused($atOtherHomes: Boolean) { dog { name } }",
+    fires: &[Rule::AllVariablesUsed],
+    valid: "query variableUsed($atOtherHomes: Boolean) \
+            { dog { isHouseTrained(atOtherHomes: $atOtherHomes) } }",
+  },
+  Fixture {
+    rule: Rule::AllVariableUsagesAreAllowed,
+    schema: None,
+    invalid: "query intCannotGoIntoBoolean($intArg: Int) \
+              { arguments { booleanArgField(booleanArg: $intArg) } }",
+    fires: &[Rule::AllVariableUsagesAreAllowed],
+    valid: "query booleanIntoBoolean($booleanArg: Boolean) \
+            { arguments { booleanArgField(booleanArg: $booleanArg) } }",
+  },
+];
+
+// ---------------------------------------------------------------------------------------------
+// the floor
+// ---------------------------------------------------------------------------------------------
+
+/// Rules with no fixture, each excused in writing.
+///
+/// The list is empty and is expected to stay that way. It exists so that an excuse has to be
+/// written down rather than implied by a rule quietly missing from the table.
+const UNFIREABLE: &[(Rule, &str)] = &[];
+
+#[test]
+fn liveness_floor() {
+  let schema = build(SCHEMA);
+
+  let mut missing = Vec::new();
+  for rule in Rule::ALL {
+    let excused = UNFIREABLE.iter().any(|(excused, _)| excused == rule);
+    let fixtured = FIXTURES.iter().any(|fixture| fixture.rule == *rule);
+    if !fixtured && !excused {
+      missing.push(rule);
+    }
+    assert!(
+      !(fixtured && excused),
+      "{rule:?} is both excused and fixtured; delete the excuse"
+    );
+  }
+  assert!(
+    missing.is_empty(),
+    "these rules have no document that makes them fire: {missing:?} — add one to FIXTURES, or \
+     record a written reason in UNFIREABLE"
+  );
+
+  // The census must not pass vacuously.
+  assert!(
+    Rule::ALL.len() >= 28,
+    "read only {} rules; the enumeration is wrong, not the fixtures",
+    Rule::ALL.len()
+  );
+
+  for fixture in FIXTURES {
+    let schema = match fixture.schema {
+      Some(sdl) => build(sdl),
+      None => build(SCHEMA),
+    };
+    let _ = &schema;
+
+    let actual = fired(&schema, fixture.invalid);
+    assert_eq!(
+      actual,
+      sorted(fixture.fires),
+      "the fixture for {:?} fired {actual:?}\n---\n{}",
+      fixture.rule,
+      fixture.invalid
+    );
+    assert!(
+      actual.contains(&fixture.rule),
+      "the fixture for {:?} did not fire it\n---\n{}",
+      fixture.rule,
+      fixture.invalid
+    );
+
+    let twin = fired(&schema, fixture.valid);
+    assert!(
+      twin.is_empty(),
+      "the valid twin for {:?} fired {twin:?}\n---\n{}",
+      fixture.rule,
+      fixture.valid
+    );
+  }
+  let _ = schema;
+}
+
+/// Every rule can be selected on its own, and firing it needs no other rule to have run.
+///
+/// This is the property that makes `RuleSet` a real door rather than a filter: a consumer that
+/// asks for one rule gets exactly that rule's diagnostics, from a document that also violates
+/// others.
+#[test]
+fn every_rule_is_independently_addressable() {
+  for fixture in FIXTURES {
+    let schema = match fixture.schema {
+      Some(sdl) => build(sdl),
+      None => build(SCHEMA),
+    };
+    let alone = RuleSet::only(fixture.rule);
+    let diagnostics = diagnose_with(&schema, fixture.invalid, alone);
+    assert!(
+      !diagnostics.is_empty(),
+      "{:?} fired nothing when selected alone\n---\n{}",
+      fixture.rule,
+      fixture.invalid
+    );
+    for diagnostic in &diagnostics {
+      assert_eq!(
+        diagnostic.rule(),
+        fixture.rule,
+        "selecting {:?} alone produced {:?}",
+        fixture.rule,
+        diagnostic.rule()
+      );
+    }
+
+    // And the complement: with the rule switched off, the document never reports it.
+    let without = RuleSet::ALL.without(fixture.rule);
+    for diagnostic in diagnose_with(&schema, fixture.invalid, without) {
+      assert_ne!(
+        diagnostic.rule(),
+        fixture.rule,
+        "{:?} fired although it was excluded",
+        fixture.rule
+      );
+    }
+  }
+}
+
+/// The empty rule set validates nothing, so every fixture passes.
+///
+/// The complement of the floor: it shows the gate above measures rule *evaluation* and not merely
+/// diagnostic filtering, because an empty set makes even the worst document valid.
+#[test]
+fn the_empty_rule_set_accepts_everything() {
+  let schema = build(SCHEMA);
+  for fixture in FIXTURES.iter().filter(|fixture| fixture.schema.is_none()) {
+    let diagnostics = diagnose_with(&schema, fixture.invalid, RuleSet::EMPTY);
+    assert!(
+      diagnostics.is_empty(),
+      "the empty rule set reported {:?}",
+      diagnostics.first().map(Diagnostic::rule)
+    );
+  }
+}
+
+/// Every valid twin is valid under every rule, over every sink.
+#[test]
+fn every_valid_twin_is_valid_under_every_rule() {
+  for fixture in FIXTURES {
+    let schema = match fixture.schema {
+      Some(sdl) => build(sdl),
+      None => build(SCHEMA),
+    };
+    let document = parse(fixture.valid);
+    let mut scratch = Scratch::new();
+
+    let mut first = First::new();
+    assert!(
+      validate_executable(
+        &schema,
+        &document,
+        &mut scratch,
+        &Budget::default(),
+        &mut first
+      )
+      .is_ok(),
+      "the twin for {:?} is invalid: {:?}",
+      fixture.rule,
+      first.get().map(|d| d.rule())
+    );
+
+    let mut count = Count::new();
+    assert!(
+      validate_executable(
+        &schema,
+        &document,
+        &mut scratch,
+        &Budget::default(),
+        &mut count
+      )
+      .is_ok()
+    );
+    assert_eq!(count.get(), 0);
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// the sinks
+// ---------------------------------------------------------------------------------------------
+
+/// `First` keeps one diagnostic and stops; the others see the whole document.
+#[test]
+fn sinks_mirror_their_tokora_counterparts() {
+  let schema = build(SCHEMA);
+  // Three independent mistakes, so "stopped early" is observable rather than inferred.
+  let source = "{ dog { meowVolume purrVolume } cat }";
+  let document = parse(source);
+  let mut scratch = Scratch::new();
+  let budget = Budget::default();
+
+  let mut first = First::new();
+  let invalid = validate_executable(&schema, &document, &mut scratch, &budget, &mut first)
+    .expect_err("the document is invalid");
+  assert_eq!(invalid.emitted(), 1, "First must stop at the first");
+  assert!(invalid.stopped());
+  assert_eq!(
+    first.get().expect("a diagnostic").rule(),
+    Rule::FieldSelections
+  );
+
+  let mut collected = Vec::new();
+  let mut collect = Collect::new(&mut collected);
+  let invalid = validate_executable(&schema, &document, &mut scratch, &budget, &mut collect)
+    .expect_err("the document is invalid");
+  assert!(!invalid.stopped());
+  assert_eq!(invalid.emitted() as usize, collected.len());
+  assert_eq!(collected.len(), 3, "{collected:#?}");
+
+  let mut count = Count::new();
+  let invalid = validate_executable(&schema, &document, &mut scratch, &budget, &mut count)
+    .expect_err("the document is invalid");
+  assert_eq!(count.get(), 3);
+  assert_eq!(invalid.emitted(), 3);
+
+  // `Ignore` keeps nothing and the verdict still stands: the count is the validator's, not the
+  // sink's.
+  let invalid = validate_executable(&schema, &document, &mut scratch, &budget, &mut Ignore)
+    .expect_err("the document is invalid");
+  assert_eq!(invalid.emitted(), 3);
+  assert!(!invalid.stopped());
+}
+
+/// A sink handed by mutable reference is a sink, so a caller can keep theirs.
+#[test]
+fn a_borrowed_sink_is_a_sink() {
+  let schema = build(SCHEMA);
+  let document = parse("{ dog { meowVolume } }");
+  let mut scratch = Scratch::new();
+  let mut sink = Count::new();
+  let mut borrowed = &mut sink;
+  assert!(
+    validate_executable(
+      &schema,
+      &document,
+      &mut scratch,
+      &Budget::default(),
+      &mut borrowed
+    )
+    .is_err()
+  );
+  assert_eq!(sink.get(), 1);
+}
+
+// ---------------------------------------------------------------------------------------------
+// diagnostics
+// ---------------------------------------------------------------------------------------------
+
+/// A diagnostic is a value: it names its rule, points at the source, and renders only on demand.
+#[test]
+fn a_diagnostic_points_at_what_it_refused() {
+  let schema = build(SCHEMA);
+  let source = "{ dog { meowVolume } }";
+  let diagnostics = diagnose(&schema, source);
+  let diagnostic = &diagnostics[0];
+
+  assert_eq!(diagnostic.rule(), Rule::FieldSelections);
+  assert_eq!(diagnostic.subject_source(), Some(&"meowVolume"));
+  let span = diagnostic.span();
+  assert_eq!(&source[span.start()..span.end()], "meowVolume");
+  assert!(matches!(diagnostic.context_of(), Context::Type(_)));
+  assert_eq!(
+    diagnostic.display(&schema).to_string(),
+    "5.3.1 Field Selections: `meowVolume` on type `Dog` (8..18)"
+  );
+}
+
+/// A duplicate points at both occurrences.
+#[test]
+fn a_duplicate_points_back_at_the_first() {
+  let schema = build(SCHEMA);
+  let source = "query a { dog { name } } query a { dog { nickname } }";
+  let diagnostics = diagnose(&schema, source);
+  assert_eq!(diagnostics.len(), 1);
+  let related = diagnostics[0].related_span().expect("a related span");
+  assert!(related.start() < diagnostics[0].span().start());
+  assert_eq!(&source[related.start()..related.end()], "a");
+}
+
+/// Every diagnostic every fixture produces renders, and names something.
+#[test]
+fn every_diagnostic_renders() {
+  for fixture in FIXTURES {
+    let schema = match fixture.schema {
+      Some(sdl) => build(sdl),
+      None => build(SCHEMA),
+    };
+    for diagnostic in diagnose(&schema, fixture.invalid) {
+      let rendered = diagnostic.display(&schema).to_string();
+      assert!(
+        rendered.starts_with(diagnostic.rule().section()),
+        "{rendered} does not open with its section"
+      );
+      assert!(
+        rendered.len() > diagnostic.rule().section().len() + diagnostic.rule().title().len(),
+        "{rendered} says nothing beyond the rule's name"
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// acceptance: the shapes the rules must NOT refuse
+// ---------------------------------------------------------------------------------------------
+
+/// The specification's own valid examples, and the shapes that look wrong and are not.
+#[test]
+fn valid_documents_stay_valid() {
+  let schema = build(SCHEMA);
+  for source in [
+    // Introspection is an ordinary document against the injected meta-schema.
+    "{ __schema { types { name } } }",
+    "{ __type(name: \"Dog\") { name kind } }",
+    "{ dog { __typename name } }",
+    // `__typename` is the one field selectable directly on a union.
+    "{ catOrDog { __typename ... on Dog { barkVolume } ... on Cat { meowVolume } } }",
+    // Interface field selection is on the interface's own fields.
+    "{ pet { name } }",
+    // An Int literal coerces into a Float position; an Int and a String both into an ID.
+    "{ arguments { floatArgField(floatArg: 123) } }",
+    "{ arguments { idArgField(idArg: 123) } }",
+    "{ arguments { idArgField(idArg: \"123\") } }",
+    // A custom scalar takes whatever the service can read.
+    "{ arguments { customScalarArgField(customArg: { anything: [1, 2] }) } }",
+    // A non-list value in a list position is the one-element list containing it.
+    "{ arguments { booleanListArgField(booleanListArg: true) } }",
+    "{ arguments { booleanListArgField(booleanListArg: [true, false, null]) } }",
+    // An argument with a schema default may be omitted.
+    "{ arguments { optionalNonNullBooleanArgField } }",
+    // Order does not matter in arguments.
+    "{ arguments { multipleRequirements(y: 2, x: 1) } }",
+    "{ arguments { multipleRequirements(x: 1, y: 2) } }",
+    // A fragment may be spread by several operations, and each supplies its own variables.
+    "query one($atOtherHomes: Boolean) { dog { ...trained } } \
+     query two($atOtherHomes: Boolean) { dog { ...trained } } \
+     fragment trained on Dog { isHouseTrained(atOtherHomes: $atOtherHomes) }",
+    // A subscription may collect one root field through a fragment.
+    "subscription sub { ...newMessageFields } \
+     fragment newMessageFields on Subscription { newMessage { body sender } }",
+    // Two selections of the same response name are one entry in the subscription's map.
+    "subscription sub { newMessage { body } newMessage { sender } }",
+    // A nullable variable reaches a non-null location when either side has a default.
+    "query withLocationDefault($booleanArg: Boolean) \
+     { arguments { optionalNonNullBooleanArgField(optionalBooleanArg: $booleanArg) } }",
+    "query withVariableDefault($booleanArg: Boolean = true) \
+     { arguments { nonNullBooleanArgField(nonNullBooleanArg: $booleanArg) } }",
+    // A non-null list variable reaches a nullable list location.
+    "query nonNullListToList($list: [Boolean]!) \
+     { arguments { booleanListArgField(booleanListArg: $list) } }",
+    // OneOf: exactly one field, and a non-null variable in it.
+    "mutation addCat { addPet(pet: { cat: { name: \"Brontie\" } }) { name } }",
+    "mutation addCat($cat: CatInput!) { addPet(pet: { cat: $cat }) { name } }",
+    "mutation addCatWithDefault($cat: CatInput! = { name: \"Brontie\" }) \
+     { addPet(pet: { cat: $cat }) { name } }",
+    // Repeatable directives repeat; non-repeatable ones may appear once per location.
+    "{ dog { name @skip(if: true) } owner: dog { name @skip(if: false) } }",
+    // A variable definition may carry its own directives and a default value.
+    "query defaults($search: FindDogInput = { name: \"Fido\" }) \
+     { findDog(searchBy: $search) { name } }",
+  ] {
+    let diagnostics = diagnose(&schema, source);
+    assert!(
+      diagnostics.is_empty(),
+      "a valid document was refused: {:?}\n---\n{source}",
+      diagnostics
+        .iter()
+        .map(|d| (d.rule(), d.display(&schema).to_string()))
+        .collect::<Vec<_>>()
+    );
+  }
+}
+
+/// Draft 5.5.2.3's one adopted deviation: a spread whose condition *is* the scope is valid even
+/// where the possible-object set is empty.
+///
+/// `Empty` is an interface nothing implements, so both possible-object sets are empty and the
+/// intersection is too. graphql-js, apollo-compiler and graphql-spec#1109 all accept it.
+#[test]
+fn a_condition_that_is_the_scope_is_always_possible() {
+  let schema = build(SCHEMA);
+  assert!(
+    schema
+      .possible_objects(schema.type_by_name(b"Empty").expect("Empty is defined").0)
+      .expect("an interface carries a bitset")
+      .iter()
+      .all(|word| *word == 0),
+    "the fixture stopped being an interface with no implementors"
+  );
+  assert!(diagnose(&schema, "{ empty { ... on Empty { nothing } } }").is_empty());
+  assert!(
+    diagnose(
+      &schema,
+      "{ empty { ...emptyFragment } } fragment emptyFragment on Empty { nothing }"
+    )
+    .is_empty()
+  );
+}
+
+// ---------------------------------------------------------------------------------------------
+// the rules the ecosystem gets wrong, and the corners the table does not reach
+// ---------------------------------------------------------------------------------------------
+
+/// Draft 5.6.3, which apollo-compiler 1.32 does not implement at all, at every nesting depth.
+#[test]
+fn input_object_field_uniqueness_holds_at_depth() {
+  let schema = build(SCHEMA);
+  assert_eq!(
+    fired(
+      &schema,
+      "{ arguments { customScalarArgField(customArg: 1) } }"
+    ),
+    []
+  );
+  // Nested inside a list inside an object, which is where a scan that reused one buffer for every
+  // depth would lose the outer level's state.
+  assert_eq!(
+    fired(
+      &schema,
+      r#"{ findDog(searchBy: { name: "a", name: "b", owner: "x" }) { name } }"#
+    ),
+    [Rule::InputObjectFieldUniqueness]
+  );
+}
+
+/// Draft 5.8.5 in every position, including inside a list literal — where apollo-compiler compares
+/// only named types and accepts a nullable variable in a non-null item position.
+#[test]
+fn variable_usage_is_checked_inside_list_literals() {
+  let schema = build(SCHEMA);
+  // `booleanList(booleanListArg: [Boolean!])`: the item position is non-null.
+  assert_eq!(
+    fired(
+      &schema,
+      "query nested($v: Boolean) { booleanList(booleanListArg: [$v]) }"
+    ),
+    [Rule::AllVariableUsagesAreAllowed]
+  );
+  assert_eq!(
+    fired(
+      &schema,
+      "query nested($v: Boolean!) { booleanList(booleanListArg: [$v]) }"
+    ),
+    []
+  );
+}
+
+/// Draft 5.6.1 and 5.8.5's OneOf clauses, which apollo-compiler 1.32 does not implement at all.
+#[test]
+fn one_of_input_objects_are_checked() {
+  let schema = build(SCHEMA);
+  for (source, expected) in [
+    (
+      "mutation empty { addPet(pet: {}) { name } }",
+      &[Rule::ValuesOfCorrectType][..],
+    ),
+    (
+      "mutation two($dog: DogInput) { addPet(pet: { cat: { name: \"a\" }, dog: $dog }) { name } }",
+      &[Rule::ValuesOfCorrectType, Rule::AllVariableUsagesAreAllowed],
+    ),
+    (
+      "mutation nulled { addPet(pet: { cat: null }) { name } }",
+      &[Rule::ValuesOfCorrectType],
+    ),
+    // A nullable variable in a OneOf field position, one list level down.
+    (
+      "mutation nested($dog: DogInput) { addPets(pets: [{ dog: $dog }]) { name } }",
+      &[Rule::AllVariableUsagesAreAllowed],
+    ),
+  ] {
+    assert_eq!(fired(&schema, source), sorted(expected), "---\n{source}");
+  }
+}
+
+/// Draft 5.2.4.1 forbids `@skip` and `@include` on a subscription's root selection set, and
+/// forbids an introspection field there.
+#[test]
+fn subscription_roots_are_collected_without_runtime_values() {
+  let schema = build(SCHEMA);
+  for source in [
+    "subscription requiresRuntime($bool: Boolean!) \
+     { newMessage @include(if: $bool) { body } }",
+    "subscription introspects { __typename }",
+    "subscription throughFragment { ...two } \
+     fragment two on Subscription { newMessage { body } disallowedSecondRootField }",
+  ] {
+    let rules = fired(&schema, source);
+    assert!(
+      rules.contains(&Rule::SingleRootField),
+      "5.2.4.1 did not fire for\n---\n{source}\n--- got {rules:?}"
+    );
+  }
+}
+
+/// Draft 5.5.2.2 runs over the whole fragment graph, including fragments no operation reaches —
+/// unlike apollo-compiler, which skips unused fragments.
+///
+/// A rule that later expands fragments must never meet an unestablished graph, so the cycle is
+/// established whether or not anybody spreads it.
+#[test]
+fn cycles_are_found_in_unused_fragments_too() {
+  let schema = build(SCHEMA);
+  assert_eq!(
+    fired(
+      &schema,
+      "{ dog { name } } fragment a on Dog { ...b } fragment b on Dog { ...a }"
+    ),
+    sorted(&[
+      Rule::FragmentSpreadsMustNotFormCycles,
+      Rule::FragmentsMustBeUsed
+    ])
+  );
+  // A fragment that spreads itself is the degenerate case.
+  assert!(
+    fired(
+      &schema,
+      "{ dog { ...self } } fragment self on Dog { name ...self }"
+    )
+    .contains(&Rule::FragmentSpreadsMustNotFormCycles)
+  );
+}
+
+/// A fragment several operations share reports its own mistakes once, and its variable usages once
+/// per operation.
+///
+/// This is the split the walk is built around: definition-local rules fire on first entry, and the
+/// operation-scoped rules fire every time.
+#[test]
+fn shared_fragments_report_structure_once_and_variables_per_operation() {
+  let schema = build(SCHEMA);
+
+  let structural = diagnose(
+    &schema,
+    "query one { dog { ...bad } } query two { dog { ...bad } } fragment bad on Dog { meowVolume }",
+  );
+  assert_eq!(
+    structural.len(),
+    1,
+    "a shared fragment reported its own mistake more than once: {structural:#?}"
+  );
+  assert_eq!(structural[0].rule(), Rule::FieldSelections);
+
+  let variables = diagnose(
+    &schema,
+    "query defines($atOtherHomes: Boolean) { dog { ...trained } } \
+     query omits { dog { ...trained } } \
+     fragment trained on Dog { isHouseTrained(atOtherHomes: $atOtherHomes) }",
+  );
+  assert_eq!(variables.len(), 1, "{variables:#?}");
+  assert_eq!(variables[0].rule(), Rule::AllVariableUsesDefined);
+}
+
+/// An unreached fragment still has its structure validated, and has no variable scope to check
+/// against.
+#[test]
+fn unreached_fragments_are_still_structurally_validated() {
+  let schema = build(SCHEMA);
+  assert_eq!(
+    fired(
+      &schema,
+      "{ dog { name } } fragment orphan on Dog { meowVolume }"
+    ),
+    sorted(&[Rule::FieldSelections, Rule::FragmentsMustBeUsed])
+  );
+  // A variable usage inside one is not reported: the rule is scoped to an operation, and no
+  // operation includes this fragment.
+  assert_eq!(
+    fired(
+      &schema,
+      "{ dog { name } } fragment orphan on Dog { isHouseTrained(atOtherHomes: $nope) }"
+    ),
+    [Rule::FragmentsMustBeUsed]
+  );
+}
+
+/// Draft 5.4.3 and 5.6.4 own the explicit-`null` case, so one mistake produces one diagnostic.
+#[test]
+fn an_explicit_null_in_a_required_position_reports_once() {
+  let schema = build(SCHEMA);
+  assert_eq!(
+    fired(
+      &schema,
+      "{ arguments { nonNullBooleanArgField(nonNullBooleanArg: null) } }"
+    ),
+    [Rule::RequiredArguments]
+  );
+  assert_eq!(
+    fired(&schema, "{ requiredInput(input: { req: null }) }"),
+    [Rule::InputObjectRequiredFields]
+  );
+}
+
+/// A mistake at an unresolved position does not cascade: an unknown field's subselections are left
+/// alone, and a variable used in an unknown argument is still "used".
+#[test]
+fn unresolved_positions_do_not_cascade() {
+  let schema = build(SCHEMA);
+  assert_eq!(
+    fired(&schema, "{ dog { meowVolume { andAnother { andMore } } } }"),
+    [Rule::FieldSelections]
+  );
+  assert_eq!(
+    fired(
+      &schema,
+      "query q($v: Boolean) { dog { isHouseTrained(nope: $v) } }"
+    ),
+    [Rule::ArgumentNames]
+  );
+  assert_eq!(
+    fired(
+      &schema,
+      "query q($v: Boolean) { dog { name @nope(arg: $v) } }"
+    ),
+    [Rule::DirectivesAreDefined]
+  );
+}
+
+/// Deep nesting is walked without recursing on it, in both trees.
+///
+/// # Why the AST is assembled by hand
+///
+/// The parser is a recursive descent, and in a debug build its own recursion overflows a test
+/// thread's stack somewhere between 25 and 50 levels of selection nesting — long before anything
+/// the validator would notice. Parsing a deep document would therefore measure the parser, not
+/// this claim. Building the tree directly, which the public AST types allow, puts the validator
+/// alone under test: a thousand levels in each tree, with no parser in the picture.
+///
+/// The finished documents are deliberately leaked. `Vec`'s own `Drop` is recursive, so dropping a
+/// thousand nested selection sets would overflow the stack on the way out and the test would fail
+/// for a reason that has nothing to do with what it measures.
+#[test]
+fn deep_documents_are_walked_iteratively() {
+  const DEPTH: usize = 1_000;
+  let schema = build(SCHEMA);
+  let mut scratch = Scratch::new();
+  let budget = Budget::default();
+
+  let selections = nested_selection_document(DEPTH);
+  assert!(
+    validate_executable(&schema, &selections, &mut scratch, &budget, &mut Ignore).is_ok(),
+    "a thousand nested selection sets"
+  );
+  core::mem::forget(selections);
+
+  let values = nested_value_document(DEPTH);
+  assert!(
+    validate_executable(&schema, &values, &mut scratch, &budget, &mut Ignore).is_ok(),
+    "a thousand nested object literals"
+  );
+  core::mem::forget(values);
+
+  // And the same shapes with a mistake at the bottom, so the walk is shown to have arrived.
+  let selections = nested_selection_document_ending_in(DEPTH, "notAField");
+  assert_eq!(
+    {
+      let mut sink = First::new();
+      let _ = validate_executable(&schema, &selections, &mut scratch, &budget, &mut sink);
+      sink.get().map(Diagnostic::rule)
+    },
+    Some(Rule::FieldSelections)
+  );
+  core::mem::forget(selections);
+}
+
+fn nested_selection_document(depth: usize) -> ExecutableDocument<&'static str> {
+  nested_selection_document_ending_in(depth, "leaf")
+}
+
+fn nested_selection_document_ending_in(
+  depth: usize,
+  innermost: &'static str,
+) -> ExecutableDocument<&'static str> {
+  let span = SimpleSpan::const_new(0, 0);
+  let mut set = SelectionSet::new(
+    span,
+    vec![Selection::Field(Field::new(
+      span,
+      None,
+      Name::new(span, innermost),
+      None,
+      None,
+      None,
+    ))],
+  );
+  for _ in 0..depth {
+    set = SelectionSet::new(
+      span,
+      vec![Selection::Field(Field::new(
+        span,
+        None,
+        Name::new(span, "nest"),
+        None,
+        None,
+        Some(set),
+      ))],
+    );
+  }
+  document(SelectionSet::new(
+    span,
+    vec![Selection::Field(Field::new(
+      span,
+      None,
+      Name::new(span, "nest"),
+      None,
+      None,
+      Some(set),
+    ))],
+  ))
+}
+
+fn nested_value_document(depth: usize) -> ExecutableDocument<&'static str> {
+  let span = SimpleSpan::const_new(0, 0);
+  // `Recursive` has no required fields, so the innermost literal is the empty object.
+  let mut value = InputValue::Object(Object::new(span, vec![]));
+  for _ in 0..depth {
+    value = InputValue::Object(Object::new(
+      span,
+      vec![ObjectField::new(span, Name::new(span, "rec"), value)],
+    ));
+  }
+  document(SelectionSet::new(
+    span,
+    vec![Selection::Field(Field::new(
+      span,
+      None,
+      Name::new(span, "recursive"),
+      Some(ArgumentList::new(
+        span,
+        vec![Argument::new(span, Name::new(span, "input"), value)],
+      )),
+      None,
+      None,
+    ))],
+  ))
+}
+
+fn document(set: SelectionSet<&'static str>) -> ExecutableDocument<&'static str> {
+  let span = SimpleSpan::const_new(0, 0);
+  ExecutableDocument::new(
+    span,
+    vec![Described::new(
+      span,
+      None,
+      ExecutableDefinition::Operation(OperationDefinition::Shorthand(set)),
+    )],
+  )
+}
+
+// ---------------------------------------------------------------------------------------------
+// the scratch
+// ---------------------------------------------------------------------------------------------
+
+/// One `Scratch` serves an unbounded number of validations, and stops growing.
+#[test]
+fn the_scratch_is_reused_not_regrown() {
+  let schema = build(SCHEMA);
+  let source = "query one($atOtherHomes: Boolean) { dog { ...trained ...named } } \
+                fragment trained on Dog { isHouseTrained(atOtherHomes: $atOtherHomes) } \
+                fragment named on Dog { name owner { name pets { name } } }";
+  let document = parse(source);
+  let mut scratch = Scratch::new();
+  let budget = Budget::default();
+
+  for _ in 0..3 {
+    assert!(
+      validate_executable(&schema, &document, &mut scratch, &budget, &mut Ignore).is_ok(),
+      "{source}"
+    );
+  }
+  let settled = scratch.capacity();
+  for _ in 0..20 {
+    assert!(validate_executable(&schema, &document, &mut scratch, &budget, &mut Ignore).is_ok());
+  }
+  assert_eq!(
+    scratch.capacity(),
+    settled,
+    "the working set kept growing after it had seen the document"
+  );
+
+  // And a reset leaves it usable, with its capacity intact.
+  scratch.reset();
+  assert_eq!(scratch.capacity(), settled);
+  assert!(validate_executable(&schema, &document, &mut scratch, &budget, &mut Ignore).is_ok());
+}
+
+/// A `Scratch` left over from an invalid document does not poison the next one.
+#[test]
+fn a_scratch_does_not_carry_state_between_documents() {
+  let schema = build(SCHEMA);
+  let mut scratch = Scratch::new();
+  let budget = Budget::default();
+
+  let bad = parse("{ dog { meowVolume } } fragment unused on Dog { name }");
+  let mut first = First::new();
+  assert!(validate_executable(&schema, &bad, &mut scratch, &budget, &mut first).is_err());
+
+  let good = parse("{ dog { ...used } } fragment used on Dog { name }");
+  let mut sink = Count::new();
+  assert!(
+    validate_executable(&schema, &good, &mut scratch, &budget, &mut sink).is_ok(),
+    "the second document saw the first one's leftovers"
+  );
+  assert_eq!(sink.get(), 0);
+}


### PR DESCRIPTION
## The rules

Twenty-eight, each a variant of `Rule` carrying its draft section, each independently selectable through `RuleSet`.

| § | rule | notes |
|---|---|---|
| 5.2.1.1 | Operation Type Existence | new in the draft; absent from the Oct 2021 text |
| 5.2.2.1 | Operation Name Uniqueness | sorted index scan, no map |
| 5.2.3.1 | Lone Anonymous Operation | |
| 5.2.4.1 | Single Root Field | full `CollectSubscriptionFields`, including the `@skip`/`@include` prohibition and the introspection-root clause |
| 5.3.1 | Field Selections | union's `__typename` falls out of the schema's field group, no rule of its own |
| **5.3.2** | *Field Selection Merging* | **deferred to phase 3** |
| 5.3.3 | Leaf Field Selections | both directions |
| 5.4.1 | Argument Names | fields and directives |
| 5.4.2 | Argument Uniqueness | |
| 5.4.3 | Required Arguments | draft renumbering; owns the explicit-`null` case |
| 5.5.1.1 | Fragment Name Uniqueness | on the index build |
| 5.5.1.2 | Fragment Spread Type Existence | named and inline |
| 5.5.1.3 | Fragments on Composite Types | |
| 5.5.1.4 | Fragments Must Be Used | reachability from the operations, over the same graph |
| 5.5.2.1 | Fragment Spread Target Defined | on the edge collection |
| 5.5.2.2 | Fragment Spreads Must Not Form Cycles | iterative DFS over integers |
| 5.5.2.3 | Fragment Spread Is Possible | all four subsections, one bitset intersection |
| 5.6.1 | Values of Correct Type | including Int/Float literal range from the retained spelling, custom-scalar permissiveness, singleton-to-list coercion and the OneOf literal rules |
| 5.6.2 | Input Object Field Names | |
| 5.6.3 | Input Object Field Uniqueness | apollo-compiler 1.32 does not implement this at all |
| 5.6.4 | Input Object Required Fields | owns the explicit-`null` case |
| 5.7.1 | Directives Are Defined | |
| 5.7.2 | Directives Are in Valid Locations | one `AND` against the precomputed mask |
| 5.7.3 | Directives Are Unique per Location | non-repeatable only |
| 5.8.1 | Variable Uniqueness | |
| 5.8.2 | Variables Are Input Types | |
| 5.8.3 | All Variable Uses Defined | through fragment spreads, transitively |
| 5.8.4 | All Variables Used | same walk, reverse direction |
| 5.8.5 | All Variable Usages Are Allowed | full `IsVariableUsageAllowed` **in every position**, including inside list and object literals, and the OneOf `IsNonNullPosition` branch |
