### PR TITLE
ci: a syn-based census that fails when a public entry narrows the source type to `&str`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,51 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: bash ci/check_workflow_triggers.sh
 
+  # Check that no public entry has narrowed the source type to a concrete one
+  #
+  # The crate ships `bstr`, `bytes`, `hipstr`, `smallvec` and `smol-bytes` integrations so that a
+  # consumer picks its own source representation, and §3, syntactic §5 and §6/§7 all honour that
+  # with `S: AsRef<[u8]>`. Nothing failed when three public entries did not: they compile, they
+  # pass every test, they read naturally, and the narrowing is discovered by a consumer at a call
+  # site. That is #122, and the timing is the point — the §6/§7 line has seven phases still to
+  # come and every one of them adds public entries, so a gate that exists BEFORE them turns each
+  # future narrowing into an error at the moment it is written rather than into an audit later.
+  #
+  # TWO STEPS, BOTH NAMED, AND THE SELFTEST FIRST. `ci/miri_scope.py` is the local model: it runs
+  # its own selftest before the expensive work, because a guard that cannot fail is the defect the
+  # guard exists to catch. The census's selftest runs its verdict against synthetic crates and
+  # requires every branch to fire; if it cannot, this job is red before it has read `smear` at all.
+  #
+  # `-p source-census` NAMES THE PACKAGE. A cargo target *filter* that matches nothing warns and
+  # exits 0, which is exactly how a gate here becomes vacuous — measured on 1.97.1, `-p` on a
+  # package that does not exist is `error: package ID specification did not match any packages`,
+  # exit 101. The census additionally refuses to pass on a run that read zero public entries, and
+  # its exemption table fails on any entry that matches nothing, so a reader that stops finding
+  # the crate's surface reddens rather than reporting a clean one.
+  #
+  # In no `needs:` chain, and about twenty seconds once `syn` is cached, so it blocks nothing.
+  source-genericity:
+    name: source-genericity
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - name: Cache cargo build and registry
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-source-census-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-source-census-
+    - name: source-census --selftest
+      run: cargo run -p source-census -- --selftest
+    - name: source-census
+      run: cargo run -p source-census -- --verbose
+
   # Check formatting
   rustfmt:
     name: rustfmt
@@ -278,12 +323,13 @@ jobs:
   # Fifteen targets, one question: does the crate a consumer installs build for them. That is
   # `smear` and only `smear` — it is the sole publishable member, which is a property of the
   # manifests rather than an opinion, and the step below re-reads it out of `cargo metadata` so
-  # the list cannot go stale in silence. The other four are `publish = false`: two criterion
-  # harnesses — one of which also carries the `apollo-compiler` differential oracle — and two
-  # tripwires, none of which any target here will ever run.
+  # the list cannot go stale in silence. The other five are `publish = false`: two criterion
+  # harnesses — one of which also carries the `apollo-compiler` differential oracle — two
+  # tripwires, and the `source-genericity` gate's `syn` reader, none of which any target here
+  # will ever run.
   #
   # This job said `cargo build --target ...` with no package selection until it was fixed, so it
-  # built all five, and one of them cannot be built for a 32-bit target at all:
+  # built every member, and one of them cannot be built for a 32-bit target at all:
   # `smear-apollo-bench` pins `apollo-compiler =1.32.0`, whose lib carries
   # `assert!(size_of::<Name>() == 24)`. At 32 bits that is false, it is a const assertion so it
   # fires during compilation, and `cross (i686-linux-android)` failed on `main` with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,32 @@
 [workspace]
 members = [
   "benchmarks",
+  "ci/source_census",
   "smear",
   "smear-benches",
   "smear-noatomic",
   "smear-smoke",
 ]
 
-# ── THREE OF THE FIVE MEMBERS PULL `smear` PAST ITS DEFAULT FEATURE SET ──────────────────────
+# ── THREE OF THE SIX MEMBERS PULL `smear` PAST ITS DEFAULT FEATURE SET ───────────────────────
 #
 # `benchmarks` and `smear-smoke` both enable `smear/rowan`; `smear-smoke` also enables
 # `lossless-coverage` and `test-support`. Cargo unifies features across the SELECTED packages,
 # so a bare workspace-wide command resolves `smear` with every feature it declares turned on.
 #
-# `smear-noatomic` is the one member this arithmetic does not reach, and deliberately so: its
-# `[dependencies]` table is empty and CI asserts that out of `cargo metadata`, so it has no edge
-# to `smear` to unify a feature through. It reaches the representation by `#[path]`-including
-# those source files, which is what lets it build for a core with no compare-and-swap while
-# `smear` itself cannot.
+# TWO members this arithmetic does not reach, both deliberately and for different reasons.
+#
+# `smear-noatomic`'s `[dependencies]` table is empty and CI asserts that out of `cargo metadata`,
+# so it has no edge to `smear` to unify a feature through. It reaches the representation by
+# `#[path]`-including those source files, which is what lets it build for a core with no
+# compare-and-swap while `smear` itself cannot.
+#
+# `ci/source_census` depends on `syn` and on nothing in this workspace. It READS `smear`'s source
+# as text — it is the #122 gate against a public entry narrowing its source type to `&str` — so
+# it has no reason to link the crate, and an edge would put it in the resolve for no benefit. It
+# is a member so that `cargo fmt --all`, `cargo clippy --workspace` and `cargo test --workspace`
+# reach the gate itself; a gate that this repository's own gates do not check is a gate that
+# rots.
 #
 # That arithmetic is how the entire lossless CST tower entered the Miri selection without anyone
 # choosing it. #70 added `benchmarks`, #84 added `smear-smoke`, and each time the Miri scripts —
@@ -27,7 +36,7 @@ members = [
 #
 # There is deliberately NO `default-members` narrowing that away. It would pin the Miri
 # selection at the price of silently narrowing every OTHER bare command in the repository:
-# `cargo test --all-features` in `.github/workflows/ci.yml` is meant to cover all five members
+# `cargo test --all-features` in `.github/workflows/ci.yml` is meant to cover every member
 # and would quietly have stopped, with no exit code saying so — the same defect class, one turn
 # later. The selection is pinned where it is READ instead: `ci/miri_sb.sh` and `ci/miri_tb.sh`
 # pass `-p smear`, and `ci/miri_scope.py` fails the run if what got interpreted is not what

--- a/ci/source_census/Cargo.toml
+++ b/ci/source_census/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "source-census"
+version = "0.0.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+# A workspace member with NO edge to `smear`, which is the property that keeps the arithmetic in
+# the root manifest's header unchanged: it adds no feature to the resolve, so nothing about which
+# `smear` features a workspace-wide command turns on moves because this crate exists. It is a
+# member so that `cargo fmt --all`, `cargo clippy --workspace` and `cargo test --workspace` reach
+# it — a gate that its own repository's gates do not check is a gate that rots.
+
+[dependencies]
+# `span-locations` is what turns a `syn` span into a file/line, and the census reports one per
+# finding: a narrowing named without a line is a narrowing someone has to grep for. Feature
+# resolver 3 keeps normal-dependency features apart from proc-macro ones, so enabling it here
+# does not reach the `proc-macro2` that `thiserror` and `derive_more` build against.
+proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = "1"
+syn = { version = "2", features = ["full", "parsing", "printing", "clone-impls", "extra-traits"] }
+
+[lints]
+workspace = true

--- a/ci/source_census/src/census.rs
+++ b/ci/source_census/src/census.rs
@@ -1,0 +1,476 @@
+//! Runs the rule over the surface and renders the verdict.
+
+use std::collections::{BTreeSet, HashSet};
+
+use syn::{ImplItem, Item, Signature, TraitItem, Type, Visibility};
+
+use crate::{
+  exempt::{self, EXEMPTIONS, Exemption},
+  rule::{
+    self, Cost, Scope, SourcePositions, TextHit, bound_type_list, family_at_concrete_text,
+    harvest_source_positions, holds_source_generically, render, signature_types,
+  },
+  surface::{self, MacroTemplate, Surface, is_doc_hidden},
+};
+
+/// One public function or inherent method the census read.
+pub struct Entry {
+  pub module: String,
+  pub name: String,
+  pub file: String,
+  pub line: usize,
+  pub sig: Signature,
+  pub self_ty: Option<Type>,
+  pub scope: Scope,
+}
+
+impl Entry {
+  pub fn location(&self) -> String {
+    format!("{}:{}", self.file, self.line)
+  }
+}
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum Verdict {
+  /// A byte view: `S: AsRef<[u8]>` already produces one, so nothing is imposed on the caller.
+  Neutral,
+  /// Concrete text, but not the document: a name, a key, a message, an output buffer, a constant.
+  Datum,
+  /// Concrete text standing where the crate elsewhere puts a source type parameter.
+  Narrowed,
+}
+
+pub struct Observation {
+  pub module: String,
+  pub entry: String,
+  pub location: String,
+  pub param: String,
+  pub ty: String,
+  /// The concrete text type inside `ty` that the verdict is about, when the parameter's type is
+  /// larger than it — `Cow<'static, str>` inside `impl Into<Cow<'static, str>>`.
+  pub text: String,
+  pub cost: Cost,
+  pub verdict: Verdict,
+  /// Which test decided it, in the rule's own numbering.
+  pub why: String,
+}
+
+pub struct Report {
+  pub entries_read: usize,
+  pub params_read: usize,
+  pub observations: Vec<Observation>,
+  pub source_positions: SourcePositions,
+  pub files_read: usize,
+  pub macro_invocations: usize,
+  /// `macro_rules!` bodies that template a `pub fn` taking concrete text.
+  pub macro_templates: Vec<MacroTemplate>,
+  pub public_modules: Vec<String>,
+  /// Narrowings with no exemption. Every one is a failure.
+  pub unexplained: Vec<usize>,
+  /// Narrowings matched to an exemption, paired with it.
+  pub recorded: Vec<(usize, &'static Exemption)>,
+  /// Exemptions that matched nothing — a table that has gone stale.
+  pub stale: Vec<&'static Exemption>,
+  /// Problems with the table itself.
+  pub table_problems: Vec<String>,
+}
+
+/// Reads the crate at `lib_rs` and classifies every concrete text parameter on its public surface.
+///
+/// Detection only: the exemption table is applied by [`reconcile`], so that the selftest can
+/// exercise the rule against synthetic crates the table knows nothing about.
+pub fn detect(lib_rs: &std::path::Path, crate_name: &str) -> Result<Report, String> {
+  let surface = surface::load(lib_rs, crate_name)?;
+  let crate_types = declared_types(&surface);
+  let source_positions = derive_source_positions(&surface, &crate_types);
+  let entries = collect_entries(&surface);
+
+  let mut observations = Vec::new();
+  let mut params_read = 0usize;
+
+  for entry in &entries {
+    let all_types = signature_types(&entry.sig, entry.self_ty.as_ref());
+    let entry_has_family_at_text = all_types
+      .iter()
+      .find_map(|ty| family_at_concrete_text(ty, &source_positions));
+
+    for arg in &entry.sig.inputs {
+      let syn::FnArg::Typed(typed) = arg else {
+        continue;
+      };
+      params_read += 1;
+      let param = pattern_name(&typed.pat);
+      let hits = rule::text_hits(&typed.ty);
+      let Some(hit) = worst(&hits) else { continue };
+
+      let this_ty = render(&typed.ty);
+      let others: Vec<Type> = all_types
+        .iter()
+        .filter(|ty| render(ty) != this_ty)
+        .cloned()
+        .collect();
+      let (verdict, why) = classify(
+        entry,
+        &param,
+        hit,
+        &others,
+        entry_has_family_at_text.as_ref(),
+        &source_positions,
+      );
+
+      observations.push(Observation {
+        module: entry.module.clone(),
+        entry: entry.name.clone(),
+        location: entry.location(),
+        param,
+        ty: render(&typed.ty),
+        text: hit.rendered.clone(),
+        cost: hit.cost,
+        verdict,
+        why,
+      });
+    }
+  }
+
+  observations.sort_by(|a, b| {
+    (a.module.as_str(), a.entry.as_str(), a.param.as_str()).cmp(&(
+      b.module.as_str(),
+      b.entry.as_str(),
+      b.param.as_str(),
+    ))
+  });
+
+  let macro_templates = surface::macro_templates(&surface);
+  let public_modules = surface
+    .modules
+    .iter()
+    .filter(|m| m.named_by_path && m.path.len() > 1)
+    .map(|m| m.display_path())
+    .collect();
+
+  Ok(Report {
+    entries_read: entries.len(),
+    params_read,
+    observations,
+    source_positions,
+    files_read: surface.files_read,
+    macro_invocations: surface.macro_invocations,
+    macro_templates,
+    public_modules,
+    unexplained: Vec::new(),
+    recorded: Vec::new(),
+    stale: Vec::new(),
+    table_problems: Vec::new(),
+  })
+}
+
+/// Matches every narrowing against the exemption table, and the table against the crate.
+pub fn reconcile(report: &mut Report) {
+  let mut used: HashSet<usize> = HashSet::new();
+  for (index, observation) in report.observations.iter().enumerate() {
+    if observation.verdict != Verdict::Narrowed {
+      continue;
+    }
+    let found = EXEMPTIONS.iter().enumerate().find(|(_, exemption)| {
+      exemption.matches(&observation.module, &observation.entry, &observation.param)
+    });
+    match found {
+      Some((slot, exemption)) => {
+        used.insert(slot);
+        report.recorded.push((index, exemption));
+      }
+      None => report.unexplained.push(index),
+    }
+  }
+  report.stale = EXEMPTIONS
+    .iter()
+    .enumerate()
+    .filter(|(slot, _)| !used.contains(slot))
+    .map(|(_, exemption)| exemption)
+    .collect();
+  report.table_problems = exempt::validate();
+}
+
+/// The four tests of `rule`'s header, in order.
+fn classify(
+  entry: &Entry,
+  param: &str,
+  hit: &TextHit,
+  other_types: &[Type],
+  family_hit: Option<&(String, String)>,
+  positions: &SourcePositions,
+) -> (Verdict, String) {
+  if hit.cost == Cost::None {
+    return (
+      Verdict::Neutral,
+      "a byte view — `S: AsRef<[u8]>` produces one, so no representation is imposed".to_string(),
+    );
+  }
+  if hit.out_param {
+    return (
+      Verdict::Datum,
+      "behind `&mut`: an output buffer, not input".to_string(),
+    );
+  }
+  if hit.konstant {
+    return (
+      Verdict::Datum,
+      "explicitly `'static`: a compile-time constant, not a slice of a caller's document"
+        .to_string(),
+    );
+  }
+  if let Some((family, argument)) = family_hit {
+    return (
+      Verdict::Narrowed,
+      format!(
+        "test 1 — `{family}` carries a source position and this entry applies it to `{argument}`"
+      ),
+    );
+  }
+  if rule::SOURCE_LEXICON.contains(&param) {
+    return (
+      Verdict::Narrowed,
+      format!("test 2 — the parameter is named `{param}`, which the crate uses for a document"),
+    );
+  }
+  let holder = other_types
+    .iter()
+    .find(|ty| holds_source_generically(ty, &entry.scope, positions));
+  if let Some(holder) = holder {
+    return (
+      Verdict::Datum,
+      format!(
+        "test 3 — the source is already in hand generically, as `{}`",
+        render(holder)
+      ),
+    );
+  }
+  (
+    Verdict::Narrowed,
+    "test 4 — nothing in the signature carries a source type, so this parameter is the document"
+      .to_string(),
+  )
+}
+
+/// The costliest text type inside one parameter; a parameter is judged on its worst position.
+///
+/// `&mut` and `'static` hits are set aside first, so `render(out: &mut String, space: &'static
+/// str)` is not convicted by either. Falling back to the first hit when that leaves nothing keeps
+/// the parameter reported — as the datum it is — rather than dropped from the census silently.
+/// Utf8 outranks Representation only to decide which hit is quoted; both convict.
+fn worst(hits: &[TextHit]) -> Option<&TextHit> {
+  hits
+    .iter()
+    .filter(|h| !h.out_param && !h.konstant)
+    .max_by_key(|h| match h.cost {
+      Cost::None => 0,
+      Cost::Representation => 1,
+      Cost::Utf8 => 2,
+    })
+    .or_else(|| hits.first())
+}
+
+fn pattern_name(pat: &syn::Pat) -> String {
+  use quote::ToTokens as _;
+  match pat {
+    syn::Pat::Ident(i) => i.ident.to_string(),
+    other => other.to_token_stream().to_string(),
+  }
+}
+
+/// Idents of every type, enum, union, trait and alias the crate declares.
+fn declared_types(surface: &Surface) -> BTreeSet<String> {
+  let mut out = BTreeSet::new();
+  for module in &surface.modules {
+    for item in &module.items {
+      let ident = match item {
+        Item::Struct(i) => Some(i.ident.to_string()),
+        Item::Enum(i) => Some(i.ident.to_string()),
+        Item::Union(i) => Some(i.ident.to_string()),
+        Item::Trait(i) => Some(i.ident.to_string()),
+        Item::Type(i) => Some(i.ident.to_string()),
+        _ => None,
+      };
+      out.extend(ident);
+    }
+  }
+  out
+}
+
+/// Reads the whole crate — public and private — for the positions it treats as source positions.
+fn derive_source_positions(surface: &Surface, crate_types: &BTreeSet<String>) -> SourcePositions {
+  let mut positions = SourcePositions::new();
+  let harvest = |types: &[Type], scope: &Scope, positions: &mut SourcePositions| {
+    for ty in types {
+      harvest_source_positions(ty, scope, crate_types, positions);
+    }
+  };
+
+  for module in &surface.modules {
+    for item in &module.items {
+      match item {
+        Item::Fn(f) => {
+          let mut scope = Scope::default();
+          scope.extend_from(&f.sig.generics);
+          harvest(&signature_types(&f.sig, None), &scope, &mut positions);
+        }
+        Item::Impl(i) => {
+          let mut impl_scope = Scope::default();
+          impl_scope.extend_from(&i.generics);
+          let mut types = vec![(*i.self_ty).clone()];
+          types.extend(bound_type_list(&i.generics));
+          harvest(&types, &impl_scope, &mut positions);
+          for member in &i.items {
+            let ImplItem::Fn(f) = member else { continue };
+            let mut scope = impl_scope.clone();
+            scope.extend_from(&f.sig.generics);
+            harvest(
+              &signature_types(&f.sig, Some(&i.self_ty)),
+              &scope,
+              &mut positions,
+            );
+          }
+        }
+        Item::Trait(t) => {
+          let mut trait_scope = Scope::default();
+          trait_scope.extend_from(&t.generics);
+          harvest(&bound_type_list(&t.generics), &trait_scope, &mut positions);
+          for member in &t.items {
+            let TraitItem::Fn(f) = member else { continue };
+            let mut scope = trait_scope.clone();
+            scope.extend_from(&f.sig.generics);
+            harvest(&signature_types(&f.sig, None), &scope, &mut positions);
+          }
+        }
+        Item::Struct(s) => {
+          let mut scope = Scope::default();
+          scope.extend_from(&s.generics);
+          let types: Vec<Type> = s.fields.iter().map(|f| f.ty.clone()).collect();
+          harvest(&types, &scope, &mut positions);
+        }
+        Item::Enum(e) => {
+          let mut scope = Scope::default();
+          scope.extend_from(&e.generics);
+          let types: Vec<Type> = e
+            .variants
+            .iter()
+            .flat_map(|v| v.fields.iter())
+            .map(|f| f.ty.clone())
+            .collect();
+          harvest(&types, &scope, &mut positions);
+        }
+        Item::Type(t) => {
+          let mut scope = Scope::default();
+          scope.extend_from(&t.generics);
+          harvest(&[(*t.ty).clone()], &scope, &mut positions);
+        }
+        _ => {}
+      }
+    }
+  }
+  positions
+}
+
+/// Every public function, inherent method and trait method the crate exposes.
+fn collect_entries(surface: &Surface) -> Vec<Entry> {
+  let mut out = Vec::new();
+  for module in &surface.modules {
+    let module_path = module.display_path();
+    for item in &module.items {
+      match item {
+        Item::Fn(f) => {
+          if !matches!(f.vis, Visibility::Public(_))
+            || is_doc_hidden(&f.attrs)
+            || !surface.item_is_public(&module.path, &f.sig.ident.to_string(), module.named_by_path)
+          {
+            continue;
+          }
+          let mut scope = Scope::default();
+          scope.extend_from(&f.sig.generics);
+          out.push(Entry {
+            module: module_path.clone(),
+            name: f.sig.ident.to_string(),
+            file: module.file.display().to_string(),
+            line: line_of(&f.sig.ident),
+            sig: f.sig.clone(),
+            self_ty: None,
+            scope,
+          });
+        }
+        Item::Trait(t) => {
+          if !matches!(t.vis, Visibility::Public(_))
+            || is_doc_hidden(&t.attrs)
+            || !surface.item_is_public(&module.path, &t.ident.to_string(), module.named_by_path)
+          {
+            continue;
+          }
+          let mut trait_scope = Scope::default();
+          trait_scope.extend_from(&t.generics);
+          for member in &t.items {
+            let TraitItem::Fn(f) = member else { continue };
+            if is_doc_hidden(&f.attrs) {
+              continue;
+            }
+            let mut scope = trait_scope.clone();
+            scope.extend_from(&f.sig.generics);
+            out.push(Entry {
+              module: module_path.clone(),
+              name: format!("{}::{}", t.ident, f.sig.ident),
+              file: module.file.display().to_string(),
+              line: line_of(&f.sig.ident),
+              sig: f.sig.clone(),
+              self_ty: None,
+              scope,
+            });
+          }
+        }
+        Item::Impl(i) => {
+          if i.trait_.is_some() || is_doc_hidden(&i.attrs) {
+            continue;
+          }
+          let Some(type_name) = self_type_ident(&i.self_ty) else {
+            continue;
+          };
+          if !surface.public_types.contains(&type_name) {
+            continue;
+          }
+          let mut impl_scope = Scope::default();
+          impl_scope.extend_from(&i.generics);
+          for member in &i.items {
+            let ImplItem::Fn(f) = member else { continue };
+            if !matches!(f.vis, Visibility::Public(_)) || is_doc_hidden(&f.attrs) {
+              continue;
+            }
+            let mut scope = impl_scope.clone();
+            scope.extend_from(&f.sig.generics);
+            out.push(Entry {
+              module: module_path.clone(),
+              name: format!("{}::{}", type_name, f.sig.ident),
+              file: module.file.display().to_string(),
+              line: line_of(&f.sig.ident),
+              sig: f.sig.clone(),
+              self_ty: Some((*i.self_ty).clone()),
+              scope,
+            });
+          }
+        }
+        _ => {}
+      }
+    }
+  }
+  out
+}
+
+fn self_type_ident(ty: &Type) -> Option<String> {
+  match ty {
+    Type::Path(p) => Some(p.path.segments.last()?.ident.to_string()),
+    Type::Reference(r) => self_type_ident(&r.elem),
+    Type::Paren(p) => self_type_ident(&p.elem),
+    Type::Group(g) => self_type_ident(&g.elem),
+    _ => None,
+  }
+}
+
+fn line_of(ident: &proc_macro2::Ident) -> usize {
+  ident.span().start().line
+}

--- a/ci/source_census/src/exempt.rs
+++ b/ci/source_census/src/exempt.rs
@@ -1,0 +1,367 @@
+//! The exemptions, as data with a reason on every one of them.
+//!
+//! # Why the format is what it is
+//!
+//! An omission is invisible. A line missing from a check looks exactly like a property that holds,
+//! which is the whole shape al8n/smear#122 is about, so an exemption here is not permission to
+//! skip a site — it is a *record* of a narrowing, printed on every run, that has to be argued for
+//! in writing.
+//!
+//! Four things make an unexplained exemption fail rather than pass:
+//!
+//! 1. **`reason` is a struct field, not an option.** A [`Exemption`] cannot be constructed without
+//!    one; leaving it out is a compile error in this crate, before any census runs.
+//! 2. **A reason that says nothing fails the run.** [`validate`] rejects one shorter than
+//!    [`MIN_REASON`] bytes, and rejects the placeholder words people reach for when they have not
+//!    got a reason (`todo`, `tbd`, `fixme`, `see above`, `n/a`).
+//! 3. **`issue` is required for anything not structural.** An exemption whose `kind` is
+//!    [`Kind::Tracked`] must name the issue that owns the narrowing, so it is debt with a home
+//!    rather than debt with an excuse. [`Kind::Structural`] is for a constraint that no issue will
+//!    ever close, and it must say what forces it.
+//! 4. **A stale exemption fails.** An entry that matches nothing in the crate is an error, not a
+//!    no-op. That is what forces the table to shrink when #121 and #103 widen their doors: the day
+//!    `validate_schema_lossless` stops taking `&str`, this table stops matching and the census
+//!    goes red until the line is deleted.
+//!
+//! # What is exempt today, and what is not
+//!
+//! The two `&str` parameters that are *not* narrowings at all — `Executor::start`'s `operation`
+//! and `Executor::handle_field_error`'s `message` — are absent from this table on purpose. They
+//! are classified by the rule, structurally, and needing an exemption for them would have meant
+//! the rule was wrong. See `rule`'s header.
+
+/// The shortest reason the census will accept. Long enough that "rowan" or "#121" alone does not
+/// clear it, short enough that a genuine one-line reason does.
+pub const MIN_REASON: usize = 40;
+
+const PLACEHOLDERS: &[&str] = &["todo", "tbd", "fixme", "see above", "n/a", "xxx", "wip"];
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Kind {
+  /// A narrowing that is tracked and is expected to go away. Must name its issue.
+  Tracked,
+  /// A constraint the crate cannot remove, whatever anyone decides. Must say what imposes it.
+  Structural,
+  /// Not a narrowing at all — the rule's default-convict fired on a parameter that is a datum,
+  /// and the record says why. This is the one kind that is evidence AGAINST the rule, so it is
+  /// counted separately in the run's own output: if it ever stops being a handful, the rule is
+  /// wrong and no amount of recording will fix that.
+  NotSource,
+}
+
+/// One recorded narrowing.
+#[derive(Clone, Copy)]
+pub struct Exemption {
+  /// The module the entry is declared in, exactly as the census prints it.
+  pub module: &'static str,
+  /// `parse_document`, or `Schema::from_introspection` for an inherent method.
+  pub entry: &'static str,
+  /// The parameter. `*` records every narrowed parameter of the entry.
+  pub param: &'static str,
+  pub kind: Kind,
+  /// The issue that owns it. Required for [`Kind::Tracked`].
+  pub issue: Option<u32>,
+  pub reason: &'static str,
+}
+
+/// The three lossless roots of each dialect, `fn(&str) -> Parse`.
+const LOSSLESS_ROOT: &str = "The materialization door: it builds a rowan green tree, and rowan's \
+   `GreenNodeBuilder::token` takes `&str`, so UTF-8 binds SOMEWHERE on this path. Whether it \
+   binds at the public door or deeper is exactly al8n/smear#121's third question — the substrate \
+   runner one layer down is already generic (`Lx::Source: tokora::cst::CstText` at \
+   `parser/lossless/runner.rs`), so the abstraction exists and it is this entry that spells the \
+   concrete type. Recorded, not accepted.";
+
+/// The projections from a rowan tree back to a borrowing AST.
+const LOSSLESS_PROJECTION: &str = "A projection re-slices the caller's own buffer by the tree's byte offsets and hands back an \
+   AST borrowing it, so the AST's source type is whatever this parameter is — which is why the \
+   `&'src str` here forces `Document<&'src str>` on every consumer of the lossless half while \
+   the syntactic half is generic. Nothing in the signature needs UTF-8 except rowan's own \
+   `SyntaxToken::text()` comparison, which is al8n/smear#121's question about where the \
+   constraint really binds.";
+
+/// Everything the census finds on `main` and does not fail on, each with its argument.
+///
+/// The three sites al8n/smear#122 names as the calibration answer are the first three groups. They
+/// are recorded rather than fixed because #121 and #103 own them, and because a census whose known
+/// answer is invisible in its own output cannot be checked against that answer.
+pub const EXEMPTIONS: &[Exemption] = &[
+  // ── §5 lossless, the validator doors — al8n/smear#121 ────────────────────────────────────────
+  Exemption {
+    module: "smear::validator::lossless",
+    entry: "validate_executable_lossless",
+    param: "*",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: "The lossless twin of `validate_executable<S, K> where S: AsRef<[u8]> + Clone, \
+             K: Sink<S>`, narrowed to `&'src str` at both the source parameter and the sink's \
+             source type. A consumer holding `bytes::Bytes` can use the syntactic door and not \
+             this one. #121 is settling whether the rowan boundary genuinely binds at the door or \
+             deeper; until it does, this is a recorded narrowing and not an accepted shape.",
+  },
+  Exemption {
+    module: "smear::validator::lossless",
+    entry: "validate_executable_lossless_with",
+    param: "*",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: "`validate_executable_lossless`'s `rules` sibling, and narrowed identically — the \
+             same `&'src str` source and the same `Sink<&'src str>`. Recorded separately because \
+             widening one door and not the other would leave the asymmetry in place under a \
+             shrinking table.",
+  },
+  Exemption {
+    module: "smear::validator::lossless",
+    entry: "validate_schema_lossless",
+    param: "*",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: "The §3 door `Schema::build<S>(&TypeSystemDocument<S>) where S: AsRef<[u8]>` is \
+             generic; this lossless door in front of it is not. Nothing in its signature carries \
+             a source type — `&Parse` is a rowan tree — so the `&str` is the document itself, \
+             tracked on #121.",
+  },
+  // ── §4 introspection — al8n/smear#103 ────────────────────────────────────────────────────────
+  Exemption {
+    module: "smear::validator::schema::introspection",
+    entry: "Schema::from_introspection",
+    param: "response",
+    kind: Kind::Tracked,
+    issue: Some(103),
+    reason: "An introspection response arrives off a transport, which is where `bytes::Bytes` is \
+             most likely to be what the caller already holds, and `&str` makes them validate \
+             UTF-8 over the whole body first. #103 replaces the `serde_json` reader with a tokora \
+             one and settles the string representation while it is in there.",
+  },
+  Exemption {
+    module: "smear::validator::schema::introspection",
+    entry: "to_sdl",
+    param: "response",
+    kind: Kind::Tracked,
+    issue: Some(103),
+    reason: "`Schema::from_introspection`'s intermediate form, public in its own right and \
+             narrowed at the same parameter for the same reason. Widening one without the other \
+             would leave the door a caller reaches for directly still narrow.",
+  },
+  // ── §5 lossless, the parser doors — al8n/smear#121 ───────────────────────────────────────────
+  //
+  // NOT in #121's table, which enumerates the two validator doors. They are the same family: the
+  // census found them by the same rule and they narrow the same property, so they are recorded
+  // under the issue that owns the question rather than left out of it.
+  Exemption {
+    module: "smear::parser::graphql::lossless::runner",
+    entry: "parse_document",
+    param: "src",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_ROOT,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::runner",
+    entry: "parse_executable_document",
+    param: "src",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_ROOT,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::runner",
+    entry: "parse_type_system_document",
+    param: "src",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_ROOT,
+  },
+  Exemption {
+    module: "smear::parser::graphqlx::lossless::runner",
+    entry: "parse_document",
+    param: "src",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_ROOT,
+  },
+  Exemption {
+    module: "smear::parser::graphqlx::lossless::runner",
+    entry: "parse_executable_document",
+    param: "src",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_ROOT,
+  },
+  Exemption {
+    module: "smear::parser::graphqlx::lossless::runner",
+    entry: "parse_type_system_document",
+    param: "src",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_ROOT,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "project",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "project_executable_document",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "project_executable_document_recovered",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "project_type_system_document",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "project_type_system_document_recovered",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "Document::to_ast",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "ExecutableDocument::to_ast",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::graphql::lossless::project",
+    entry: "TypeSystemDocument::to_ast",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: LOSSLESS_PROJECTION,
+  },
+  Exemption {
+    module: "smear::parser::lossless::project",
+    entry: "verify_slice",
+    param: "source",
+    kind: Kind::Tracked,
+    issue: Some(121),
+    reason: "The dialect-independent helper the projections above call, and the narrowest place \
+             the rowan constraint could bind: it compares the caller's slice against \
+             `SyntaxToken::text()`, which rowan returns as `&str`. If al8n/smear#121 concludes \
+             that the constraint is genuinely rowan's rather than the door's, this is the entry \
+             the conclusion is about, and it becomes STRUCTURAL rather than being deleted.",
+  },
+  // ── Not narrowings: the rule's default-convict misfiring ─────────────────────────────────────
+  //
+  // Two, out of 22 narrowed parameters over 864 public entries. The count is the evidence for the
+  // rule rather than a note about it: a rule needing an exemption for every second entry would be
+  // the wrong rule, and this is the number that says whether it is.
+  Exemption {
+    module: "smear::validator::schema::repr::location",
+    entry: "DirectiveLocation::from_name",
+    param: "name",
+    kind: Kind::NotSource,
+    issue: None,
+    reason: "A draft §3 directive-location keyword — `QUERY`, `FIELD_DEFINITION` — matched \
+             against a closed, ASCII set this enum defines. It is a key the caller composes, not \
+             a document, and every source representation produces one for free. Test 3 does not \
+             acquit it only because `DirectiveLocation` is a plain enum with no source type to \
+             hold.",
+  },
+  Exemption {
+    module: "smear::validator::schema::repr::ty",
+    entry: "PackedType::write",
+    param: "name",
+    kind: Kind::NotSource,
+    issue: None,
+    reason: "The already-interned base type name, handed back in so the wrapper can be printed \
+             around it — `[Foo!]!`. It comes out of the schema's own name arena, so it is this \
+             crate's `&str` and not the caller's buffer. Test 3 does not acquit it because \
+             `PackedType` is a `u32` bitfield with no source type to hold.",
+  },
+];
+
+/// Refuses a table that would let a narrowing through without an argument.
+pub fn validate() -> Vec<String> {
+  EXEMPTIONS
+    .iter()
+    .enumerate()
+    .flat_map(|(index, exemption)| check_one(exemption, index))
+    .collect()
+}
+
+/// The guards, on one record. Public so the selftest can hand it a deliberately broken one.
+pub fn check_one(exemption: &Exemption, index: usize) -> Vec<String> {
+  let mut problems = Vec::new();
+  let at = format!(
+    "exemption {} ({}::{} / {})",
+    index, exemption.module, exemption.entry, exemption.param
+  );
+  let reason = exemption.reason.trim();
+  if reason.len() < MIN_REASON {
+    problems.push(format!(
+      "{at}: the reason is {} bytes and the census requires at least {MIN_REASON}. An exemption \
+       is a claim that a narrowing is acceptable; a claim that short is not one",
+      reason.len()
+    ));
+  }
+  let lowered = reason.to_ascii_lowercase();
+  if let Some(placeholder) = PLACEHOLDERS.iter().find(|p| lowered.contains(**p)) {
+    problems.push(format!(
+      "{at}: the reason contains the placeholder {placeholder:?}, which is what a missing reason \
+       looks like when someone has to fill a required field"
+    ));
+  }
+  match (exemption.kind, exemption.issue) {
+    (Kind::Tracked, None) => problems.push(format!(
+      "{at}: a tracked narrowing must name the issue that owns it, or it is debt with nowhere to \
+       be paid"
+    )),
+    (Kind::Structural | Kind::NotSource, Some(issue)) => problems.push(format!(
+      "{at}: it is recorded as {:?} — nothing anyone closes — and yet names issue #{issue}. One \
+       of the two is wrong",
+      exemption.kind
+    )),
+    _ => {}
+  }
+  if exemption.module.is_empty() || exemption.entry.is_empty() || exemption.param.is_empty() {
+    problems.push(format!("{at}: module, entry and param must all be named"));
+  }
+  problems
+}
+
+impl Exemption {
+  pub fn matches(&self, module: &str, entry: &str, param: &str) -> bool {
+    self.module == module && self.entry == entry && (self.param == "*" || self.param == param)
+  }
+
+  pub fn label(&self) -> String {
+    match (self.kind, self.issue) {
+      (Kind::Tracked, Some(issue)) => format!("TRACKED al8n/smear#{issue}"),
+      (Kind::Tracked, None) => "TRACKED (no issue — invalid)".to_string(),
+      (Kind::Structural, _) => "STRUCTURAL".to_string(),
+      (Kind::NotSource, _) => "NOT SOURCE — the rule misfired".to_string(),
+    }
+  }
+}

--- a/ci/source_census/src/main.rs
+++ b/ci/source_census/src/main.rs
@@ -1,0 +1,452 @@
+//! Fails a build when a public entry takes source text at a concrete type.
+//!
+//! `smear` ships five source-representation integrations so a consumer can pick one. §3, syntactic
+//! §5 and §6/§7 honour that with `S: AsRef<[u8]>`. Nothing fails when a new public entry spells the
+//! same parameter `&str` instead: it compiles, it passes every test, it reads naturally, and the
+//! narrowing is discovered by a consumer at a call site. That is al8n/smear#122, and this is the
+//! mechanism it asks for.
+//!
+//! Run from the repository root:
+//!
+//! ```text
+//! cargo run -p source-census --                # census `smear`, exit 1 on an unexplained finding
+//! cargo run -p source-census -- --selftest     # prove every branch of the verdict can fail
+//! cargo run -p source-census -- --verbose      # also list the parameters that cost nothing
+//! ```
+//!
+//! Three modules carry the design and each states its own reasoning:
+//!
+//! * [`surface`] — which entries a consumer can reach, derived from the code rather than listed.
+//! * [`rule`] — what counts as a parameter carrying source text, which is the whole judgement.
+//! * [`exempt`] — the recorded narrowings, and what makes an unexplained one fail.
+//!
+//! # What makes this gate non-vacuous
+//!
+//! `ci/miri_scope.py` fails a Miri cell when the interpreted set is not what the scripts claim.
+//! The same idea applies here in three places:
+//!
+//! * `--selftest` runs the verdict against synthetic crates and requires every branch to fire.
+//! * An exemption that matches nothing is a failure, so the table is a live canary: if the reader
+//!   ever stops finding the surface — a moved file, a `mod` shape it cannot walk — the table goes
+//!   stale in the same instant and the run goes red, rather than reporting a clean crate.
+//! * A run that reads zero public entries, or examines zero parameters, fails outright.
+
+mod census;
+mod exempt;
+mod rule;
+mod selftest;
+mod surface;
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+  path::{Path, PathBuf},
+  process::ExitCode,
+};
+
+use census::{Report, Verdict};
+use rule::Cost;
+
+const DEFAULT_ROOT: &str = "smear/src/lib.rs";
+const DEFAULT_CRATE: &str = "smear";
+
+fn main() -> ExitCode {
+  let mut root = PathBuf::from(DEFAULT_ROOT);
+  let mut crate_name = DEFAULT_CRATE.to_string();
+  let mut verbose = false;
+  let mut run_selftest = false;
+
+  let mut args = std::env::args().skip(1);
+  while let Some(arg) = args.next() {
+    match arg.as_str() {
+      "--selftest" => run_selftest = true,
+      "--verbose" => verbose = true,
+      "--crate-root" => match args.next() {
+        Some(value) => root = PathBuf::from(value),
+        None => return fail("--crate-root needs a path to a crate's lib.rs"),
+      },
+      "--crate-name" => match args.next() {
+        Some(value) => crate_name = value,
+        None => return fail("--crate-name needs a name"),
+      },
+      "--help" | "-h" => {
+        println!(
+          "source-census [--crate-root {DEFAULT_ROOT}] [--crate-name {DEFAULT_CRATE}] \
+           [--verbose] [--selftest]"
+        );
+        return ExitCode::SUCCESS;
+      }
+      other => return fail(&format!("unknown argument {other:?}")),
+    }
+  }
+
+  if run_selftest {
+    return match selftest::run() {
+      Ok(cases) => {
+        println!("source-census selftest OK: {cases} cases");
+        ExitCode::SUCCESS
+      }
+      Err(problems) => {
+        error("the selftest did not behave as `rule`'s header claims");
+        for problem in problems {
+          println!("  - {problem}");
+        }
+        ExitCode::FAILURE
+      }
+    };
+  }
+
+  // A gate that only works from one directory is a gate someone runs from the wrong one and
+  // reads the error as noise. The default path is tried against the working directory first and
+  // then against this crate's own location, which is fixed relative to the repository.
+  if !root.is_file() && root == Path::new(DEFAULT_ROOT) {
+    let beside = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+      .join("..")
+      .join("..")
+      .join(DEFAULT_ROOT);
+    if beside.is_file() {
+      root = beside;
+    }
+  }
+  if !root.is_file() {
+    return fail(&format!(
+      "no such crate root: {} — run this from the repository root, or pass --crate-root",
+      root.display()
+    ));
+  }
+
+  let mut report = match census::detect(&root, &crate_name) {
+    Ok(report) => report,
+    Err(message) => return fail(&message),
+  };
+  census::reconcile(&mut report);
+  render(&report, &root, verbose);
+
+  if verdict(&report) {
+    ExitCode::SUCCESS
+  } else {
+    ExitCode::FAILURE
+  }
+}
+
+const RULE: &str =
+  "────────────────────────────────────────────────────────────────────────────────────────────";
+
+fn render(report: &Report, root: &Path, verbose: bool) {
+  println!();
+  println!("── Source genericity census ─{}", &RULE[..RULE.len() - 84]);
+  println!("crate root: {}", root.display());
+  println!(
+    "read: {} files, {} publicly reachable modules, {} public entries, {} parameters",
+    report.files_read,
+    report.public_modules.len(),
+    report.entries_read,
+    report.params_read,
+  );
+  println!(
+    "source positions derived from the crate ({}): {}",
+    report.source_positions.len(),
+    render_positions(report),
+  );
+  println!(
+    "item-position macro invocations, whose expansions this tool cannot see: {}",
+    report.macro_invocations,
+  );
+  render_macro_templates(report);
+
+  section(
+    report,
+    Verdict::Neutral,
+    "NEUTRAL",
+    "a byte view; `S: AsRef<[u8]>` already produces one",
+    verbose,
+  );
+  section(
+    report,
+    Verdict::Datum,
+    "DATUM",
+    "concrete text that is not the document",
+    true,
+  );
+
+  let narrowed: Vec<usize> = report
+    .observations
+    .iter()
+    .enumerate()
+    .filter(|(_, o)| o.verdict == Verdict::Narrowed)
+    .map(|(i, _)| i)
+    .collect();
+  println!();
+  println!(
+    "NARROWED — concrete text standing where the crate elsewhere puts a source type: {}",
+    narrowed.len()
+  );
+  for (index, exemption) in &report.recorded {
+    let o = &report.observations[*index];
+    println!(
+      "  ! [{}] {}::{}  {}: {} <{}>{}",
+      exemption.label(),
+      o.module,
+      o.entry,
+      o.param,
+      o.ty,
+      cost_tag(o.cost),
+      inner_text(o),
+    );
+    println!("      {}", o.location);
+    println!("      {}", o.why);
+    println!("      reason: {}", squash(exemption.reason));
+  }
+  for index in &report.unexplained {
+    let o = &report.observations[*index];
+    println!(
+      "  x [UNEXPLAINED] {}::{}  {}: {} <{}>{}",
+      o.module,
+      o.entry,
+      o.param,
+      o.ty,
+      cost_tag(o.cost),
+      inner_text(o)
+    );
+    println!("      {}", o.location);
+    println!("      {}", o.why);
+  }
+  println!("{RULE}");
+  println!();
+}
+
+fn section(report: &Report, want: Verdict, title: &str, gloss: &str, show: bool) {
+  let rows: Vec<_> = report
+    .observations
+    .iter()
+    .filter(|o| o.verdict == want)
+    .collect();
+  println!();
+  println!("{title} — {gloss}: {}", rows.len());
+  if !show {
+    println!("  (listed with --verbose)");
+    return;
+  }
+  for o in rows {
+    println!(
+      "  . {}::{}  {}: {}{}",
+      o.module,
+      o.entry,
+      o.param,
+      o.ty,
+      inner_text(o)
+    );
+    println!("      {}", o.why);
+  }
+}
+
+/// What step 1 of the rule charged this parameter.
+fn cost_tag(cost: Cost) -> &'static str {
+  match cost {
+    Cost::None => "bytes",
+    Cost::Utf8 => "utf-8",
+    Cost::Representation => "owned",
+  }
+}
+
+/// `  [via Cow<'static, str>]` when the text type is nested inside a larger parameter type.
+fn inner_text(o: &census::Observation) -> String {
+  if o.text == o.ty {
+    String::new()
+  } else {
+    format!("  [via {}]", o.text)
+  }
+}
+
+/// The one place the census cannot see, measured rather than described.
+fn render_macro_templates(report: &Report) {
+  let unguarded: Vec<_> = report
+    .macro_templates
+    .iter()
+    .filter(|t| !t.konstant && !t.doc_hidden)
+    .collect();
+  println!(
+    "`pub fn` templates inside `macro_rules!` taking concrete text: {} ({} constant, {} \
+     `doc(hidden)`, {} neither)",
+    report.macro_templates.len(),
+    report.macro_templates.iter().filter(|t| t.konstant).count(),
+    report
+      .macro_templates
+      .iter()
+      .filter(|t| !t.konstant && t.doc_hidden)
+      .count(),
+    unguarded.len(),
+  );
+  for template in &report.macro_templates {
+    let verdict = if template.konstant {
+      "constant"
+    } else if template.doc_hidden {
+      "`doc(hidden)`, so not API"
+    } else {
+      "NOT GUARDED"
+    };
+    println!(
+      "    {}! {}: {}  ({}:{}) — {verdict}",
+      template.macro_name, template.param, template.rendered, template.file, template.line
+    );
+  }
+}
+
+fn render_positions(report: &Report) -> String {
+  let mut out: Vec<String> = report
+    .source_positions
+    .iter()
+    .map(|(family, indices)| {
+      let list: Vec<String> = indices.iter().map(usize::to_string).collect();
+      format!("{family}<{}>", list.join(","))
+    })
+    .collect();
+  out.sort();
+  if out.is_empty() {
+    return "none".to_string();
+  }
+  out.join(" ")
+}
+
+/// Prints every reason the run fails, and returns whether it passed.
+fn verdict(report: &Report) -> bool {
+  let mut ok = true;
+
+  for problem in &report.table_problems {
+    error(&format!("the exemption table is not usable: {problem}"));
+    ok = false;
+  }
+
+  if report.entries_read == 0 || report.params_read == 0 {
+    error(
+      "the census read no public entries, or no parameters. It would then pass by having nothing \
+       to check, which is the defect it exists to catch — the reader has stopped finding the \
+       crate's surface",
+    );
+    ok = false;
+  }
+
+  if !report.unexplained.is_empty() {
+    error(&format!(
+      "{} public {} source text at a concrete type and {} not recorded",
+      report.unexplained.len(),
+      plural(
+        report.unexplained.len(),
+        "parameter takes",
+        "parameters take"
+      ),
+      plural(report.unexplained.len(), "is", "are"),
+    ));
+    for index in &report.unexplained {
+      let o = &report.observations[*index];
+      println!(
+        "  - {}::{}  {}: {}  ({})",
+        o.module, o.entry, o.param, o.ty, o.location
+      );
+      println!("    {}", o.why);
+    }
+    println!(
+      "  Either make the entry generic over the source — `S: AsRef<[u8]>`, as §3, syntactic §5 \
+       and §6/§7 already are — or record it in ci/source_census/src/exempt.rs with a reason and \
+       the issue that owns it. Deleting the parameter from the census is not one of the options: \
+       there is nowhere to delete it from."
+    );
+    ok = false;
+  }
+
+  let unguarded: Vec<_> = report
+    .macro_templates
+    .iter()
+    .filter(|t| !t.konstant && !t.doc_hidden)
+    .collect();
+  if !unguarded.is_empty() {
+    error(&format!(
+      "{} `pub fn` {} inside a `macro_rules!` source text at a concrete type",
+      unguarded.len(),
+      plural(unguarded.len(), "template takes", "templates take"),
+    ));
+    for template in &unguarded {
+      println!(
+        "  - {}! {}: {}  ({}:{})",
+        template.macro_name, template.param, template.rendered, template.file, template.line
+      );
+    }
+    println!(
+      "  A macro is where a narrowing multiplies: `lossless_drivers!` alone expands into fourteen \
+       modules. The census cannot read the items a macro produces, so it reads the template \
+       instead — make the parameter generic over the source, or make the expansion \
+       `#[doc(hidden)]` if it is not API, or `&'\''static str` if it is a constant."
+    );
+    ok = false;
+  }
+
+  if !report.stale.is_empty() {
+    error(&format!(
+      "{} {} in the exemption table {} nothing in the crate",
+      report.stale.len(),
+      plural(report.stale.len(), "entry", "entries"),
+      plural(report.stale.len(), "matches", "match"),
+    ));
+    for exemption in &report.stale {
+      println!(
+        "  - {}::{}  {}",
+        exemption.module, exemption.entry, exemption.param
+      );
+    }
+    println!(
+      "  A stale exemption is not harmless: it is a recorded narrowing that no longer exists, or \
+       a reader that has stopped seeing the entry. If the door was widened, delete the line — \
+       that is how this table is made to shrink. If it was not, the census is no longer reading \
+       what it thinks it is."
+    );
+    ok = false;
+  }
+
+  if ok {
+    let misfires = report
+      .recorded
+      .iter()
+      .filter(|(_, e)| e.kind == exempt::Kind::NotSource)
+      .count();
+    println!(
+      "source-census OK: {} public entries, {} parameters, {} narrowed and all recorded with a \
+       reason ({} tracked, {} structural, {misfires} where the rule misfired)",
+      report.entries_read,
+      report.params_read,
+      report.recorded.len(),
+      report
+        .recorded
+        .iter()
+        .filter(|(_, e)| e.kind == exempt::Kind::Tracked)
+        .count(),
+      report
+        .recorded
+        .iter()
+        .filter(|(_, e)| e.kind == exempt::Kind::Structural)
+        .count(),
+    );
+  }
+  ok
+}
+
+fn plural(n: usize, one: &str, many: &str) -> String {
+  if n == 1 { one } else { many }.to_string()
+}
+
+fn squash(text: &str) -> String {
+  text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn error(message: &str) {
+  if std::env::var_os("GITHUB_ACTIONS").is_some() {
+    println!("::error::source-census: {message}");
+  } else {
+    println!("error: source-census: {message}");
+  }
+}
+
+fn fail(message: &str) -> ExitCode {
+  error(message);
+  ExitCode::FAILURE
+}

--- a/ci/source_census/src/rule.rs
+++ b/ci/source_census/src/rule.rs
@@ -1,0 +1,583 @@
+//! What counts as a parameter carrying source text, and why.
+//!
+//! # The property
+//!
+//! `smear` ships `bstr`, `bytes`, `hipstr`, `smallvec` and `smol-bytes` integrations so that a
+//! consumer picks its own source representation. §3, syntactic §5 and §6/§7 honour that with
+//! `S: AsRef<[u8]>`. A public entry that spells a source parameter `&str` instead takes that
+//! choice away: a caller holding `bytes::Bytes` must validate UTF-8 and re-borrow before it can
+//! call, and nothing in the crate says so — the constraint is discovered by the borrow checker at
+//! the call site, possibly years later (al8n/smear#121, #122).
+//!
+//! # Step 1 — does the type constrain anything at all
+//!
+//! Not every concrete text type is a narrowing:
+//!
+//! * **`&[u8]` constrains nobody.** `S: AsRef<[u8]>` *is* the promise that a source produces one,
+//!   so a byte view is the currency every representation already speaks. `Schema::sym(&[u8])` and
+//!   `Schema::type_by_name(&[u8])` are correct as written and this census says nothing about them.
+//! * **`&str` and `String` do constrain.** They add a UTF-8 obligation the byte bound does not
+//!   carry.
+//! * **`Vec<u8>`, `Bytes`, `HipStr`, `SmallVec<[u8; N]>` … constrain**, differently: they pin one
+//!   owned representation, which is the same defect wearing the other hat.
+//!
+//! # Step 2 — is this parameter the document
+//!
+//! This is the judgement the whole census turns on. Too narrow and the next narrowing walks past
+//! it; too broad and it fires on `Executor::start`'s `operation: Option<&str>`, which is a lookup
+//! key the caller composes — draft §6.1's `GetOperation` argument — and is correctly `&str`.
+//!
+//! The rule, in one sentence:
+//!
+//! > **A concrete text parameter is the document unless the entry demonstrably already has the
+//! > document in hand generically.**
+//!
+//! Default-convict, because the two failure directions are not symmetric. A false positive is a
+//! line in the exemption table with a reason on it, read once by a human. A false negative is the
+//! defect this census exists to prevent, and it is silent. So the burden of proof sits on the
+//! entry: `&str` is a narrowing until the signature shows otherwise.
+//!
+//! Four tests run in order.
+//!
+//! 1. **A source-generic family applied to a concrete text type** — convict. The set of
+//!    "source-generic families" is *derived from the crate*, never listed: any generic type or
+//!    trait that is anywhere applied to a type parameter carrying a source bound owns a source
+//!    position at that argument index. `validate_executable<S, K>(…) where S: AsRef<[u8]>,
+//!    K: Sink<S>` is what makes `Sink`'s first argument a source position, which is what makes
+//!    `K: Sink<&'src str>` in `validate_executable_lossless` a narrowing — stated by the crate
+//!    about itself.
+//! 2. **The parameter's name is in the source lexicon** — convict. This is name evidence and it is
+//!    deliberately *conviction-only*: being in the lexicon adds a finding, being absent from it
+//!    never removes one. A vocabulary that could acquit would be a hand-maintained list of what to
+//!    skip, which is the defect one level up; a vocabulary that can only accuse is a strictly
+//!    tightening heuristic that cannot cause a miss.
+//! 3. **The source is already in hand generically** — acquit. The receiver, or another parameter,
+//!    is a source-generic family applied to a *type parameter* (`&'a ExecutableDocument<S>`,
+//!    `Executor<'a, S, V>`, `Cst<'inp, Lx, Em>`) or is a bare source-bound parameter. The document
+//!    is then already present in the caller's own representation, so a second, concrete text value
+//!    in the same signature is necessarily *about* that document rather than being it: a name to
+//!    look up, a message to attach, a key to compare.
+//! 4. **Otherwise** — convict.
+//!
+//! Three things are acquitted before any of that, because the type says so outright:
+//!
+//! * `&mut str` / `&mut String` / `&mut Vec<u8>` — a mutable borrow is an output buffer, not input.
+//! * `&'static str` — an explicitly `'static` borrow cannot be a slice of a caller's document
+//!   without the caller leaking it, so it is a compile-time constant. `finish_root`'s
+//!   `space: &'static str` is the dialect's own name.
+//! * A type mentioning no concrete text type at all.
+//!
+//! # Worked answers
+//!
+//! | entry | parameter | test | verdict |
+//! |---|---|---|---|
+//! | `Executor::start` | `operation: Option<&str>` | 3 — `&mut self` is `Executor<'a, S, V>`, and `Executor`'s first type argument is a source position | **datum** |
+//! | `Executor::handle_field_error` | `message: &str` | 3 — same receiver | **datum** |
+//! | `validate_executable_lossless` | `source: &'src str` | 1 — `K: Sink<&'src str>`, and `Sink`'s first argument is a source position | **narrowed** |
+//! | `validate_schema_lossless` | `source: &str` | 2, then 4 — `&Parse` is a rowan tree and carries no source type, so nothing is in hand | **narrowed** |
+//! | `Schema::from_introspection` | `response: &str` | 2, then 4 — an associated function with nothing else in the signature | **narrowed** |
+//! | `Schema::sym` | `bytes: &[u8]` | step 1 — a byte view constrains nobody | **neutral** |
+//!
+//! # Where the rule is known to be weak
+//!
+//! Test 3 acquits every concrete text parameter on a source-generic receiver, so a hypothetical
+//! `Executor::parse_extension(&mut self, sdl: &str)` — a *second* document handed to a type that
+//! already holds one — is caught only by test 2, on the name. That is the reason the lexicon
+//! exists and the reason it can only convict. A shape that defeats both is a shape the exemption
+//! table cannot help with, and it is the one to widen the rule for when it appears.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use quote::ToTokens as _;
+use syn::{
+  GenericArgument, GenericParam, Generics, PathArguments, ReturnType, Signature, Type,
+  TypeParamBound, WherePredicate,
+};
+
+/// Parameter names that say "this is the document", used only to accuse.
+///
+/// Every entry here is a word the crate already uses for a whole document at a public door:
+/// `source` and `src` at the lossless doors, `response` at the introspection doors, `sdl` in
+/// `to_sdl`'s own prose. The rest are the words the next such door is likely to use.
+pub const SOURCE_LEXICON: &[&str] = &[
+  "body",
+  "bytes",
+  "content",
+  "doc",
+  "document",
+  "input",
+  "payload",
+  "query",
+  "raw",
+  "response",
+  "schema_source",
+  "sdl",
+  "source",
+  "src",
+  "text",
+];
+
+/// Parameterised trait bounds that mean "this type parameter is a source representation", when
+/// their argument is itself a text type: `AsRef<[u8]>` and `AsRef<str>` qualify, `AsRef<Path>`
+/// does not. `CstText` — tokora's, bound at `parser/lossless/runner.rs`'s `Lx::Source` — takes no
+/// argument and is recognised on its own.
+const SOURCE_BOUNDS: &[&str] = &["AsRef", "Borrow"];
+
+/// What a concrete text type in a signature costs a caller.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Cost {
+  /// `&[u8]`, `&BStr` — `S: AsRef<[u8]>` already produces one, so nothing is imposed.
+  None,
+  /// `&str` — a UTF-8 obligation on top of the byte bound.
+  Utf8,
+  /// `String`, `Vec<u8>`, `Bytes`, `HipStr`, `SmallVec<[u8; N]>` — one owned representation pinned.
+  Representation,
+}
+
+/// One concrete text type found inside a parameter's type.
+#[derive(Clone, Debug)]
+pub struct TextHit {
+  pub rendered: String,
+  pub cost: Cost,
+  /// Behind a `&mut`, so it is an output buffer rather than input.
+  pub out_param: bool,
+  /// Behind an explicit `&'static`, so it is a compile-time constant.
+  pub konstant: bool,
+}
+
+/// `family ident -> type-argument indices that stand for a source representation`.
+///
+/// Derived by reading the whole crate: wherever a generic path is applied to a type parameter that
+/// carries a source bound, that argument index is a source position for that family.
+pub type SourcePositions = BTreeMap<String, BTreeSet<usize>>;
+
+/// The generic environment a signature is read in: the function's own parameters plus the
+/// enclosing `impl` or `trait`'s.
+#[derive(Default, Clone)]
+pub struct Scope {
+  pub all_params: BTreeSet<String>,
+  pub source_params: BTreeSet<String>,
+}
+
+impl Scope {
+  pub fn extend_from(&mut self, generics: &Generics) {
+    for param in &generics.params {
+      if let GenericParam::Type(t) = param {
+        let name = t.ident.to_string();
+        self.all_params.insert(name.clone());
+        if t.bounds.iter().any(is_source_bound) {
+          self.source_params.insert(name);
+        }
+      }
+    }
+    for predicate in generics.where_clause.iter().flat_map(|w| &w.predicates) {
+      let WherePredicate::Type(pt) = predicate else {
+        continue;
+      };
+      let Some(root) = root_param_of(&pt.bounded_ty) else {
+        continue;
+      };
+      if pt.bounds.iter().any(is_source_bound) {
+        // `S: AsRef<[u8]>` marks `S`; `Lx::Source: CstText` marks `Lx`, because a lexer whose
+        // source is text is exactly as much "the caller's representation, generically" as the
+        // text itself.
+        self.source_params.insert(root);
+      }
+    }
+  }
+}
+
+fn is_source_bound(bound: &TypeParamBound) -> bool {
+  let TypeParamBound::Trait(t) = bound else {
+    return false;
+  };
+  let Some(last) = t.path.segments.last() else {
+    return false;
+  };
+  let name = last.ident.to_string();
+  if name == "CstText" {
+    return true;
+  }
+  if !SOURCE_BOUNDS.contains(&name.as_str()) {
+    return false;
+  }
+  // `AsRef<[u8]>` and `AsRef<str>` are source bounds; `AsRef<Path>` is not.
+  type_args(&last.arguments)
+    .iter()
+    .any(|arg| matches!(text_cost(arg), Some(Cost::None | Cost::Utf8)))
+}
+
+/// The leading identifier of a bounded type: `S` for `S`, `Lx` for `Lx::Source`.
+fn root_param_of(ty: &Type) -> Option<String> {
+  let Type::Path(p) = ty else { return None };
+  Some(p.path.segments.first()?.ident.to_string())
+}
+
+/// The type arguments of a path segment, lifetimes and const arguments skipped.
+fn type_args(arguments: &PathArguments) -> Vec<&Type> {
+  match arguments {
+    PathArguments::AngleBracketed(a) => a
+      .args
+      .iter()
+      .filter_map(|arg| match arg {
+        GenericArgument::Type(t) => Some(t),
+        _ => None,
+      })
+      .collect(),
+    _ => Vec::new(),
+  }
+}
+
+/// What one type costs a caller, if it is a concrete text type at all.
+///
+/// `None` is returned for anything that is not text, and [`Cost::None`] for text that costs
+/// nothing — the two are different answers and the caller needs both.
+fn text_cost(ty: &Type) -> Option<Cost> {
+  match ty {
+    Type::Slice(s) => is_u8(&s.elem).then_some(Cost::None),
+    Type::Array(a) => is_u8(&a.elem).then_some(Cost::None),
+    Type::Path(p) => {
+      let last = p.path.segments.last()?;
+      let name = last.ident.to_string();
+      let args = type_args(&last.arguments);
+      match name.as_str() {
+        "str" => Some(Cost::Utf8),
+        "BStr" => Some(Cost::None),
+        "String" | "HipStr" | "SmolStr" | "CompactString" | "BString" | "Bytes" | "BytesMut"
+        | "SmolBytes" => Some(Cost::Representation),
+        // An owned container of text or of bytes pins one owned representation either way.
+        "Cow" | "Box" | "Rc" | "Arc" => args
+          .first()
+          .and_then(|inner| text_cost(inner))
+          .map(|_| Cost::Representation),
+        "Vec" | "SmallVec" | "TinyVec" | "ArrayVec" => args
+          .first()
+          .filter(|inner| is_u8(inner) || matches!(text_cost(inner), Some(Cost::None)))
+          .map(|_| Cost::Representation),
+        _ => None,
+      }
+    }
+    _ => None,
+  }
+}
+
+fn is_u8(ty: &Type) -> bool {
+  matches!(ty, Type::Path(p) if p.path.is_ident("u8"))
+}
+
+/// Does the outermost path segment carry an explicit `'static` lifetime argument?
+fn has_static_argument(ty: &Type) -> bool {
+  let Type::Path(p) = ty else { return false };
+  let Some(last) = p.path.segments.last() else {
+    return false;
+  };
+  let PathArguments::AngleBracketed(args) = &last.arguments else {
+    return false;
+  };
+  args
+    .args
+    .iter()
+    .any(|arg| matches!(arg, GenericArgument::Lifetime(lt) if lt.ident == "static"))
+}
+
+/// Every concrete text type inside `ty`, with the borrow context that surrounds it.
+pub fn text_hits(ty: &Type) -> Vec<TextHit> {
+  fn walk(ty: &Type, out_param: bool, konstant: bool, out: &mut Vec<TextHit>) {
+    // A reference is scored as a whole, so the finding reads `&'src str` rather than `str` and so
+    // that `&mut` and `'static` reach the type they qualify.
+    if let Type::Reference(r) = ty {
+      let mutable = out_param || r.mutability.is_some();
+      let is_static = konstant || r.lifetime.as_ref().is_some_and(|lt| lt.ident == "static");
+      if let Some(cost) = text_cost(&r.elem) {
+        out.push(TextHit {
+          rendered: render(ty),
+          cost,
+          out_param: mutable,
+          konstant: is_static,
+        });
+        return;
+      }
+      walk(&r.elem, mutable, is_static, out);
+      return;
+    }
+    if let Some(cost) = text_cost(ty) {
+      out.push(TextHit {
+        rendered: render(ty),
+        cost,
+        out_param,
+        // `Cow<'static, str>` says the same thing `&'static str` does — it cannot be a slice of a
+        // caller's document without the caller leaking one — so `LexerErrorData::other`'s
+        // `impl Into<Cow<'static, str>>` is a message, not a source.
+        konstant: konstant || has_static_argument(ty),
+      });
+      return;
+    }
+    match ty {
+      Type::Paren(p) => walk(&p.elem, out_param, konstant, out),
+      Type::Group(g) => walk(&g.elem, out_param, konstant, out),
+      Type::Ptr(p) => walk(&p.elem, out_param, konstant, out),
+      Type::Tuple(t) => {
+        for elem in &t.elems {
+          walk(elem, out_param, konstant, out);
+        }
+      }
+      Type::Path(p) => {
+        for segment in &p.path.segments {
+          for arg in type_args(&segment.arguments) {
+            walk(arg, out_param, konstant, out);
+          }
+          if let PathArguments::Parenthesized(pa) = &segment.arguments {
+            for input in &pa.inputs {
+              walk(input, out_param, konstant, out);
+            }
+          }
+        }
+      }
+      Type::ImplTrait(i) => walk_bounds(i.bounds.iter(), out_param, konstant, out),
+      Type::TraitObject(t) => walk_bounds(t.bounds.iter(), out_param, konstant, out),
+      _ => {}
+    }
+  }
+
+  fn walk_bounds<'a>(
+    bounds: impl Iterator<Item = &'a TypeParamBound>,
+    out_param: bool,
+    konstant: bool,
+    out: &mut Vec<TextHit>,
+  ) {
+    for bound in bounds {
+      let TypeParamBound::Trait(t) = bound else {
+        continue;
+      };
+      // `impl AsRef<[u8]>` and `impl Fn(&str) -> …` are read for what they mention, but an
+      // `AsRef<[u8]>` bound is the representation-agnostic spelling and costs nothing.
+      if is_source_bound(bound) {
+        continue;
+      }
+      for segment in &t.path.segments {
+        for arg in type_args(&segment.arguments) {
+          walk(arg, out_param, konstant, out);
+        }
+      }
+    }
+  }
+
+  let mut out = Vec::new();
+  walk(ty, false, false, &mut out);
+  out
+}
+
+pub fn render(ty: &Type) -> String {
+  let text = ty.to_token_stream().to_string();
+  text
+    .replace(" ::", "::")
+    .replace(":: ", "::")
+    .replace(" <", "<")
+    .replace("< ", "<")
+    .replace(" >", ">")
+    .replace(" ,", ",")
+    .replace("& ", "&")
+    .replace("' ", "'")
+}
+
+/// Records every `family<… T …>` where `T` is a source-bound type parameter.
+///
+/// `crate_types` restricts this to families the crate under census declares itself. Without it
+/// `Option<S>` — written once anywhere for an optional description — would make `(Option, 0)` a
+/// source position, and `Executor::start`'s `operation: Option<&str>` would then be convicted by
+/// test 1 for no better reason than that `Option` is generic. The crate's own type vocabulary is
+/// read out of its own `struct`, `enum`, `trait` and `type` declarations, so nothing here is a
+/// list of names to skip.
+pub fn harvest_source_positions(
+  ty: &Type,
+  scope: &Scope,
+  crate_types: &BTreeSet<String>,
+  out: &mut SourcePositions,
+) {
+  let Type::Path(p) = ty else {
+    walk_children(ty, &mut |child| {
+      harvest_source_positions(child, scope, crate_types, out)
+    });
+    return;
+  };
+  for segment in &p.path.segments {
+    let family = segment.ident.to_string();
+    let args = type_args(&segment.arguments);
+    for (index, arg) in args.iter().enumerate() {
+      if mentions_source_param(arg, scope) && crate_types.contains(&family) {
+        out.entry(family.clone()).or_default().insert(index);
+      }
+      harvest_source_positions(arg, scope, crate_types, out);
+    }
+  }
+}
+
+/// Is `ty` a source-bound type parameter, or a borrow of one?
+fn mentions_source_param(ty: &Type, scope: &Scope) -> bool {
+  match ty {
+    Type::Path(p) => p
+      .path
+      .get_ident()
+      .is_some_and(|id| scope.source_params.contains(&id.to_string())),
+    Type::Reference(r) => mentions_source_param(&r.elem, scope),
+    Type::Paren(p) => mentions_source_param(&p.elem, scope),
+    Type::Group(g) => mentions_source_param(&g.elem, scope),
+    _ => false,
+  }
+}
+
+/// Does `ty` put the caller's source in the entry's hands generically?
+///
+/// Either a bare source-bound parameter, or any source-generic family applied to a type parameter
+/// rather than to a concrete type.
+pub fn holds_source_generically(ty: &Type, scope: &Scope, positions: &SourcePositions) -> bool {
+  if mentions_source_param(ty, scope) {
+    return true;
+  }
+  let mut held = false;
+  if let Type::Path(p) = ty {
+    for segment in &p.path.segments {
+      let family = segment.ident.to_string();
+      let args = type_args(&segment.arguments);
+      let source_indices = positions.get(&family);
+      for (index, arg) in args.iter().enumerate() {
+        let at_source_position = source_indices.is_some_and(|s| s.contains(&index));
+        if at_source_position && is_type_parameter(arg, scope) {
+          held = true;
+        }
+        if holds_source_generically(arg, scope, positions) {
+          held = true;
+        }
+      }
+    }
+  } else {
+    walk_children(ty, &mut |child| {
+      if holds_source_generically(child, scope, positions) {
+        held = true;
+      }
+    });
+  }
+  held
+}
+
+fn is_type_parameter(ty: &Type, scope: &Scope) -> bool {
+  match ty {
+    Type::Path(p) => p
+      .path
+      .get_ident()
+      .is_some_and(|id| scope.all_params.contains(&id.to_string())),
+    Type::Reference(r) => is_type_parameter(&r.elem, scope),
+    Type::Paren(p) => is_type_parameter(&p.elem, scope),
+    Type::Group(g) => is_type_parameter(&g.elem, scope),
+    _ => false,
+  }
+}
+
+/// Does `ty` apply a source-generic family to a *concrete text type*?
+///
+/// Returns the family and the argument, for the finding's explanation.
+pub fn family_at_concrete_text(ty: &Type, positions: &SourcePositions) -> Option<(String, String)> {
+  if let Type::Path(p) = ty {
+    for segment in &p.path.segments {
+      let family = segment.ident.to_string();
+      let args = type_args(&segment.arguments);
+      let source_indices = positions.get(&family);
+      for (index, arg) in args.iter().enumerate() {
+        if source_indices.is_some_and(|s| s.contains(&index))
+          && text_hits(arg)
+            .iter()
+            .any(|hit| hit.cost != Cost::None && !hit.out_param)
+        {
+          return Some((family.clone(), render(arg)));
+        }
+        if let Some(found) = family_at_concrete_text(arg, positions) {
+          return Some(found);
+        }
+      }
+    }
+    return None;
+  }
+  let mut found = None;
+  walk_children(ty, &mut |child| {
+    if found.is_none() {
+      found = family_at_concrete_text(child, positions);
+    }
+  });
+  found
+}
+
+/// Applies `f` to the immediate type children of `ty`, for the non-path shapes.
+fn walk_children(ty: &Type, f: &mut impl FnMut(&Type)) {
+  match ty {
+    Type::Reference(r) => f(&r.elem),
+    Type::Paren(p) => f(&p.elem),
+    Type::Group(g) => f(&g.elem),
+    Type::Ptr(p) => f(&p.elem),
+    Type::Slice(s) => f(&s.elem),
+    Type::Array(a) => f(&a.elem),
+    Type::Tuple(t) => t.elems.iter().for_each(f),
+    Type::ImplTrait(i) => bound_types(i.bounds.iter(), f),
+    Type::TraitObject(t) => bound_types(t.bounds.iter(), f),
+    _ => {}
+  }
+}
+
+fn bound_types<'a>(bounds: impl Iterator<Item = &'a TypeParamBound>, f: &mut impl FnMut(&Type)) {
+  for bound in bounds {
+    let TypeParamBound::Trait(t) = bound else {
+      continue;
+    };
+    for segment in &t.path.segments {
+      for arg in type_args(&segment.arguments) {
+        f(arg);
+      }
+    }
+  }
+}
+
+/// Every type a signature mentions: the receiver, the parameters, the return type, and the types
+/// named in its own bounds.
+pub fn signature_types(sig: &Signature, self_ty: Option<&Type>) -> Vec<Type> {
+  let mut out = Vec::new();
+  if let Some(ty) = self_ty {
+    out.push(ty.clone());
+  }
+  for arg in &sig.inputs {
+    match arg {
+      syn::FnArg::Typed(t) => out.push((*t.ty).clone()),
+      syn::FnArg::Receiver(r) => out.push((*r.ty).clone()),
+    }
+  }
+  if let ReturnType::Type(_, ty) = &sig.output {
+    out.push((**ty).clone());
+  }
+  out.extend(bound_type_list(&sig.generics));
+  out
+}
+
+/// The types named in an item's bounds, as `Type` values — `Sink<&'src str>` from
+/// `where K: Sink<&'src str>`.
+pub fn bound_type_list(generics: &Generics) -> Vec<Type> {
+  let mut out = Vec::new();
+  let mut push_bounds = |bounds: &syn::punctuated::Punctuated<TypeParamBound, syn::Token![+]>| {
+    for bound in bounds {
+      if let TypeParamBound::Trait(t) = bound {
+        out.push(Type::Path(syn::TypePath {
+          qself: None,
+          path: t.path.clone(),
+        }));
+      }
+    }
+  };
+  for param in &generics.params {
+    if let GenericParam::Type(t) = param {
+      push_bounds(&t.bounds);
+    }
+  }
+  for predicate in generics.where_clause.iter().flat_map(|w| &w.predicates) {
+    if let WherePredicate::Type(pt) = predicate {
+      push_bounds(&pt.bounds);
+    }
+  }
+  out
+}

--- a/ci/source_census/src/selftest.rs
+++ b/ci/source_census/src/selftest.rs
@@ -1,0 +1,382 @@
+//! Proves every branch of the verdict can fire, against synthetic crates.
+//!
+//! A check that has only ever been green proves nothing, and this repository has shipped several
+//! (al8n/smear#73, #122). So the cases below are written as crates and run through the same
+//! [`census::detect`](crate::census::detect) a real run uses — the file walk, the re-export
+//! resolution, the source-position derivation and the four tests, end to end. Nothing is stubbed;
+//! if the reader stops finding public entries, these fail first.
+//!
+//! Two of the cases are the discrimination al8n/smear#122 asks for by name: `Executor::start`'s
+//! `operation: Option<&str>` must come out a datum and the three narrowed doors must come out
+//! findings, in signatures shaped like the real ones.
+
+use std::{
+  fs,
+  path::{Path, PathBuf},
+};
+
+use crate::{
+  census::{self, Verdict},
+  exempt,
+};
+
+/// `(entry, parameter, verdict, a fragment the explanation must contain)`.
+///
+/// The fragment is what keeps a case from passing for the wrong reason: several of these could
+/// come out with the right verdict off the wrong test, and a rule that is right by accident is
+/// one refactor away from being wrong in silence.
+type Want = (&'static str, &'static str, Verdict, &'static str);
+
+struct Case {
+  name: &'static str,
+  source: &'static str,
+  wants: &'static [Want],
+  /// Entries the census must NOT report at all, at any verdict.
+  absent: &'static [&'static str],
+}
+
+/// A miniature of the crate's real shape: a source-generic substrate, a source-generic executor,
+/// and doors on top of it.
+const SUBSTRATE: &str = r#"
+pub mod ast {
+  pub struct ExecutableDocument<S> { pub source: S }
+  pub struct Parse { pub green: u32 }
+  pub struct Schema { pub names: u32 }
+}
+pub mod sink {
+  pub trait Sink<S> { fn emit(&mut self, value: S); }
+}
+pub mod syntactic {
+  use super::ast::{ExecutableDocument, Schema};
+  use super::sink::Sink;
+  pub fn validate_executable<S, K>(schema: &Schema, document: &ExecutableDocument<S>, sink: &mut K)
+  where
+    S: AsRef<[u8]> + Clone,
+    K: Sink<S>,
+  { let _ = (schema, document, sink); }
+}
+"#;
+
+const CASES: &[Case] = &[
+  Case {
+    name: "a free entry taking the document at `&str` is a narrowing",
+    source: r#"
+      pub mod door {
+        use crate::ast::Parse;
+        pub fn validate_schema_lossless(parse: &Parse, source: &str) -> u32 {
+          let _ = (parse, source);
+          0
+        }
+      }
+    "#,
+    wants: &[(
+      "validate_schema_lossless",
+      "source",
+      Verdict::Narrowed,
+      "test 2",
+    )],
+    absent: &[],
+  },
+  Case {
+    name: "a source-generic family applied to a concrete text type is a narrowing (test 1)",
+    source: r#"
+      pub mod door {
+        use crate::ast::Parse;
+        use crate::sink::Sink;
+        pub fn validate_executable_lossless<'src, K>(parse: &Parse, buffer: &'src str, sink: &mut K)
+        where
+          K: Sink<&'src str>,
+        { let _ = (parse, buffer, sink); }
+      }
+    "#,
+    // `buffer` is in no lexicon and the entry holds nothing generically, so only the
+    // `Sink<&'src str>` bound can convict it. That is test 1 on its own.
+    wants: &[(
+      "validate_executable_lossless",
+      "buffer",
+      Verdict::Narrowed,
+      "test 1 — `Sink` carries a source position",
+    )],
+    absent: &[],
+  },
+  Case {
+    name: "a lookup key on a source-generic receiver is a datum (test 3, `Executor::start`)",
+    source: r#"
+      pub mod exec {
+        use crate::ast::{ExecutableDocument, Schema};
+        pub struct Executor<'a, S, V> {
+          pub schema: &'a Schema,
+          pub document: &'a ExecutableDocument<S>,
+          pub values: core::marker::PhantomData<V>,
+        }
+        impl<'a, S, V> Executor<'a, S, V>
+        where
+          S: AsRef<[u8]>,
+        {
+          pub fn start(&mut self, operation: Option<&str>, root: u32) -> Result<(), u32> {
+            let _ = (operation, root);
+            Ok(())
+          }
+          pub fn handle_field_error(&mut self, id: u32, message: &str) { let _ = (id, message); }
+        }
+      }
+    "#,
+    wants: &[
+      ("Executor::start", "operation", Verdict::Datum, "test 3"),
+      (
+        "Executor::handle_field_error",
+        "message",
+        Verdict::Datum,
+        "test 3",
+      ),
+    ],
+    absent: &[],
+  },
+  Case {
+    name: "the lexicon convicts a document handed to a source-generic receiver (test 2 beats 3)",
+    source: r#"
+      pub mod exec {
+        use crate::ast::{ExecutableDocument, Schema};
+        pub struct Executor<'a, S, V> {
+          pub schema: &'a Schema,
+          pub document: &'a ExecutableDocument<S>,
+          pub values: core::marker::PhantomData<V>,
+        }
+        impl<'a, S, V> Executor<'a, S, V>
+        where
+          S: AsRef<[u8]>,
+        {
+          pub fn parse_extension(&mut self, sdl: &str) { let _ = sdl; }
+        }
+      }
+    "#,
+    wants: &[(
+      "Executor::parse_extension",
+      "sdl",
+      Verdict::Narrowed,
+      "test 2",
+    )],
+    absent: &[],
+  },
+  Case {
+    name: "a byte view imposes nothing and is neutral",
+    source: r#"
+      pub mod repr {
+        pub struct Table { pub n: u32 }
+        impl Table {
+          pub fn sym(&self, bytes: &[u8]) -> Option<u32> { let _ = bytes; None }
+        }
+      }
+    "#,
+    wants: &[("Table::sym", "bytes", Verdict::Neutral, "byte view")],
+    absent: &[],
+  },
+  Case {
+    name: "an owned representation is a narrowing even though it is not `&str`",
+    source: r#"
+      pub mod door {
+        pub fn load(payload: alloc_shim::Vec<u8>) -> u32 { let _ = payload; 0 }
+      }
+      pub mod alloc_shim { pub use std::vec::Vec; }
+    "#,
+    wants: &[("load", "payload", Verdict::Narrowed, "test 2")],
+    absent: &[],
+  },
+  Case {
+    name: "`&mut` is an output buffer and `'static` is a constant",
+    source: r#"
+      pub mod door {
+        pub fn render(out: &mut String, space: &'static str) { let _ = (out, space); }
+      }
+    "#,
+    wants: &[
+      ("render", "out", Verdict::Datum, "output buffer"),
+      ("render", "space", Verdict::Datum, "'static"),
+    ],
+    absent: &[],
+  },
+  Case {
+    name: "a private entry and a `#[doc(hidden)]` entry are not public surface",
+    source: r#"
+      mod hidden_module {
+        pub fn invisible(source: &str) { let _ = source; }
+      }
+      pub mod visible {
+        #[doc(hidden)]
+        pub fn also_invisible(source: &str) { let _ = source; }
+        pub(crate) fn not_public(source: &str) { let _ = source; }
+      }
+    "#,
+    wants: &[],
+    absent: &["invisible", "also_invisible", "not_public"],
+  },
+  Case {
+    name: "a `pub use` of a private module's item makes that item public surface",
+    source: r#"
+      pub mod outer {
+        mod inner;
+        pub use inner::reexported;
+      }
+    "#,
+    wants: &[("reexported", "source", Verdict::Narrowed, "test 2")],
+    absent: &[],
+  },
+  Case {
+    name: "an entry generic over the source reports nothing at all",
+    source: r#"
+      pub mod door {
+        use crate::ast::ExecutableDocument;
+        pub fn validate<S: AsRef<[u8]>>(document: &ExecutableDocument<S>, name: &[u8]) -> u32 {
+          let _ = (document, name);
+          0
+        }
+      }
+    "#,
+    wants: &[("validate", "name", Verdict::Neutral, "byte view")],
+    absent: &[],
+  },
+];
+
+/// The extra file the `pub use` case needs, keyed by the case's module layout.
+const INNER_RS: &str = r#"
+pub fn reexported(source: &str) -> u32 { let _ = source; 0 }
+pub fn not_reexported(source: &str) -> u32 { let _ = source; 0 }
+"#;
+
+/// Runs every case and returns how many ran, or the list of disagreements.
+pub fn run() -> Result<usize, Vec<String>> {
+  let mut problems = Vec::new();
+  let root = scratch_dir();
+
+  for (index, case) in CASES.iter().enumerate() {
+    let dir = root.join(format!("case{index}"));
+    if let Err(message) = lay_out(&dir, case) {
+      problems.push(format!("{}: {message}", case.name));
+      continue;
+    }
+    let report = match census::detect(&dir.join("lib.rs"), "probe") {
+      Ok(report) => report,
+      Err(message) => {
+        problems.push(format!(
+          "{}: the census could not read it: {message}",
+          case.name
+        ));
+        continue;
+      }
+    };
+    for (entry, param, want, because) in case.wants {
+      let found = report
+        .observations
+        .iter()
+        .find(|o| o.entry == *entry && o.param == *param);
+      match found {
+        None => problems.push(format!(
+          "{}: `{entry}`'s `{param}` was not reported at all — the reader did not reach it, so \
+           the case tested nothing",
+          case.name
+        )),
+        Some(o) if o.verdict != *want => problems.push(format!(
+          "{}: `{entry}`'s `{param}` came out {:?}, wanted {want:?} ({})",
+          case.name, o.verdict, o.why
+        )),
+        Some(o) if !o.why.contains(because) => problems.push(format!(
+          "{}: `{entry}`'s `{param}` came out {want:?} for the wrong reason — wanted {because:?}, \
+           got {:?}",
+          case.name, o.why
+        )),
+        Some(_) => {}
+      }
+    }
+    for entry in case.absent {
+      if report.observations.iter().any(|o| o.entry == *entry) {
+        problems.push(format!(
+          "{}: `{entry}` was reported, and it is not public surface",
+          case.name
+        ));
+      }
+    }
+  }
+
+  problems.extend(table_cases());
+  let _ = fs::remove_dir_all(&root);
+
+  if problems.is_empty() {
+    Ok(CASES.len() + TABLE_CASES)
+  } else {
+    Err(problems)
+  }
+}
+
+/// How many checks [`table_cases`] makes, for the count the selftest prints.
+const TABLE_CASES: usize = 3;
+
+/// The table's own guards, exercised against deliberately broken records.
+fn table_cases() -> Vec<String> {
+  let mut problems = Vec::new();
+
+  if !exempt::validate().is_empty() {
+    problems.push(format!(
+      "the shipped exemption table does not pass its own validation: {:?}",
+      exempt::validate()
+    ));
+  }
+
+  let short = exempt::Exemption {
+    module: "m",
+    entry: "e",
+    param: "p",
+    kind: exempt::Kind::Structural,
+    issue: None,
+    reason: "rowan",
+  };
+  if exempt::check_one(&short, 0).is_empty() {
+    problems.push(
+      "a one-word reason passed validation — an exemption could then be recorded without an \
+       argument, which is the omission this table exists to prevent"
+        .to_string(),
+    );
+  }
+
+  let untracked = exempt::Exemption {
+    module: "m",
+    entry: "e",
+    param: "p",
+    kind: exempt::Kind::Tracked,
+    issue: None,
+    reason: "A narrowing that is expected to go away once the door is widened, some day, \
+             by somebody.",
+  };
+  if exempt::check_one(&untracked, 0).is_empty() {
+    problems.push(
+      "a tracked narrowing with no issue passed validation — that is debt with nowhere to be paid"
+        .to_string(),
+    );
+  }
+
+  problems
+}
+
+fn lay_out(dir: &Path, case: &Case) -> Result<(), String> {
+  let _ = fs::remove_dir_all(dir);
+  fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+  let lib = format!("{SUBSTRATE}\n{}\n", case.source);
+  fs::write(dir.join("lib.rs"), lib).map_err(|e| e.to_string())?;
+  if case.source.contains("mod inner;") {
+    fs::create_dir_all(dir.join("outer")).map_err(|e| e.to_string())?;
+    fs::write(dir.join("outer").join("inner.rs"), INNER_RS).map_err(|e| e.to_string())?;
+  }
+  Ok(())
+}
+
+fn scratch_dir() -> PathBuf {
+  let stamp = std::time::SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .map(|d| d.as_nanos())
+    .unwrap_or_default();
+  let dir = std::env::temp_dir().join(format!(
+    "source-census-selftest-{stamp}-{}",
+    std::process::id()
+  ));
+  let _ = fs::create_dir_all(&dir);
+  dir
+}

--- a/ci/source_census/src/surface.rs
+++ b/ci/source_census/src/surface.rs
@@ -1,0 +1,615 @@
+//! The crate's public surface, read out of the source rather than written down.
+//!
+//! Two things are derived here and nowhere else in this tool: which modules a consumer can name,
+//! and which functions inside them a consumer can call. Both have to come from the code. A list of
+//! entries to check is the same defect the census exists to catch, one level up — it agrees with
+//! the crate on the day it is written and goes stale in silence afterwards (al8n/smear#122).
+//!
+//! # What counts as reachable
+//!
+//! A module is reachable when every `mod` on the path from the crate root to it is `pub`. A
+//! `pub(crate)`, `pub(super)` or `pub(in …)` module is not: nothing outside the crate can name it,
+//! so a `&str` inside constrains nobody.
+//!
+//! `mod m; pub use m::{A, B};` — the shape `validator/mod.rs` and `schema/mod.rs` both use — makes
+//! `A` and `B` public while `m` stays private, so a private module's items are read too, filtered
+//! by what the re-export names. A glob re-export takes the module whole.
+//!
+//! An inherent `impl` contributes its `pub fn`s whenever the type it is on is publicly nameable,
+//! wherever that `impl` block happens to live: Rust does not care that `impl Schema` for a
+//! re-exported `Schema` sits in a private module.
+//!
+//! # What is deliberately not read
+//!
+//! * `#[cfg(test)]` items. Not API.
+//! * `#[doc(hidden)]` items. That attribute is the crate's own statement that something is not
+//!   API, and it is how the `test-support` coverage harnesses under `parser::*::lossless` are
+//!   spelled. Reading the attribute rather than naming those modules keeps this derived.
+//! * Items produced by a `macro_rules!` expansion. `syn` sees the macro's tokens, not the items
+//!   they become, so a public entry that only exists after expansion is invisible here. That is a
+//!   real bound on the census and it is reported on every run rather than left to be discovered.
+//! * Trait `impl` blocks. A trait impl cannot choose its own signature — the `trait` declaration
+//!   does, and that declaration is read.
+
+use std::{
+  collections::BTreeSet,
+  path::{Path, PathBuf},
+};
+
+use quote::ToTokens as _;
+use syn::{Item, UseTree, Visibility};
+
+/// One module of the crate under census, with the items written in it.
+pub struct Module {
+  /// `["smear", "validator", "lossless"]`.
+  pub path: Vec<String>,
+  /// The file the module's body was read from. Inline modules share their parent's.
+  pub file: PathBuf,
+  pub items: Vec<Item>,
+  /// Every `mod` from the crate root to here is `pub`, and none carries `#[doc(hidden)]`.
+  pub named_by_path: bool,
+}
+
+impl Module {
+  pub fn display_path(&self) -> String {
+    self.path.join("::")
+  }
+}
+
+/// Everything the census needs to know about who can call what.
+pub struct Surface {
+  pub modules: Vec<Module>,
+  /// Fully-qualified paths of items a `pub use` in a reachable module makes public.
+  exported_items: BTreeSet<Vec<String>>,
+  /// Modules taken whole by a `pub use m::*` in a reachable module.
+  glob_exported: BTreeSet<Vec<String>>,
+  /// Idents of publicly nameable types, for matching inherent `impl` blocks against.
+  pub public_types: BTreeSet<String>,
+  /// Files read, and item-position macro invocations found in them.
+  ///
+  /// The second is the census's blind spot, counted so that it is stated on every run rather than
+  /// assumed away: `syn` sees a macro's tokens, not the items they expand to, so a public entry
+  /// that exists only after expansion is not censused. Measured on this crate the expansions are
+  /// either `pub(crate)` (`lossless_production!`) or `#[cfg(feature = "test-support")]
+  /// #[doc(hidden)]` (`lossless_drivers!`), so nothing public hides there today — but "today" is
+  /// exactly the kind of claim this tool exists to stop trusting, so the count is printed.
+  pub files_read: usize,
+  pub macro_invocations: usize,
+}
+
+/// Reads the crate rooted at `lib_rs` into a [`Surface`].
+pub fn load(lib_rs: &Path, crate_name: &str) -> Result<Surface, String> {
+  let mut modules = Vec::new();
+  let mut macro_invocations = 0usize;
+  let children_dir = lib_rs
+    .parent()
+    .ok_or_else(|| format!("{} has no parent directory", lib_rs.display()))?
+    .to_path_buf();
+
+  read_module(
+    lib_rs,
+    &children_dir,
+    vec![crate_name.to_string()],
+    true,
+    &mut modules,
+    &mut macro_invocations,
+  )?;
+
+  let mut surface = Surface {
+    files_read: modules
+      .iter()
+      .map(|m| m.file.clone())
+      .collect::<BTreeSet<_>>()
+      .len(),
+    modules,
+    exported_items: BTreeSet::new(),
+    glob_exported: BTreeSet::new(),
+    public_types: BTreeSet::new(),
+    macro_invocations,
+  };
+  surface.resolve_reexports();
+  surface.collect_public_types();
+  Ok(surface)
+}
+
+/// Parses one file and reads it as a module.
+fn read_module(
+  file: &Path,
+  children_dir: &Path,
+  path: Vec<String>,
+  named_by_path: bool,
+  out: &mut Vec<Module>,
+  macro_invocations: &mut usize,
+) -> Result<(), String> {
+  let text = std::fs::read_to_string(file).map_err(|e| format!("{}: {e}", file.display()))?;
+  let parsed =
+    syn::parse_file(&text).map_err(|e| format!("{}: not parseable Rust: {e}", file.display()))?;
+  read_items(
+    parsed.items,
+    file,
+    children_dir,
+    path,
+    named_by_path,
+    out,
+    macro_invocations,
+  )
+}
+
+/// Records one module's own items and descends into the `mod`s it declares, inline or not.
+///
+/// Written over items rather than over files so that an inline `mod` is the same case as a file
+/// one at any depth: its children resolve under `<children_dir>/<name>/`, and its own `mod`s
+/// recurse here again.
+fn read_items(
+  items: Vec<Item>,
+  file: &Path,
+  children_dir: &Path,
+  path: Vec<String>,
+  named_by_path: bool,
+  out: &mut Vec<Module>,
+  macro_invocations: &mut usize,
+) -> Result<(), String> {
+  let mut own = Vec::new();
+  let mut mods: Vec<syn::ItemMod> = Vec::new();
+
+  for item in items {
+    if is_cfg_test(attrs_of(&item)) {
+      continue;
+    }
+    match item {
+      Item::Mod(m) => mods.push(m),
+      // An item-position macro INVOCATION carries no ident; a `macro_rules!` definition does.
+      Item::Macro(ref m) if m.ident.is_none() => {
+        *macro_invocations += 1;
+        own.push(item);
+      }
+      other => own.push(other),
+    }
+  }
+
+  out.push(Module {
+    path: path.clone(),
+    file: file.to_path_buf(),
+    items: own,
+    named_by_path,
+  });
+
+  for m in mods {
+    let name = m.ident.to_string();
+    let child_public =
+      named_by_path && matches!(m.vis, Visibility::Public(_)) && !is_doc_hidden(&m.attrs);
+    let mut child_path = path.clone();
+    child_path.push(name.clone());
+
+    match m.content {
+      Some((_, inner)) => read_items(
+        inner,
+        file,
+        &children_dir.join(&name),
+        child_path,
+        child_public,
+        out,
+        macro_invocations,
+      )?,
+      None => {
+        let (child_file, child_children_dir) = resolve_module_file(children_dir, &m)?;
+        read_module(
+          &child_file,
+          &child_children_dir,
+          child_path,
+          child_public,
+          out,
+          macro_invocations,
+        )?;
+      }
+    }
+  }
+
+  Ok(())
+}
+
+/// `mod m;` in a module whose children live in `dir` — `dir/m.rs` or `dir/m/mod.rs`, or whatever
+/// `#[path = "…"]` says.
+fn resolve_module_file(dir: &Path, m: &syn::ItemMod) -> Result<(PathBuf, PathBuf), String> {
+  if let Some(explicit) = path_attr(&m.attrs) {
+    let file = dir.join(&explicit);
+    let children = file
+      .parent()
+      .map(Path::to_path_buf)
+      .unwrap_or_else(|| dir.to_path_buf());
+    return Ok((file, children));
+  }
+  let name = m.ident.to_string();
+  let flat = dir.join(format!("{name}.rs"));
+  if flat.is_file() {
+    return Ok((flat, dir.join(&name)));
+  }
+  let nested = dir.join(&name).join("mod.rs");
+  if nested.is_file() {
+    return Ok((nested, dir.join(&name)));
+  }
+  Err(format!(
+    "`mod {name};` resolves to neither {} nor {} — the census cannot read a module it cannot \
+     find, and skipping it would hide whatever is inside",
+    flat.display(),
+    nested.display()
+  ))
+}
+
+impl Surface {
+  /// Walks every `pub use` in a reachable module and records what it makes public.
+  fn resolve_reexports(&mut self) {
+    let known: BTreeSet<Vec<String>> = self.modules.iter().map(|m| m.path.clone()).collect();
+    let mut items = BTreeSet::new();
+    let mut globs = BTreeSet::new();
+
+    for module in &self.modules {
+      if !module.named_by_path {
+        continue;
+      }
+      for item in &module.items {
+        let Item::Use(u) = item else { continue };
+        if !matches!(u.vis, Visibility::Public(_)) {
+          continue;
+        }
+        let mut leaves = Vec::new();
+        walk_use(&u.tree, &mut Vec::new(), &mut leaves);
+        for (prefix, leaf) in leaves {
+          let Some(base) = resolve_path(&prefix, &module.path, &known) else {
+            continue;
+          };
+          match leaf {
+            Leaf::Glob => {
+              globs.insert(base);
+            }
+            Leaf::Name(name) => {
+              let mut full = base;
+              full.push(name);
+              items.insert(full);
+            }
+          }
+        }
+      }
+    }
+
+    self.exported_items = items;
+    self.glob_exported = globs;
+  }
+
+  /// Idents of every publicly nameable type, so an inherent `impl` can be matched to one.
+  fn collect_public_types(&mut self) {
+    let mut types = BTreeSet::new();
+    for module in &self.modules {
+      for item in &module.items {
+        let Some((ident, vis)) = type_decl(item) else {
+          continue;
+        };
+        if !matches!(vis, Visibility::Public(_)) || is_doc_hidden(attrs_of(item)) {
+          continue;
+        }
+        if self.item_is_public(&module.path, &ident, module.named_by_path) {
+          types.insert(ident);
+        }
+      }
+    }
+    // A `pub use` can also name a type that lives behind a private module and is not declared
+    // `pub` in a module this loop reaches, so take the re-exported leaf names as well. Over-
+    // matching here is harmless: a re-exported `const MAX_SYMBOLS` lands in the set and no `impl`
+    // block ever names it, so nothing extra is read.
+    for path in &self.exported_items {
+      if let Some(last) = path.last()
+        && last.starts_with(|c: char| c.is_ascii_uppercase())
+      {
+        types.insert(last.clone());
+      }
+    }
+    self.public_types = types;
+  }
+
+  /// Can a consumer name `module::name`?
+  pub fn item_is_public(&self, module: &[String], name: &str, named_by_path: bool) -> bool {
+    if named_by_path {
+      return true;
+    }
+    if self.glob_exported.contains(module) {
+      return true;
+    }
+    let mut full = module.to_vec();
+    full.push(name.to_string());
+    self.exported_items.contains(&full)
+  }
+}
+
+enum Leaf {
+  Name(String),
+  Glob,
+}
+
+/// Flattens a `use` tree into `(prefix, leaf)` pairs.
+fn walk_use(tree: &UseTree, prefix: &mut Vec<String>, out: &mut Vec<(Vec<String>, Leaf)>) {
+  match tree {
+    UseTree::Path(p) => {
+      prefix.push(p.ident.to_string());
+      walk_use(&p.tree, prefix, out);
+      prefix.pop();
+    }
+    UseTree::Name(n) => out.push((prefix.clone(), Leaf::Name(n.ident.to_string()))),
+    UseTree::Rename(r) => out.push((prefix.clone(), Leaf::Name(r.ident.to_string()))),
+    UseTree::Glob(_) => out.push((prefix.clone(), Leaf::Glob)),
+    UseTree::Group(g) => {
+      for tree in &g.items {
+        walk_use(tree, prefix, out);
+      }
+    }
+  }
+}
+
+/// Turns a `use` prefix into an absolute module path, or `None` when it leaves the crate.
+fn resolve_path(
+  prefix: &[String],
+  here: &[String],
+  known: &BTreeSet<Vec<String>>,
+) -> Option<Vec<String>> {
+  let crate_name = here.first()?;
+  let mut out: Vec<String>;
+  let rest: &[String];
+
+  match prefix.first().map(String::as_str) {
+    None => return Some(here.to_vec()),
+    Some("crate") => {
+      out = vec![crate_name.clone()];
+      rest = &prefix[1..];
+    }
+    Some("self") => {
+      out = here.to_vec();
+      rest = &prefix[1..];
+    }
+    Some("super") => {
+      out = here.to_vec();
+      out.pop()?;
+      rest = &prefix[1..];
+    }
+    Some(first) => {
+      let mut candidate = here.to_vec();
+      candidate.push(first.to_string());
+      if !known.contains(&candidate) {
+        // Another crate, or a re-export of one. Nothing here to census.
+        return None;
+      }
+      out = candidate;
+      rest = &prefix[1..];
+    }
+  }
+
+  for segment in rest {
+    if segment == "super" {
+      out.pop()?;
+    } else {
+      out.push(segment.clone());
+    }
+  }
+  Some(out)
+}
+
+pub fn attrs_of(item: &Item) -> &[syn::Attribute] {
+  match item {
+    Item::Const(i) => &i.attrs,
+    Item::Enum(i) => &i.attrs,
+    Item::ExternCrate(i) => &i.attrs,
+    Item::Fn(i) => &i.attrs,
+    Item::ForeignMod(i) => &i.attrs,
+    Item::Impl(i) => &i.attrs,
+    Item::Macro(i) => &i.attrs,
+    Item::Mod(i) => &i.attrs,
+    Item::Static(i) => &i.attrs,
+    Item::Struct(i) => &i.attrs,
+    Item::Trait(i) => &i.attrs,
+    Item::TraitAlias(i) => &i.attrs,
+    Item::Type(i) => &i.attrs,
+    Item::Union(i) => &i.attrs,
+    Item::Use(i) => &i.attrs,
+    _ => &[],
+  }
+}
+
+fn type_decl(item: &Item) -> Option<(String, &Visibility)> {
+  match item {
+    Item::Struct(i) => Some((i.ident.to_string(), &i.vis)),
+    Item::Enum(i) => Some((i.ident.to_string(), &i.vis)),
+    Item::Union(i) => Some((i.ident.to_string(), &i.vis)),
+    Item::Type(i) => Some((i.ident.to_string(), &i.vis)),
+    Item::Trait(i) => Some((i.ident.to_string(), &i.vis)),
+    _ => None,
+  }
+}
+
+pub fn is_doc_hidden(attrs: &[syn::Attribute]) -> bool {
+  attrs.iter().any(|a| {
+    if !a.path().is_ident("doc") {
+      return false;
+    }
+    let mut hidden = false;
+    let _ = a.parse_nested_meta(|meta| {
+      if meta.path.is_ident("hidden") {
+        hidden = true;
+      }
+      Ok(())
+    });
+    hidden
+  })
+}
+
+/// `#[cfg(test)]` and `#[cfg(all(test, …))]`, which are not API under any feature set.
+///
+/// The bare identifier is what is looked for, so `feature = "test-support"` — a string literal —
+/// cannot be mistaken for it. That distinction is load-bearing: `test-support` items ARE compiled
+/// into a shipped build when a consumer turns the feature on, and they are excluded by
+/// `#[doc(hidden)]` instead, which is what the crate itself uses to say they are not API.
+fn is_cfg_test(attrs: &[syn::Attribute]) -> bool {
+  fn mentions_test(tokens: proc_macro2::TokenStream) -> bool {
+    tokens.into_iter().any(|tt| match tt {
+      proc_macro2::TokenTree::Ident(id) => id == "test",
+      proc_macro2::TokenTree::Group(g) => mentions_test(g.stream()),
+      _ => false,
+    })
+  }
+  attrs
+    .iter()
+    .any(|a| a.path().is_ident("cfg") && mentions_test(a.meta.to_token_stream()))
+}
+
+fn path_attr(attrs: &[syn::Attribute]) -> Option<String> {
+  for a in attrs {
+    if !a.path().is_ident("path") {
+      continue;
+    }
+    if let syn::Meta::NameValue(nv) = &a.meta
+      && let syn::Expr::Lit(syn::ExprLit {
+        lit: syn::Lit::Str(s),
+        ..
+      }) = &nv.value
+    {
+      return Some(s.value());
+    }
+  }
+  None
+}
+
+/// A `pub fn` template inside a `macro_rules!` body, with a concrete text parameter.
+///
+/// The census's one real blind spot: `syn` sees a macro's tokens, not the items they become, so a
+/// public entry that exists only after expansion is not read by anything above. Rather than record
+/// that as a caveat and move on, the templates themselves are scanned — a `pub fn` written inside
+/// a `macro_rules!` with a `&str` parameter narrows every entry it expands to, and it is visible
+/// in the tokens whether or not the expansion is.
+pub struct MacroTemplate {
+  pub macro_name: String,
+  pub file: String,
+  pub line: usize,
+  pub param: String,
+  pub rendered: String,
+  /// The parameter is `&'static str`, so it is a compile-time constant like any other.
+  pub konstant: bool,
+  /// The macro body carries `doc(hidden)`, so what it expands to is not API.
+  pub doc_hidden: bool,
+}
+
+/// Reads every `macro_rules!` in the crate for `pub fn` templates taking concrete text.
+pub fn macro_templates(surface: &Surface) -> Vec<MacroTemplate> {
+  let mut out = Vec::new();
+  for module in &surface.modules {
+    for item in &module.items {
+      let Item::Macro(m) = item else { continue };
+      let Some(name) = &m.ident else { continue };
+      let tokens: Vec<proc_macro2::TokenTree> = flatten(m.mac.tokens.clone());
+      let doc_hidden = mentions_ident(&tokens, "doc") && mentions_ident(&tokens, "hidden");
+      for (param, rendered, konstant, line) in text_params_of_pub_fns(&tokens) {
+        out.push(MacroTemplate {
+          macro_name: name.to_string(),
+          file: module.file.display().to_string(),
+          line,
+          param,
+          rendered,
+          konstant,
+          doc_hidden,
+        });
+      }
+    }
+  }
+  out
+}
+
+/// Every token in the stream, groups included, in source order.
+fn flatten(stream: proc_macro2::TokenStream) -> Vec<proc_macro2::TokenTree> {
+  let mut out = Vec::new();
+  for tt in stream {
+    if let proc_macro2::TokenTree::Group(g) = &tt {
+      out.push(tt.clone());
+      out.extend(flatten(g.stream()));
+    } else {
+      out.push(tt);
+    }
+  }
+  out
+}
+
+fn mentions_ident(tokens: &[proc_macro2::TokenTree], want: &str) -> bool {
+  tokens
+    .iter()
+    .any(|tt| matches!(tt, proc_macro2::TokenTree::Ident(id) if id == want))
+}
+
+/// `(parameter name, rendered type, is `'static`, line)` for each `pub fn(… : &str …)` template.
+///
+/// `pub` IMMEDIATELY followed by `fn` is what makes this public-only: `pub(crate) fn` puts a
+/// parenthesised group between the two.
+fn text_params_of_pub_fns(tokens: &[proc_macro2::TokenTree]) -> Vec<(String, String, bool, usize)> {
+  use proc_macro2::{Delimiter, TokenTree};
+  let mut out = Vec::new();
+  for index in 0..tokens.len().saturating_sub(1) {
+    let (TokenTree::Ident(first), TokenTree::Ident(second)) = (&tokens[index], &tokens[index + 1])
+    else {
+      continue;
+    };
+    if first != "pub" || second != "fn" {
+      continue;
+    }
+    let params = tokens[index + 2..].iter().find_map(|tt| match tt {
+      TokenTree::Group(g) if g.delimiter() == Delimiter::Parenthesis => Some(g.clone()),
+      _ => None,
+    });
+    let Some(params) = params else { continue };
+    for chunk in split_top_level(params.stream()) {
+      let mentions_text = chunk
+        .iter()
+        .any(|tt| matches!(tt, TokenTree::Ident(id) if id == "str" || id == "String"));
+      if !mentions_text {
+        continue;
+      }
+      let konstant = chunk
+        .iter()
+        .any(|tt| matches!(tt, TokenTree::Ident(id) if id == "static"));
+      let name = match chunk.first() {
+        Some(TokenTree::Ident(id)) => id.to_string(),
+        _ => "<pattern>".to_string(),
+      };
+      let rendered = tidy(
+        &chunk
+          .iter()
+          .map(std::string::ToString::to_string)
+          .collect::<Vec<_>>()
+          .join(" "),
+      );
+      out.push((name, rendered, konstant, params.span().start().line));
+    }
+  }
+  out
+}
+
+/// Undoes the whitespace `TokenTree::to_string` inserts, so a template reads like Rust.
+fn tidy(text: &str) -> String {
+  text
+    .replace(" : ", ": ")
+    .replace("& ", "&")
+    .replace("' ", "'")
+    .replace(" ::", "::")
+    .replace(":: ", "::")
+    .replace(" <", "<")
+    .replace("< ", "<")
+    .replace(" >", ">")
+    .replace(" ,", ",")
+}
+
+/// Splits a token stream on top-level commas.
+fn split_top_level(stream: proc_macro2::TokenStream) -> Vec<Vec<proc_macro2::TokenTree>> {
+  let mut out = vec![Vec::new()];
+  for tt in stream {
+    if matches!(&tt, proc_macro2::TokenTree::Punct(p) if p.as_char() == ',') {
+      out.push(Vec::new());
+    } else {
+      out.last_mut().expect("always one open chunk").push(tt);
+    }
+  }
+  out.retain(|chunk| !chunk.is_empty());
+  out
+}

--- a/ci/source_census/src/tests.rs
+++ b/ci/source_census/src/tests.rs
@@ -1,0 +1,17 @@
+//! The selftest, as a `cargo test` target as well as a `--selftest` flag.
+//!
+//! `ci/miri_scope.py` runs its selftest first inside the job it guards, before anything expensive,
+//! and the census does the same — the CI step calls `--selftest` before the census proper. Running
+//! the identical cases here as well is what puts them in `cargo test --workspace --all-features`,
+//! so a change to the rule that breaks the discrimination fails on a developer's machine and not
+//! only in the job.
+
+use crate::selftest;
+
+#[test]
+fn the_rule_discriminates() {
+  match selftest::run() {
+    Ok(cases) => assert!(cases > 0, "the selftest ran no cases"),
+    Err(problems) => panic!("{}", problems.join("\n")),
+  }
+}


### PR DESCRIPTION
Closes #122.
