### PR TITLE
fix(lexer)!: a measured nesting ceiling, so a valid document stops aborting the process

### DIFF
--- a/smear-lexer/src/graphql/handlers/mod.rs
+++ b/smear-lexer/src/graphql/handlers/mod.rs
@@ -1,13 +1,14 @@
 use tokora::{
   error::{UnexpectedEnd, UnexpectedLexeme},
   logos::{Lexer, Logos, Source},
-  state::tracker::{LimitExceeded, Limiter},
+  state::tracker::LimitExceeded,
   utils::Lexeme,
 };
 
 use crate::{
   handlers::{self, ValidateNumberChar, handle_number_suffix},
   hints::FloatHint,
+  limits::LosslessLimits,
 };
 
 use super::error;
@@ -20,7 +21,7 @@ pub(super) fn increase_recursion_depth_and_token<'a, C, T>(
   lexer: &mut Lexer<'a, T>,
 ) -> Result<(), error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::increase_recursion_depth_and_token(lexer)
 }
@@ -31,7 +32,7 @@ pub(super) fn tt_hook_and_then<'a, C, T, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> Result<O, error::LexerError<C, LimitExceeded>>,
 ) -> Result<O, error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook_and_then(lexer, f)
 }
@@ -43,7 +44,7 @@ pub(super) fn tt_hook_and_then_into_errors<'a, C, T, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> Result<O, error::LexerErrors<C, LimitExceeded>>,
 ) -> Result<O, error::LexerErrors<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook_and_then_into_errors(lexer, f)
 }
@@ -54,7 +55,7 @@ pub(super) fn tt_hook_map<'a, C, T, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> O,
 ) -> Result<O, error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook_map(lexer, f)
 }
@@ -64,7 +65,7 @@ pub(super) fn tt_hook<'a, C, T>(
   lexer: &mut Lexer<'a, T>,
 ) -> Result<(), error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook(lexer)
 }

--- a/smear-lexer/src/graphql/handlers/slice.rs
+++ b/smear-lexer/src/graphql/handlers/slice.rs
@@ -1,11 +1,11 @@
 use crate::{
   handlers::{self, is_ignored_byte},
   hints::{ExponentHint, FloatHint},
+  limits::LosslessLimits,
 };
 use tokora::{
   SimpleSpan,
   logos::{Lexer, Logos, Source},
-  state::tracker::Limiter,
   utils::{Lexeme, PositionedChar},
 };
 
@@ -38,7 +38,7 @@ pub(crate) fn cst_default_error<'a, S, T, Extras>(
   lexer: &mut Lexer<'a, T>,
 ) -> error::LexerErrors<u8, Extras>
 where
-  T: Logos<'a, Source = S, Extras = Limiter>,
+  T: Logos<'a, Source = S, Extras = LosslessLimits>,
   S: ?Sized + Source,
   S::Slice<'a>: AsRef<[u8]>,
 {

--- a/smear-lexer/src/graphql/handlers/str.rs
+++ b/smear-lexer/src/graphql/handlers/str.rs
@@ -2,7 +2,6 @@ use super::error::{self, FloatError};
 use tokora::{
   SimpleSpan,
   logos::{Lexer, Logos, Source},
-  state::tracker::Limiter,
   utils::{Lexeme, PositionedChar},
 };
 
@@ -11,6 +10,7 @@ type Span = SimpleSpan;
 use crate::{
   handlers::{self, is_ignored_char},
   hints::{ExponentHint, FloatHint},
+  limits::LosslessLimits,
 };
 
 type LexerError<Extras> = error::LexerError<char, Extras>;
@@ -38,7 +38,7 @@ pub(crate) fn cst_default_error<'a, S, T, Extras>(
   lexer: &mut Lexer<'a, T>,
 ) -> error::LexerErrors<char, Extras>
 where
-  T: Logos<'a, Source = S, Extras = Limiter>,
+  T: Logos<'a, Source = S, Extras = LosslessLimits>,
   S: ?Sized + Source,
   S::Slice<'a>: AsRef<str>,
 {

--- a/smear-lexer/src/graphql/lossless/token.rs
+++ b/smear-lexer/src/graphql/lossless/token.rs
@@ -44,10 +44,11 @@ macro_rules! token_impl {
       #[allow(unused_imports)]
       use tokora::utils::IntoEquivalent;
       use tokora::{
-        logos::Logos, lexer::Lexable, state::tracker::{LimitExceeded, Limiter},
+        logos::Logos, lexer::Lexable, state::tracker::LimitExceeded,
       };
       use crate::{
         error::StringErrors,
+        limits::LosslessLimits,
         graphql::{
           error::{LexerErrors, LexerError, DecimalError, FloatError},
           handlers::{
@@ -97,7 +98,7 @@ macro_rules! token_impl {
       )]
       #[logos(
         crate = tokora::logos,
-        extras = Limiter,
+        extras = LosslessLimits,
         utf8 = $utf8,
         error(TokenErrors, handlers::$handlers::cst_default_error)
       )]
@@ -271,10 +272,11 @@ macro_rules! token_impl {
       #[allow(unused_imports)]
       use tokora::utils::IntoEquivalent;
       use tokora::{
-        logos::Logos, lexer::Lexable, state::tracker::{LimitExceeded, Limiter},
+        logos::Logos, lexer::Lexable, state::tracker::LimitExceeded,
       };
       use crate::{
         error::StringErrors,
+        limits::LosslessLimits,
         graphql::{
           error::{LexerErrors, LexerError, DecimalError, FloatError},
           handlers::{
@@ -324,7 +326,7 @@ macro_rules! token_impl {
       )]
       #[logos(
         crate = tokora::logos,
-        extras = Limiter,
+        extras = LosslessLimits,
         utf8 = $utf8,
         error(TokenErrors, handlers::$handlers::cst_default_error)
       )]

--- a/smear-lexer/src/graphql/syntactic/error_parity_tests.rs
+++ b/smear-lexer/src/graphql/syntactic/error_parity_tests.rs
@@ -13,7 +13,9 @@
 
 use std::string::String;
 
-use tokora::{Lexer, state::recursion_tracker::RecursionLimiter};
+use tokora::Lexer;
+
+use crate::limits::SyntacticLimits;
 
 use crate::graphql::syntactic::SyntacticLexer;
 
@@ -150,6 +152,6 @@ fn recursion_limit_region_matches_logos() {
 #20 is_err=false span=SimpleSpan { start: 20, end: 21 } slice=\")\"
 ";
   let simd =
-    SyntacticLexer::<str>::with_state(src.as_str(), RecursionLimiter::with_limitation(limit));
+    SyntacticLexer::<str>::with_state(src.as_str(), SyntacticLimits::with_max_nesting_depth(limit));
   assert_eq!(render_error_path(simd, &src), expected);
 }

--- a/smear-lexer/src/graphql/syntactic/mod.rs
+++ b/smear-lexer/src/graphql/syntactic/mod.rs
@@ -4,7 +4,7 @@ use tokora::{
   Lexer, SimpleSpan, Slice, Source, Token,
   lexer::{FromLogos, LogosLexer},
   punct::*,
-  state::recursion_tracker::{RecursionLimitExceeded, RecursionLimiter},
+  state::recursion_tracker::RecursionLimitExceeded,
   token::*,
   utils::{CharLen, DowncastRef},
 };
@@ -28,7 +28,11 @@ use super::{
 
 use self::number::NumberLexerToken;
 
-pub use crate::simd::DEFAULT_RECURSION_LIMIT;
+// The nesting ceiling and the budget that carries it, surfaced beside the lexer they govern.
+// This position used to hold `DEFAULT_RECURSION_LIMIT = 500`, a constant that only restated
+// tokora's inherited default and named no decision; smear issue #61 replaced it with one that is
+// derived, and with the type whose `Default` actually delivers it.
+pub use crate::limits::{MAX_NESTING_DEPTH, SyntacticLimits};
 
 /// The focused GraphQL number sub-lexer the SIMD lexer delegates malformed
 /// numbers to; see [`number::NumberToken`].
@@ -500,7 +504,7 @@ pub struct SyntacticLexer<'inp, S: ?Sized = str> {
   last_span: SimpleSpan,
   /// Span of the most recently returned error token, if any.
   last_error_span: Option<SimpleSpan>,
-  state: RecursionLimiter,
+  state: SyntacticLimits,
 }
 
 impl<'inp, S> Lexer<'inp> for SyntacticLexer<'inp, S>
@@ -515,7 +519,7 @@ where
   <S::Slice<'inp> as Slice<'inp>>::Char: CharLen,
   LogosLexer<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>: Lexer<
       'inp,
-      State = RecursionLimiter,
+      State = SyntacticLimits,
       Source = LogosSourceOf<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>,
       Token = NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>,
       Offset = usize,
@@ -523,7 +527,7 @@ where
   NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>: FromLogos<'inp>
     + Token<'inp, Error = LexerErrors<<S::Slice<'inp> as Slice<'inp>>::Char, RecursionLimitExceeded>>,
 {
-  type State = RecursionLimiter;
+  type State = SyntacticLimits;
 
   type Source = S;
 
@@ -905,7 +909,7 @@ where
   NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>: FromLogos<'inp>,
   LogosLexer<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>: Lexer<
       'inp,
-      State = RecursionLimiter,
+      State = SyntacticLimits,
       Source = LogosSourceOf<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>,
       Token = NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>,
       Offset = usize,

--- a/smear-lexer/src/graphql/syntactic/number.rs
+++ b/smear-lexer/src/graphql/syntactic/number.rs
@@ -84,7 +84,7 @@ macro_rules! number_token_impl {
     mod $mod {
       use tokora::{
         logos::Logos,
-        state::recursion_tracker::{RecursionLimitExceeded, RecursionLimiter},
+        state::recursion_tracker::RecursionLimitExceeded,
       };
       use crate::graphql::{
         error::{DecimalError, FloatError, LexerErrors},
@@ -100,7 +100,7 @@ macro_rules! number_token_impl {
       #[derive(Logos, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
       #[logos(
         crate = tokora::logos,
-        extras = RecursionLimiter,
+        extras = crate::limits::SyntacticLimits,
         skip r"[ \t,\r\n\u{FEFF}]+|#[^\n\r]*?",
         utf8 = $utf8,
         error(TokenErrors, handlers::$handlers::default_error)

--- a/smear-lexer/src/graphql/syntactic/tests.rs
+++ b/smear-lexer/src/graphql/syntactic/tests.rs
@@ -1,4 +1,6 @@
-use tokora::{Lexer, state::recursion_tracker::RecursionLimiter};
+use tokora::Lexer;
+
+use crate::limits::SyntacticLimits;
 
 use super::*;
 
@@ -178,8 +180,10 @@ fn test_recursion_limit() {
   let field = "a {".repeat(depth) + &"}".repeat(depth);
   let query = field.replace("{}", "{b}").to_string();
 
-  let mut lexer =
-    SyntacticLexer::<str>::with_state(query.as_str(), RecursionLimiter::with_limitation(depth - 1));
+  let mut lexer = SyntacticLexer::<str>::with_state(
+    query.as_str(),
+    SyntacticLimits::with_max_nesting_depth(depth - 1),
+  );
 
   loop {
     match lexer.lex() {

--- a/smear-lexer/src/graphql/syntactic/trait_parity_tests.rs
+++ b/smear-lexer/src/graphql/syntactic/trait_parity_tests.rs
@@ -19,7 +19,9 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::{format, string::String};
 
-use tokora::{Lexer, state::recursion_tracker::RecursionLimiter};
+use tokora::Lexer;
+
+use crate::limits::SyntacticLimits;
 
 use crate::graphql::syntactic::SyntacticLexer;
 
@@ -309,7 +311,7 @@ fn full_trait_parity_low_recursion_limit() {
   assert_eq!(
     render_full!(SyntacticLexer::<str>::with_state(
       src,
-      RecursionLimiter::with_limitation(limit)
+      SyntacticLimits::with_max_nesting_depth(limit)
     )),
     expected
   );
@@ -319,7 +321,7 @@ fn full_trait_parity_low_recursion_limit() {
   {
     let simd_panicked = panics(|| {
       let mut simd =
-        SyntacticLexer::<str>::with_state(src, RecursionLimiter::with_limitation(limit));
+        SyntacticLexer::<str>::with_state(src, SyntacticLimits::with_max_nesting_depth(limit));
       while simd.lex().is_some() {}
       simd.bump(&1usize);
     });

--- a/smear-lexer/src/graphqlx/handlers/mod.rs
+++ b/smear-lexer/src/graphqlx/handlers/mod.rs
@@ -1,13 +1,14 @@
 use tokora::{
   error::{UnexpectedEnd, UnexpectedLexeme},
   logos::{Lexer, Logos, Source},
-  state::tracker::{LimitExceeded, Limiter},
+  state::tracker::LimitExceeded,
   utils::Lexeme,
 };
 
 use crate::{
   handlers::{self, ValidateNumberChar, handle_number_suffix},
   hints::{FloatHint, HexFloatHint},
+  limits::LosslessLimits,
 };
 
 use super::error;
@@ -20,7 +21,7 @@ pub(super) fn increase_recursion_depth_and_token<'a, C, T>(
   lexer: &mut Lexer<'a, T>,
 ) -> Result<(), error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::increase_recursion_depth_and_token(lexer)
 }
@@ -31,7 +32,7 @@ pub(super) fn tt_hook_and_then<'a, C, T, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> Result<O, error::LexerError<C, LimitExceeded>>,
 ) -> Result<O, error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook_and_then(lexer, f)
 }
@@ -43,7 +44,7 @@ pub(super) fn tt_hook_and_then_into_errors<'a, C, T, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> Result<O, error::LexerErrors<C, LimitExceeded>>,
 ) -> Result<O, error::LexerErrors<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook_and_then_into_errors(lexer, f)
 }
@@ -54,7 +55,7 @@ pub(super) fn tt_hook_map<'a, C, T, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> O,
 ) -> Result<O, error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook_map(lexer, f)
 }
@@ -64,7 +65,7 @@ pub(super) fn tt_hook<'a, C, T>(
   lexer: &mut Lexer<'a, T>,
 ) -> Result<(), error::LexerError<C, LimitExceeded>>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   handlers::tt_hook(lexer)
 }

--- a/smear-lexer/src/graphqlx/handlers/slice.rs
+++ b/smear-lexer/src/graphqlx/handlers/slice.rs
@@ -2,11 +2,11 @@ use crate::{
   graphqlx::error::{BinaryError, HexError, OctalError},
   handlers::{self, is_ignored_byte},
   hints::{BinaryHint, ExponentHint, FloatHint, HexExponentHint, HexFloatHint, HexHint, OctalHint},
+  limits::LosslessLimits,
 };
 use tokora::{
   error::UnexpectedEnd,
   logos::{Lexer, Logos, Source},
-  state::tracker::Limiter,
   utils::Lexeme,
 };
 
@@ -37,7 +37,7 @@ pub(crate) fn cst_default_error<'a, S, T, Extras>(
   lexer: &mut Lexer<'a, T>,
 ) -> error::LexerErrors<u8, Extras>
 where
-  T: Logos<'a, Source = S, Extras = Limiter>,
+  T: Logos<'a, Source = S, Extras = LosslessLimits>,
   S: ?Sized + Source,
   S::Slice<'a>: AsRef<[u8]>,
 {

--- a/smear-lexer/src/graphqlx/handlers/str.rs
+++ b/smear-lexer/src/graphqlx/handlers/str.rs
@@ -2,7 +2,6 @@ use super::error;
 use tokora::{
   error::UnexpectedEnd,
   logos::{Lexer, Logos, Source},
-  state::tracker::Limiter,
   utils::Lexeme,
 };
 
@@ -10,6 +9,7 @@ use crate::{
   graphqlx::error::{BinaryError, HexError, OctalError},
   handlers::{self, is_ignored_char},
   hints::{BinaryHint, ExponentHint, FloatHint, HexExponentHint, HexFloatHint, HexHint, OctalHint},
+  limits::LosslessLimits,
 };
 
 type LexerError<Extras> = error::LexerError<char, Extras>;
@@ -36,7 +36,7 @@ pub(crate) fn cst_default_error<'a, S, T, Extras>(
   lexer: &mut Lexer<'a, T>,
 ) -> error::LexerErrors<char, Extras>
 where
-  T: Logos<'a, Source = S, Extras = Limiter>,
+  T: Logos<'a, Source = S, Extras = LosslessLimits>,
   S: ?Sized + Source,
   S::Slice<'a>: AsRef<str>,
 {

--- a/smear-lexer/src/graphqlx/lossless/token.rs
+++ b/smear-lexer/src/graphqlx/lossless/token.rs
@@ -44,10 +44,11 @@ macro_rules! token_impl {
       #[allow(unused_imports)]
       use tokora::utils::IntoEquivalent;
       use tokora::{
-        logos::Logos, lexer::Lexable, state::tracker::{LimitExceeded, Limiter},
+        logos::Logos, lexer::Lexable, state::tracker::LimitExceeded,
       };
       use crate::{
         error::StringErrors,
+        limits::LosslessLimits,
         graphqlx::{
           error::{LexerErrors, LexerError, DecimalError, HexError, FloatError, HexFloatError, BinaryError, OctalError},
           handlers::{
@@ -90,7 +91,7 @@ macro_rules! token_impl {
       )]
       #[logos(
         crate = tokora::logos,
-        extras = Limiter,
+        extras = LosslessLimits,
         utf8 = $utf8,
         error(TokenErrors, handlers::$handlers::cst_default_error)
       )]
@@ -324,10 +325,11 @@ macro_rules! token_impl {
       #[allow(unused_imports)]
       use tokora::utils::IntoEquivalent;
       use tokora::{
-        logos::Logos, lexer::Lexable, state::tracker::{LimitExceeded, Limiter},
+        logos::Logos, lexer::Lexable, state::tracker::LimitExceeded,
       };
       use crate::{
         error::StringErrors,
+        limits::LosslessLimits,
         graphqlx::{
           error::{LexerErrors, LexerError, DecimalError, HexError, FloatError, HexFloatError, BinaryError, OctalError},
           handlers::{
@@ -370,7 +372,7 @@ macro_rules! token_impl {
       )]
       #[logos(
         crate = tokora::logos,
-        extras = Limiter,
+        extras = LosslessLimits,
         utf8 = $utf8,
         error(TokenErrors, handlers::$handlers::cst_default_error)
       )]

--- a/smear-lexer/src/graphqlx/syntactic/error_parity_tests.rs
+++ b/smear-lexer/src/graphqlx/syntactic/error_parity_tests.rs
@@ -10,7 +10,9 @@
 
 use std::string::String;
 
-use tokora::{Lexer, state::recursion_tracker::RecursionLimiter};
+use tokora::Lexer;
+
+use crate::limits::SyntacticLimits;
 
 use crate::graphqlx::syntactic::SyntacticLexer;
 
@@ -145,6 +147,6 @@ fn recursion_limit_region_matches_logos() {
 #20 is_err=false span=SimpleSpan { start: 20, end: 21 } slice=\")\"
 ";
   let simd =
-    SyntacticLexer::<str>::with_state(src.as_str(), RecursionLimiter::with_limitation(limit));
+    SyntacticLexer::<str>::with_state(src.as_str(), SyntacticLimits::with_max_nesting_depth(limit));
   assert_eq!(render_error_path(simd, &src), expected);
 }

--- a/smear-lexer/src/graphqlx/syntactic/mod.rs
+++ b/smear-lexer/src/graphqlx/syntactic/mod.rs
@@ -8,7 +8,7 @@ use tokora::{
     DoubleColon, Equal, Exclamation, FatArrow, Hyphen, OpenAngle, OpenBrace, OpenBracket,
     OpenParen, Pipe, Plus, Spread,
   },
-  state::recursion_tracker::{RecursionLimitExceeded, RecursionLimiter},
+  state::recursion_tracker::RecursionLimitExceeded,
   utils::{CharLen, DowncastRef},
 };
 
@@ -27,7 +27,11 @@ use crate::simd::{
   skip_ws_and_comma,
 };
 
-pub use crate::simd::DEFAULT_RECURSION_LIMIT;
+// The nesting ceiling and the budget that carries it, surfaced beside the lexer they govern.
+// This position used to hold `DEFAULT_RECURSION_LIMIT = 500`, a constant that only restated
+// tokora's inherited default and named no decision; smear issue #61 replaced it with one that is
+// derived, and with the type whose `Default` actually delivers it.
+pub use crate::limits::{MAX_NESTING_DEPTH, SyntacticLimits};
 
 use super::{
   super::{LitBlockStr, LitInlineStr},
@@ -578,7 +582,7 @@ pub struct SyntacticLexer<'inp, S: ?Sized = str> {
   last_span: SimpleSpan,
   /// Span of the most recently returned error token, if any.
   last_error_span: Option<SimpleSpan>,
-  state: RecursionLimiter,
+  state: SyntacticLimits,
 }
 
 impl<'inp, S> Lexer<'inp> for SyntacticLexer<'inp, S>
@@ -593,7 +597,7 @@ where
   NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>: FromLogos<'inp>,
   LogosLexer<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>: Lexer<
       'inp,
-      State = RecursionLimiter,
+      State = SyntacticLimits,
       Source = LogosSourceOf<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>,
       Token = NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>,
       Offset = usize,
@@ -602,7 +606,7 @@ where
     Token<'inp, Error = LexerErrors<<S::Slice<'inp> as Slice<'inp>>::Char, RecursionLimitExceeded>>,
   <S::Slice<'inp> as Slice<'inp>>::Char: CharLen,
 {
-  type State = RecursionLimiter;
+  type State = SyntacticLimits;
 
   type Source = S;
 
@@ -1002,7 +1006,7 @@ where
   NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>: FromLogos<'inp>,
   LogosLexer<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>: Lexer<
       'inp,
-      State = RecursionLimiter,
+      State = SyntacticLimits,
       Source = LogosSourceOf<'inp, NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>>,
       Token = NumberLexerToken<<S::Slice<'inp> as Slice<'inp>>::Char>,
       Offset = usize,

--- a/smear-lexer/src/graphqlx/syntactic/number.rs
+++ b/smear-lexer/src/graphqlx/syntactic/number.rs
@@ -113,7 +113,7 @@ macro_rules! number_token_impl {
     mod $mod {
       use tokora::{
         logos::Logos,
-        state::recursion_tracker::{RecursionLimitExceeded, RecursionLimiter},
+        state::recursion_tracker::RecursionLimitExceeded,
       };
       use crate::graphqlx::{
         error::{
@@ -131,7 +131,7 @@ macro_rules! number_token_impl {
       #[derive(Logos, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
       #[logos(
         crate = tokora::logos,
-        extras = RecursionLimiter,
+        extras = crate::limits::SyntacticLimits,
         skip r"[ \t,\r\n\u{FEFF}]+|#[^\n\r]*?",
         utf8 = $utf8,
         error(TokenErrors, handlers::$handlers::default_error)

--- a/smear-lexer/src/graphqlx/syntactic/trait_parity_tests.rs
+++ b/smear-lexer/src/graphqlx/syntactic/trait_parity_tests.rs
@@ -19,7 +19,9 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::{format, string::String};
 
-use tokora::{Lexer, state::recursion_tracker::RecursionLimiter};
+use tokora::Lexer;
+
+use crate::limits::SyntacticLimits;
 
 use crate::graphqlx::syntactic::SyntacticLexer;
 
@@ -322,7 +324,7 @@ fn full_trait_parity_low_recursion_limit() {
   assert_eq!(
     render_full!(SyntacticLexer::<str>::with_state(
       src,
-      RecursionLimiter::with_limitation(limit)
+      SyntacticLimits::with_max_nesting_depth(limit)
     )),
     expected
   );
@@ -332,7 +334,7 @@ fn full_trait_parity_low_recursion_limit() {
   {
     let simd_panicked = panics(|| {
       let mut simd =
-        SyntacticLexer::<str>::with_state(src, RecursionLimiter::with_limitation(limit));
+        SyntacticLexer::<str>::with_state(src, SyntacticLimits::with_max_nesting_depth(limit));
       while simd.lex().is_some() {}
       simd.bump(&1usize);
     });

--- a/smear-lexer/src/handlers.rs
+++ b/smear-lexer/src/handlers.rs
@@ -2,18 +2,21 @@ use tokora::{
   SimpleSpan,
   error::{UnexpectedEnd, UnexpectedLexeme},
   logos::{Lexer, Logos, Source},
-  state::tracker::{LimitExceeded, Limiter},
+  state::tracker::LimitExceeded,
   utils::{CharLen, Lexeme, PositionedChar},
 };
 
 type Span = SimpleSpan;
 
-use crate::error::{BadStateError, UnterminatedSpreadOperatorError};
+use crate::{
+  error::{BadStateError, UnterminatedSpreadOperatorError},
+  limits::LosslessLimits,
+};
 
 #[inline(always)]
 fn increase_token<'a, T>(lexer: &mut Lexer<'a, T>)
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   lexer.extras.increase_token();
 }
@@ -23,7 +26,7 @@ pub(super) fn increase_recursion_depth_and_token<'a, T, E>(
   lexer: &mut Lexer<'a, T>,
 ) -> Result<(), E>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
   E: BadStateError<StateError = LimitExceeded>,
 {
   lexer.extras.increase_recursion();
@@ -40,7 +43,7 @@ pub(super) fn tt_hook_and_then<'a, T, E, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> Result<O, E>,
 ) -> Result<O, E>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
   E: BadStateError<StateError = LimitExceeded>,
 {
   lexer
@@ -62,7 +65,7 @@ pub(super) fn tt_hook_and_then_into_errors<'a, T, E, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> Result<O, E>,
 ) -> Result<O, E>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
   E: BadStateError<StateError = LimitExceeded>,
 {
   lexer
@@ -83,7 +86,7 @@ pub(super) fn tt_hook_map<'a, T, E, O>(
   f: impl FnOnce(&mut Lexer<'a, T>) -> O,
 ) -> Result<O, E>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
   E: BadStateError<StateError = LimitExceeded>,
 {
   lexer
@@ -100,7 +103,7 @@ where
 #[inline(always)]
 pub(super) fn tt_hook<'a, T, E>(lexer: &mut Lexer<'a, T>) -> Result<(), E>
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
   E: BadStateError<StateError = LimitExceeded>,
 {
   lexer
@@ -125,7 +128,7 @@ where
 #[inline(always)]
 pub(super) fn decrease_recursion_depth_and_increase_token<'a, T>(lexer: &mut Lexer<'a, T>)
 where
-  T: Logos<'a, Extras = Limiter>,
+  T: Logos<'a, Extras = LosslessLimits>,
 {
   lexer.extras.decrease_recursion();
   // right punctuation also increases the token count

--- a/smear-lexer/src/lib.rs
+++ b/smear-lexer/src/lib.rs
@@ -56,6 +56,8 @@ pub mod error;
 pub mod hints;
 /// Keyword tokens for GraphQL and GraphQLx.
 pub mod keywords;
+/// The nesting ceiling every smear lex runs under, and the budget types that carry it.
+pub mod limits;
 /// Punctuation tokens used in GraphQL and GraphQLx.
 pub mod punctuator;
 

--- a/smear-lexer/src/lib.rs
+++ b/smear-lexer/src/lib.rs
@@ -56,7 +56,13 @@ pub mod error;
 pub mod hints;
 /// Keyword tokens for GraphQL and GraphQLx.
 pub mod keywords;
-/// The nesting ceiling every smear lex runs under, and the budget types that carry it.
+// NO `///` HERE, and that is a fix rather than an omission. A module with doc fragments from
+// *both* places — a `///` on the `mod` item and a `//!` header in the file — has the intra-doc
+// links of ALL of them resolved against the scope of the FIRST fragment, which is this file's.
+// `limits.rs`'s header links `MAX_NESTING_DEPTH`, which is in scope there and not here, so the
+// pair made a `-D warnings` rustdoc build fail with "no item named `MAX_NESTING_DEPTH` in scope"
+// and no source span to find it by. One fragment, one scope. The same ruling
+// `smear-parser/src/lossless/mod.rs` records for the same reason.
 pub mod limits;
 /// Punctuation tokens used in GraphQL and GraphQLx.
 pub mod punctuator;

--- a/smear-lexer/src/limits.rs
+++ b/smear-lexer/src/limits.rs
@@ -3,8 +3,8 @@
 //! # Why these types exist at all
 //!
 //! Both lexers already carried a bracket-depth counter — tokora's
-//! [`RecursionLimiter`](tokora::state::recursion_tracker::RecursionLimiter) for the syntactic
-//! stream, its [`Limiter`](tokora::state::tracker::Limiter) for the lossless one — and both
+//! [`RecursionLimiter`] for the syntactic
+//! stream, its [`Limiter`] for the lossless one — and both
 //! *inherited* that counter's ceiling instead of choosing it. tokora's own docs are explicit that
 //! the inherited 500 "was never sized against anything", because nothing about tallying lexer
 //! nesting implies a native-stack cost for it to protect against, and that "a grammar that parses
@@ -33,6 +33,32 @@
 //! existing call site — `parse_str`, `Lexer::new`, each `parse_lossless` — picks the ceiling up
 //! without being edited, and a caller who wants a different one hands a different value to
 //! `with_state` / `parse_*_with_state` / a lossless `*_with_limits` entry point.
+//!
+//! # What this counter is **not**, and the correction that says so
+//!
+//! It is not the stack-safety boundary, and the first version of this module said it was. The
+//! tally here is one saturating scalar over every opener and every closer, **pair-blind**: it
+//! decrements on any `}`, `]`, `)` — or GraphQLx `>` — regardless of which opener the parser is
+//! actually inside. The parse's own recursion is a different quantity, and the lossless recovery
+//! path is where they come apart, because it *consumes* a closer no opener matched and carries on
+//! in the same selection-set loop. Over `{ ) f { ) f { …` this counter's maximum is **1** for the
+//! whole document while every level leaves two more parser frames live: measured at `6f39cb9`,
+//! 3.5 KB of that shape aborted a 2 MiB thread at 702 levels with the ceiling never firing.
+//!
+//! The bound that holds the native stack is therefore `smear-parser`'s `lossless::depth` — one
+//! RAII level per nesting delimiter the **parse** descends through, released by leaving the frame
+//! rather than by seeing a byte. That module carries the reasoning, and every number below is
+//! still what sizes it: the ceiling it enforces is read from these types.
+//!
+//! What this counter keeps is a real job, and two of them:
+//!
+//! - **It is the cheaper check, and it fires first for well-formed input.** The lexer runs ahead
+//!   of the parser, so on a document whose closers match, the tally reaches the ceiling one token
+//!   before the parser reaches it — which is why the diagnostics for ordinary over-deep input are
+//!   unchanged by the parser-side budget.
+//! - **It is what latches tokora's poison boundary**, and that latch is what stops a
+//!   machine-generated file from being lexed to the end after it has already proved it goes too
+//!   deep. See `smear-parser/src/lossless/runner.rs` for why smear keeps the latch.
 
 use tokora::state::{
   State,
@@ -41,19 +67,33 @@ use tokora::state::{
   tracker::{LimitExceeded, Limiter},
 };
 
-/// The greatest number of **simultaneously open** brackets a smear lex accepts by default. The
+/// The greatest number of **simultaneously open** brackets a smear parse accepts by default. The
 /// next one is refused.
 ///
-/// One global tally over `{`, `[` and `(` — and, in GraphQLx, over `<` and `>` as well, because
+/// One global count over `{`, `[` and `(` — and, in GraphQLx, over `<` and `>` as well, because
 /// that dialect delimits generics with them. So a selection set inside an argument list inside a
 /// list value spends three of the 24, not one, and a GraphQLx generic path spends one per
 /// parameter level.
 ///
+/// # Two counters read this number, and only one of them is the stack-safety boundary
+///
+/// The **population is the same** — one per nesting delimiter — but they are counted on different
+/// sides and only one of them equals what recurses:
+///
+/// - the **lexer's** tally, in the types below, which is pair-blind and steps on bytes;
+/// - the **parse's** own frame budget, `smear-parser`'s `lossless::depth`, one RAII level per
+///   delimiter a lossless production descends through.
+///
+/// The second is the one this number exists for. The first is a cheap pre-filter that fires
+/// earlier for well-formed input, and it was the *only* check for one release — which is the
+/// defect the module header records: a closer no opener matched decrements it, so recovery could
+/// walk the parse arbitrarily deep with the tally reading 1.
+///
 /// # The measurement this is derived from
 ///
-/// The counter is a proxy for native stack use: the parser holds live frames for every open
-/// bracket, so the depth at which the process dies is a fact about the *deployment stack*, not
-/// about the grammar. Bisected on this tree with one parse per process on an explicitly sized
+/// Every figure below is a **native stack** measurement, and it is the number of *live frames*
+/// that costs the stack — which is what the parse-side budget counts and what the lexer's tally
+/// only approximates. Bisected on this tree with one parse per process on an explicitly sized
 /// thread, greatest depth that returns before the next one aborts with
 /// `fatal runtime error: stack overflow`:
 ///
@@ -79,6 +119,14 @@ use tokora::state::{
 /// | GraphQLx syntactic, generic angle brackets, `str`, aarch64 | **52** |
 /// | GraphQL syntactic, inline fragments, `bytes::Bytes`, aarch64 | **51** |
 /// | GraphQL lossless, inline fragments, `str`, aarch64 | ~745 (13x cheaper per level) |
+/// | GraphQL lossless, **the recovery bypass** `{ ) f {`, `str`, aarch64 | **702** |
+/// | GraphQLx lossless, the same with `)` and with `>` alike, `str`, aarch64 | **700** |
+///
+/// The last two rows are the shape that walked past the first fix, and they are why the count
+/// moved to the parse. They cost about the same per level as the row above them — a `field` frame
+/// plus a `selection_set` frame — and needed 3.5 KB of input to reach 702, with the lexer's tally
+/// reading **1** the whole way. Under the parse-side budget the same input refuses at 24 and
+/// returns; the mapping did not move, because a level of that shape is a level of any other.
 ///
 /// Five shapes were probed per door — inline fragments, field selections, list values, input
 /// objects and list types, plus GraphQLx's generic angle brackets — and inline fragments are the
@@ -120,6 +168,15 @@ use tokora::state::{
 /// GraphQLx generic-lookahead probe that nests 33 angle brackets. Both run under a raised ceiling
 /// rather than a lowered claim — which also records the ordering, because at the shipped defaults
 /// this ceiling binds long before the validator's does.
+///
+/// **At the lossless door, raising it past 64 does not reach the parse.** tokora's own
+/// parse-side recursion budget is depth 64 and is installed by `InputContext::new`, which
+/// `tokora::cst::parse_lossless` calls with no hook for a caller to raise — so
+/// a lossless parse refuses at `min(this number, 64)`, cleanly and with a positioned diagnostic
+/// rather than an abort. 64 is 5.8x the deepest document in this repository and 2.7x this
+/// default, so nothing shipped is near it; the *syntactic* door has no such cap, because the
+/// context there is the consumer's and `Parser::with_parser_and_context` takes a
+/// `ParserContext::with_recursion_limiter`.
 pub const MAX_NESTING_DEPTH: usize = 24;
 
 /// The worst depth in the table above that still returns: GraphQLx's syntactic door on a 2 MiB
@@ -166,7 +223,7 @@ const _: () = assert!(
 /// [`graphql::syntactic::SyntacticLexer`](crate::graphql::syntactic::SyntacticLexer) and its
 /// GraphQLx twin, so [`Default`] is what `Parser::with_parser(…).parse_str(src)` seeds a parse
 /// with — which is the whole reason the type exists rather than a bare
-/// [`RecursionLimiter`](tokora::state::recursion_tracker::RecursionLimiter). See the module
+/// [`RecursionLimiter`]. See the module
 /// header.
 ///
 /// ```
@@ -204,11 +261,15 @@ impl SyntacticLimits {
     Self(RecursionLimiter::with_limitation(max))
   }
 
-  /// A budget that never trips.
+  /// A budget whose **lexer-side** tally never trips.
   ///
-  /// The depth is still counted, so [`depth`](Self::depth) stays readable. Nothing then stands
-  /// between a deeply nested document and the native stack, so this is for a parse whose input is
-  /// trusted or whose depth is bounded before it arrives.
+  /// The depth is still counted, so [`depth`](Self::depth) stays readable. At the syntactic door
+  /// this removes the last check smear applies, so nothing then stands between a deeply nested
+  /// document and the native stack: it is for a parse whose input is trusted or whose depth is
+  /// bounded before it arrives.
+  ///
+  /// It is deliberately not spelled "unbounded". See [`MAX_NESTING_DEPTH`] for the second counter
+  /// and where it does and does not still apply.
   #[inline(always)]
   pub const fn unlimited() -> Self {
     Self(RecursionLimiter::unlimited())
@@ -315,9 +376,13 @@ impl LosslessLimits {
     ))
   }
 
-  /// A budget that never trips on either axis.
+  /// A budget whose lexer-side tally never trips on either axis.
   ///
-  /// See [`SyntacticLimits::unlimited`] for what removing the nesting ceiling gives up.
+  /// See [`SyntacticLimits::unlimited`] for what removing the nesting ceiling gives up — and note
+  /// the difference at *this* door: a lossless parse still descends through `smear-parser`'s
+  /// `lossless::depth`, whose ceiling this value feeds, so the effective bound here is tokora's
+  /// own parse-side budget of 64 rather than no bound at all. [`MAX_NESTING_DEPTH`] records why
+  /// that cap cannot be raised from a lossless entry point.
   #[inline(always)]
   pub const fn unlimited() -> Self {
     Self(Limiter::with_trackers(

--- a/smear-lexer/src/limits.rs
+++ b/smear-lexer/src/limits.rs
@@ -1,0 +1,408 @@
+//! The resource budget a smear lex runs under, and the nesting ceiling it defaults to.
+//!
+//! # Why these types exist at all
+//!
+//! Both lexers already carried a bracket-depth counter — tokora's
+//! [`RecursionLimiter`](tokora::state::recursion_tracker::RecursionLimiter) for the syntactic
+//! stream, its [`Limiter`](tokora::state::tracker::Limiter) for the lossless one — and both
+//! *inherited* that counter's ceiling instead of choosing it. tokora's own docs are explicit that
+//! the inherited 500 "was never sized against anything", because nothing about tallying lexer
+//! nesting implies a native-stack cost for it to protect against, and that "a grammar that parses
+//! untrusted, deeply nested input should still set its own limit […] against the stack the parse
+//! will actually run on".
+//!
+//! smear never did, and the consequence was measured (issue #61): a **valid** GraphQL document of
+//! about a kilobyte — `{ ... on Query { ... on Query { … } } }` nested 58 deep — overflowed the
+//! native stack of a 2 MiB thread and killed the process with `SIGABRT`. The inherited 500 sat an
+//! order of magnitude above that, so it could not fire first; nothing rejected the document and
+//! there was no diagnostic, because there was no return.
+//!
+//! # Why a newtype rather than a number passed at the call site
+//!
+//! The number has to arrive at the doors that already exist, and one of those doors is not
+//! smear's to change. The lossless entry points are all smear's own six functions, so a limiter
+//! passed there would reach every one of them. The **syntactic** layer ships productions and no
+//! runner: a consumer drives it with `Parser::with_parser(…).parse_str(src)`, which is what this
+//! workspace's own README, `smear-compiler`'s crate docs and `smear-schema`'s builder all write —
+//! and `parse_str` seeds the lexer with `L::State::default()`. The only place smear can name a
+//! number that reaches *that* call is the `Default` of `L::State` itself, and `L::State` was
+//! tokora's type.
+//!
+//! So these two newtypes are the decision: they are what [`Lexer::State`](tokora::Lexer::State)
+//! resolves to for smear's four lexers, and their `Default` is [`MAX_NESTING_DEPTH`]. Every
+//! existing call site — `parse_str`, `Lexer::new`, each `parse_lossless` — picks the ceiling up
+//! without being edited, and a caller who wants a different one hands a different value to
+//! `with_state` / `parse_*_with_state` / a lossless `*_with_limits` entry point.
+
+use tokora::state::{
+  State,
+  recursion_tracker::{RecursionLimitExceeded, RecursionLimiter},
+  token_tracker::TokenLimiter,
+  tracker::{LimitExceeded, Limiter},
+};
+
+/// The greatest number of **simultaneously open** brackets a smear lex accepts by default. The
+/// next one is refused.
+///
+/// One global tally over `{`, `[` and `(` — and, in GraphQLx, over `<` and `>` as well, because
+/// that dialect delimits generics with them. So a selection set inside an argument list inside a
+/// list value spends three of the 24, not one, and a GraphQLx generic path spends one per
+/// parameter level.
+///
+/// # The measurement this is derived from
+///
+/// The counter is a proxy for native stack use: the parser holds live frames for every open
+/// bracket, so the depth at which the process dies is a fact about the *deployment stack*, not
+/// about the grammar. Bisected on this tree with one parse per process on an explicitly sized
+/// thread, greatest depth that returns before the next one aborts with
+/// `fatal runtime error: stack overflow`:
+///
+/// | stack | 512 KiB | 1 MiB | **2 MiB** | 4 MiB | 8 MiB |
+/// |---|---|---|---|---|---|
+/// | syntactic door, GraphQL, `str`, debug | 12 | 27 | **57** | 118 | 239 |
+///
+/// Linear at roughly 34 KiB per level. **2 MiB is the stack this number is derived from**, and
+/// that is the claim: it is what `std::thread::spawn` gives every thread, what a tokio worker
+/// runs on, and what the libtest harness hands every `#[test]` — the smallest stack a smear parse
+/// is realistically handed. A caller who deliberately spawns a smaller thread, or who wants
+/// deeper documents on a larger one, is the reason this is configurable rather than a hard-coded
+/// wall.
+///
+/// The 2 MiB column varies by shape, dialect, source backing and architecture, and **all of it
+/// was measured** rather than assumed, because the binding cell is the worst one:
+///
+/// | cell (2 MiB, debug) | last depth that returns |
+/// |---|---|
+/// | GraphQL syntactic, inline fragments, `str`, aarch64 | 57 |
+/// | GraphQL syntactic, inline fragments, `str`, x86_64 | 60 |
+/// | GraphQLx syntactic, inline fragments, `str`, aarch64 | **53** |
+/// | GraphQLx syntactic, generic angle brackets, `str`, aarch64 | **52** |
+/// | GraphQL syntactic, inline fragments, `bytes::Bytes`, aarch64 | **51** |
+/// | GraphQL lossless, inline fragments, `str`, aarch64 | ~745 (13x cheaper per level) |
+///
+/// Five shapes were probed per door — inline fragments, field selections, list values, input
+/// objects and list types, plus GraphQLx's generic angle brackets — and inline fragments are the
+/// most expensive of them. x86_64 is not the worse architecture of the two measured. GraphQLx
+/// costs 0.93x of GraphQL and a `bytes::Bytes` backing 0.89x, so the worst *shipped
+/// configuration* — both together, which has no probe of its own — extrapolates to about **47**.
+///
+/// # Why 24, and not the release figure
+///
+/// **24 clears 47 by 1.96x.** That is deliberately the same margin tokora derived its own
+/// parser-facing default at, and for the same asymmetry: a limit that is too low returns a clean,
+/// catchable, documented diagnostic telling the caller to raise it, while a limit that is too high
+/// aborts the process with no diagnostic at all and takes every other request on that process with
+/// it. Only one of those is recoverable, so the default is set where every measured configuration
+/// survives.
+///
+/// The release figures are far higher — the syntactic door costs 4.0 KiB per level optimised
+/// rather than 34, and the lossless door 0.44 — and sizing against them is exactly the mistake
+/// this number avoids. A debug build is what `cargo test` runs, in this workspace and in every
+/// downstream that parses a document in a test, and a `SIGABRT` there does not fail a test: it
+/// kills the runner. Worth recording, because it is the sharpest statement of how thin the
+/// inherited ceiling was: in a *release* build on a 2 MiB thread, 500 levels of the syntactic door
+/// need about 1.95 MiB of the 2 MiB available. It survived by roughly 2%, which is not a margin,
+/// it is a coincidence.
+///
+/// # What it costs a real document
+///
+/// Nothing measurable. The deepest GraphQL document in this repository — 472 fixtures, including
+/// real-world subgraph schemas and one named `bench_07_large_deep_nesting.graphql` — reaches
+/// bracket depth **11**, and the next deepest 9. 24 leaves 2.2x headroom over the deepest document
+/// anyone here has written, and clears the canonical introspection query with room to spare.
+/// `smear/tests/nesting_depth.rs` re-derives that 11 from the fixtures themselves, so the claim
+/// cannot go stale as the corpus grows.
+///
+/// # What it costs a caller who genuinely needs more
+///
+/// One call. Two places in this workspace already need it and say so: `validator_merge.rs`, whose
+/// fixtures nest 200 levels to reach the *validator's* own `merge_depth` budget of 128, and one
+/// GraphQLx generic-lookahead probe that nests 33 angle brackets. Both run under a raised ceiling
+/// rather than a lowered claim — which also records the ordering, because at the shipped defaults
+/// this ceiling binds long before the validator's does.
+pub const MAX_NESTING_DEPTH: usize = 24;
+
+/// The worst depth in the table above that still returns: GraphQLx's syntactic door on a 2 MiB
+/// debug thread (53), discounted by the 0.89x a `bytes::Bytes` backing costs.
+///
+/// A constant rather than only prose so that the assertion below can read it.
+const WORST_MEASURED_BOUNDARY: usize = 47;
+
+/// The deepest GraphQL document in this repository, over 472 fixtures.
+const DEEPEST_DOCUMENT_IN_TREE: usize = 11;
+
+// THE DERIVATION IS AN OBLIGATION, NOT A COMMENT, and it is checked at compile time rather than by
+// a test for a reason that was measured rather than guessed: **a test cannot guard this**. Raising
+// the constant makes every *other* nesting test parse deeper, and past the native boundary those
+// tests do not go red — they abort the harness, which is the very failure #61 is about. Planting
+// `MAX_NESTING_DEPTH = 200` killed `smear/tests/nesting_depth.rs` with `SIGABRT` before that
+// file's own arithmetic check could run, because libtest gives no ordering between tests. A
+// `const` assertion cannot be outrun: a ceiling raised past what the measurement supports fails to
+// *build*.
+//
+// Raising it is therefore deliberately a two-line edit, and the second line is
+// `WORST_MEASURED_BOUNDARY`. Moving that means re-running the bisection behind the table above —
+// which is the point, because a number that can be raised without re-measuring has stopped being
+// derived.
+const _: () = assert!(
+  MAX_NESTING_DEPTH * 19 <= WORST_MEASURED_BOUNDARY * 10,
+  "MAX_NESTING_DEPTH leaves less than the 1.9x margin it was derived at under the worst measured \
+   native-stack boundary. Raising it needs a new measurement, not a new constant."
+);
+
+// The other side of it, and the cheap direction to get wrong: a ceiling below what real documents
+// need refuses real input while every gate in the tree still passes, because the fixtures are all
+// far shallower than the ceiling. Nothing in the suite would notice a ceiling set at 4 until a
+// consumer did.
+const _: () = assert!(
+  MAX_NESTING_DEPTH >= DEEPEST_DOCUMENT_IN_TREE * 2,
+  "MAX_NESTING_DEPTH must keep the documents this repository actually contains clear of the \
+   ceiling by at least 2x."
+);
+
+/// The budget a **syntactic** lex runs under: nesting depth, and nothing else.
+///
+/// This is [`Lexer::State`](tokora::Lexer::State) for
+/// [`graphql::syntactic::SyntacticLexer`](crate::graphql::syntactic::SyntacticLexer) and its
+/// GraphQLx twin, so [`Default`] is what `Parser::with_parser(…).parse_str(src)` seeds a parse
+/// with — which is the whole reason the type exists rather than a bare
+/// [`RecursionLimiter`](tokora::state::recursion_tracker::RecursionLimiter). See the module
+/// header.
+///
+/// ```
+/// use smear_lexer::limits::{MAX_NESTING_DEPTH, SyntacticLimits};
+///
+/// // What every unconfigured syntactic parse gets.
+/// assert_eq!(SyntacticLimits::default().max_nesting_depth(), MAX_NESTING_DEPTH);
+///
+/// // What a caller on an 8 MiB thread with deeper documents asks for instead.
+/// assert_eq!(SyntacticLimits::with_max_nesting_depth(96).max_nesting_depth(), 96);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SyntacticLimits(RecursionLimiter);
+
+impl Default for SyntacticLimits {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl SyntacticLimits {
+  /// A budget at smear's own [`MAX_NESTING_DEPTH`].
+  #[inline(always)]
+  pub const fn new() -> Self {
+    Self(RecursionLimiter::with_limitation(MAX_NESTING_DEPTH))
+  }
+
+  /// A budget at `max` simultaneously open brackets.
+  ///
+  /// The number to pass is a function of the stack the parse will run on; see
+  /// [`MAX_NESTING_DEPTH`] for the measured cost of one level.
+  #[inline(always)]
+  pub const fn with_max_nesting_depth(max: usize) -> Self {
+    Self(RecursionLimiter::with_limitation(max))
+  }
+
+  /// A budget that never trips.
+  ///
+  /// The depth is still counted, so [`depth`](Self::depth) stays readable. Nothing then stands
+  /// between a deeply nested document and the native stack, so this is for a parse whose input is
+  /// trusted or whose depth is bounded before it arrives.
+  #[inline(always)]
+  pub const fn unlimited() -> Self {
+    Self(RecursionLimiter::unlimited())
+  }
+
+  /// The ceiling this budget refuses past.
+  #[inline(always)]
+  pub const fn max_nesting_depth(&self) -> usize {
+    self.0.limitation()
+  }
+
+  /// How many brackets are open right now.
+  #[inline(always)]
+  pub const fn depth(&self) -> usize {
+    self.0.depth()
+  }
+
+  /// Opens one level.
+  #[inline(always)]
+  pub const fn increase(&mut self) {
+    self.0.increase();
+  }
+
+  /// Closes one level.
+  #[inline(always)]
+  pub const fn decrease(&mut self) {
+    self.0.decrease();
+  }
+
+  /// Whether the ceiling is still respected.
+  #[inline(always)]
+  pub const fn check(&self) -> Result<(), RecursionLimitExceeded> {
+    self.0.check()
+  }
+}
+
+impl From<RecursionLimiter> for SyntacticLimits {
+  #[inline(always)]
+  fn from(limiter: RecursionLimiter) -> Self {
+    Self(limiter)
+  }
+}
+
+impl From<SyntacticLimits> for RecursionLimiter {
+  #[inline(always)]
+  fn from(limits: SyntacticLimits) -> Self {
+    limits.0
+  }
+}
+
+impl State for SyntacticLimits {
+  type Error = RecursionLimitExceeded;
+
+  #[inline(always)]
+  fn check(&self) -> Result<(), Self::Error> {
+    Self::check(self)
+  }
+}
+
+/// The budget a **lossless** lex runs under: nesting depth and token count.
+///
+/// This is [`Lexer::State`](tokora::Lexer::State) for
+/// [`graphql::lossless::LosslessLexer`](crate::graphql::lossless::LosslessLexer) and its GraphQLx
+/// twin — the Logos `Extras` those token grammars declare — so [`Default`] is what every
+/// `parse_lossless` call seeds a parse with. See the module header.
+///
+/// The **token** half is left at tokora's unlimited default and is not part of issue #61's
+/// decision: a token count is bounded by the input length, so unlike nesting depth it cannot
+/// exhaust the native stack. It is carried here because the lossless lexer's `Extras` is the
+/// combined tracker, and it is settable so that a caller who wants a total-work bound has one.
+///
+/// ```
+/// use smear_lexer::limits::{LosslessLimits, MAX_NESTING_DEPTH};
+///
+/// assert_eq!(LosslessLimits::default().max_nesting_depth(), MAX_NESTING_DEPTH);
+/// assert_eq!(LosslessLimits::default().max_tokens(), usize::MAX);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LosslessLimits(Limiter);
+
+impl Default for LosslessLimits {
+  #[inline(always)]
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl LosslessLimits {
+  /// A budget at smear's own [`MAX_NESTING_DEPTH`], with no token ceiling.
+  #[inline(always)]
+  pub const fn new() -> Self {
+    Self(Limiter::with_trackers(
+      TokenLimiter::new(),
+      RecursionLimiter::with_limitation(MAX_NESTING_DEPTH),
+    ))
+  }
+
+  /// A budget at `max` simultaneously open brackets, with no token ceiling.
+  #[inline(always)]
+  pub const fn with_max_nesting_depth(max: usize) -> Self {
+    Self(Limiter::with_trackers(
+      TokenLimiter::new(),
+      RecursionLimiter::with_limitation(max),
+    ))
+  }
+
+  /// A budget that never trips on either axis.
+  ///
+  /// See [`SyntacticLimits::unlimited`] for what removing the nesting ceiling gives up.
+  #[inline(always)]
+  pub const fn unlimited() -> Self {
+    Self(Limiter::with_trackers(
+      TokenLimiter::new(),
+      RecursionLimiter::unlimited(),
+    ))
+  }
+
+  /// The same budget with `max` as its token ceiling.
+  #[inline(always)]
+  pub const fn with_max_tokens(self, max: usize) -> Self {
+    Self(Limiter::with_trackers(
+      TokenLimiter::with_limitation(max),
+      *self.0.recursion(),
+    ))
+  }
+
+  /// The nesting ceiling this budget refuses past.
+  #[inline(always)]
+  pub const fn max_nesting_depth(&self) -> usize {
+    self.0.recursion().limitation()
+  }
+
+  /// The token ceiling this budget refuses past.
+  #[inline(always)]
+  pub const fn max_tokens(&self) -> usize {
+    self.0.token().limitation()
+  }
+
+  /// How many brackets are open right now.
+  #[inline(always)]
+  pub const fn depth(&self) -> usize {
+    self.0.recursion().depth()
+  }
+
+  /// The token half, for the handlers that step it.
+  #[inline(always)]
+  pub const fn token(&self) -> &TokenLimiter {
+    self.0.token()
+  }
+
+  /// Counts one token.
+  #[inline(always)]
+  pub const fn increase_token(&mut self) {
+    self.0.increase_token();
+  }
+
+  /// Opens one level.
+  #[inline(always)]
+  pub const fn increase_recursion(&mut self) {
+    self.0.increase_recursion();
+  }
+
+  /// Closes one level.
+  #[inline(always)]
+  pub const fn decrease_recursion(&mut self) {
+    self.0.decrease_recursion();
+  }
+
+  /// Whether both ceilings are still respected.
+  #[inline(always)]
+  pub fn check(&self) -> Result<(), LimitExceeded> {
+    self.0.check()
+  }
+}
+
+impl From<Limiter> for LosslessLimits {
+  #[inline(always)]
+  fn from(limiter: Limiter) -> Self {
+    Self(limiter)
+  }
+}
+
+impl From<LosslessLimits> for Limiter {
+  #[inline(always)]
+  fn from(limits: LosslessLimits) -> Self {
+    limits.0
+  }
+}
+
+impl State for LosslessLimits {
+  type Error = LimitExceeded;
+
+  #[inline(always)]
+  fn check(&self) -> Result<(), Self::Error> {
+    Self::check(self)
+  }
+}

--- a/smear-lexer/src/simd/mod.rs
+++ b/smear-lexer/src/simd/mod.rs
@@ -12,12 +12,9 @@
 use tokora::{
   Lexer, SimpleSpan, Token,
   lexer::{FromLogos, LogosLexer},
-  state::recursion_tracker::RecursionLimiter,
 };
 
-/// Maximum byte recursion depth — matches the default in
-/// [`tokora::state::recursion_tracker::RecursionLimiter`].
-pub const DEFAULT_RECURSION_LIMIT: usize = 500;
+use crate::limits::SyntacticLimits;
 
 pub(crate) type LogosSourceOf<'inp, T> =
   <<T as FromLogos<'inp>>::Logos as tokora::logos::Logos<'inp>>::Source;
@@ -39,7 +36,7 @@ pub(crate) enum Delegated<'inp, T: Token<'inp>> {
   Token {
     token: T,
     end: usize,
-    state: RecursionLimiter,
+    state: SyntacticLimits,
   },
   Error {
     error: <T as Token<'inp>>::Error,
@@ -61,17 +58,11 @@ pub(crate) enum Delegated<'inp, T: Token<'inp>> {
 pub(crate) fn delegate_to_logos<'inp, T>(
   scan_primitive: &'inp LogosSourceOf<'inp, T>,
   cursor: usize,
-  state: RecursionLimiter,
+  state: SyntacticLimits,
 ) -> Option<Delegated<'inp, T>>
 where
   T: FromLogos<'inp>,
-  LogosLexer<'inp, T>: Lexer<
-      'inp,
-      State = RecursionLimiter,
-      Source = LogosSourceOf<'inp, T>,
-      Token = T,
-      Offset = usize,
-    >,
+  LogosLexer<'inp, T>: Lexer<'inp, State = SyntacticLimits, Source = LogosSourceOf<'inp, T>, Token = T, Offset = usize>,
 {
   let mut logos = LogosLexer::with_state(scan_primitive, state);
   logos.bump(&cursor);

--- a/smear-parser/src/graphql/lossless/definition.rs
+++ b/smear-parser/src/graphql/lossless/definition.rs
@@ -133,6 +133,8 @@ lossless_production! {
   /// `arguments`' loop with a different member and the opposite emptiness ruling: `syntactic/`
   /// accepts the lenient `()` for `Arguments` and rejects it here.
   fn arguments_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ArgumentsDefinition.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {
@@ -186,6 +188,8 @@ lossless_production! {
 
   /// `{ FieldDefinition+ }`
   fn fields_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::FieldsDefinition.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {
@@ -218,6 +222,8 @@ lossless_production! {
   /// that had to distinguish them at run time would be paying for a difference the grammar
   /// already makes.
   fn input_fields_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::InputFieldsDefinition.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {
@@ -380,6 +386,8 @@ lossless_production! {
 
   /// `{ EnumValueDefinition+ }`
   fn enum_values_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::EnumValuesDefinition.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {
@@ -454,6 +462,8 @@ lossless_production! {
 
   /// `{ RootOperationTypeDefinition+ }`
   fn root_operation_type_definitions<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::RootOperationTypeDefinitions.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphql/lossless/directive.rs
+++ b/smear-parser/src/graphql/lossless/directive.rs
@@ -99,6 +99,8 @@ lossless_production! {
   /// return `Err` and abort the whole list, so `(a: 1, !, b: 2)` would cost the rest of the
   /// parse instead of one token.
   fn arguments<'inp, Src, Ctx>(inp, konst: Constness) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::Arguments.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphql/lossless/executable.rs
+++ b/smear-parser/src/graphql/lossless/executable.rs
@@ -125,6 +125,8 @@ lossless_production! {
   /// for `Arguments`. Gate 1 compares the two suites' verdicts input by input, so the two
   /// rulings are followed one production at a time rather than unified into a house rule.
   fn variables_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::VariablesDefinition.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphql/lossless/mod.rs
+++ b/smear-parser/src/graphql/lossless/mod.rs
@@ -10,7 +10,10 @@ use tokora::{
   // macros in `crate::lossless` reach this dialect's lexer by — and a trait and a type alias share
   // one namespace.
   Lexer as TokoraLexer,
+  SimpleSpan,
   Source,
+  error::RecursionLimitReached,
+  input::Descent,
   state::tracker::LimitExceeded,
   utils::Expected,
 };
@@ -21,6 +24,7 @@ use crate::{
     GraphQL,
     error::{Error as DialectError, ErrorData, Errors as DialectErrors, Expectation},
   },
+  lossless::depth::FromNestingLimit,
 };
 
 pub use crate::graphql::kinds::GraphQLLang;
@@ -73,13 +77,13 @@ where
 = InputRef<'inp, 'input, GraphqlLosslessLexer<'inp, Src>, Ctx, GraphQL>;
 
 // ---------------------------------------------------------------------------------------------
-// The seven names the shared macros in `crate::lossless` reach this dialect by.
+// The eight names the shared macros in `crate::lossless` reach this dialect by.
 //
 // Aliases, not renames: the `GraphqlLossless*` spellings stay, because ~200 signatures use them
 // and renaming those is a diff that buys nothing and hides everything else. What these buy is
 // that `lossless_production!` and `lossless_drivers!` can be written once, over `Input`, `Error`,
-// `Token`, `Lexer`, `Brand`, `TokenKind` and `Keyword`, and a second dialect adopts them by
-// declaring the same seven.
+// `Token`, `Lexer`, `LexerState`, `Brand`, `TokenKind` and `Keyword`, and a second dialect adopts
+// them by declaring the same eight.
 // ---------------------------------------------------------------------------------------------
 
 /// This dialect's tokora grammar brand.
@@ -96,6 +100,15 @@ pub type Keyword = smear_lexer::graphql::ContextualKeyword;
 #[allow(type_alias_bounds)]
 pub type Lexer<'inp, Src: Source<usize> + ?Sized> = GraphqlLosslessLexer<'inp, Src>;
 
+/// The resource budget this dialect's lossless lex runs under — the Logos `Extras`, and the
+/// [`Lexer::State`](tokora::Lexer::State) the shared production bundle pins.
+///
+/// Pinned rather than left as a projection because a production has to *read* it: the nesting
+/// ceiling a parse was configured with lives here, and this module's `descend` hands it to the
+/// parser-frame budget. Over a generic `Src` the projection has nothing to normalize against
+/// without the equality, exactly as the token's `Kind` does not.
+pub type LexerState = smear_lexer::limits::LosslessLimits;
+
 /// [`GraphqlLosslessToken`], under the name the shared macros reach it by.
 #[allow(type_alias_bounds)]
 pub type Token<'inp, Src: Source<usize> + ?Sized> = GraphqlLosslessToken<'inp, Src>;
@@ -108,6 +121,44 @@ pub type Input<'inp, 'input, Src: Source<usize> + ?Sized, Ctx> =
 /// [`GraphqlLosslessError`], under the name the shared macros reach it by.
 #[allow(type_alias_bounds)]
 pub type Error<'inp, Src: Source<usize> + ?Sized, Ctx> = GraphqlLosslessError<'inp, Src, Ctx>;
+
+/// Enters one level of parser recursion under this dialect's configured nesting ceiling.
+///
+/// The whole body is reading the ceiling off the lexer state and handing it to
+/// [`crate::lossless::depth::descend`], which is where the reasoning lives. It exists per dialect
+/// only because the substrate may not name `smear-lexer`, so the number has to be read on this
+/// side of the line.
+///
+/// **Bind the guard for the whole frame** — `let mut frame = descend(inp)?; let inp = &mut *frame;`
+/// — because dropping it early releases the level before the recursion it was taken for, which
+/// type-checks and silently reinstates the unbounded descent.
+#[inline]
+pub(crate) fn descend<'r, 'inp, 'input, Src, Ctx>(
+  inp: &'r mut GraphqlLosslessInput<'inp, 'input, Src, Ctx>,
+) -> Result<
+  Descent<'r, 'inp, 'input, GraphqlLosslessLexer<'inp, Src>, Ctx, GraphQL>,
+  GraphqlLosslessError<'inp, Src, Ctx>,
+>
+where
+  Src: Source<usize> + ?Sized,
+  GraphqlLosslessToken<'inp, Src>: tokora::Token<'inp, Kind = TokenKind>
+    + tokora::lexer::FromLogos<'inp>
+    + Clone
+    + tokora::utils::DowncastRef<Keyword>,
+  GraphqlLosslessLexer<'inp, Src>: TokoraLexer<
+      'inp,
+      Token = GraphqlLosslessToken<'inp, Src>,
+      Span = SimpleSpan,
+      Offset = usize,
+      State = LexerState,
+    >,
+  Ctx: tokora::ParseContext<'inp, GraphqlLosslessLexer<'inp, Src>, GraphQL>,
+  GraphqlLosslessError<'inp, Src, Ctx>:
+    From<RecursionLimitReached<usize, GraphQL>> + FromNestingLimit,
+{
+  let ceiling = inp.state().max_nesting_depth();
+  crate::lossless::depth::descend(inp, ceiling)
+}
 
 /// One error value a GraphQL lossless parse can record.
 ///

--- a/smear-parser/src/graphql/lossless/mod.rs
+++ b/smear-parser/src/graphql/lossless/mod.rs
@@ -202,7 +202,9 @@ pub mod value;
 // one. A consumer picks a root here, once, rather than parsing the mixed form and filtering the
 // tree.
 pub use runner::{
-  Parse, parse_document, parse_executable_document, parse_type_system_document, profile,
+  Parse, parse_document, parse_document_with_limits, parse_executable_document,
+  parse_executable_document_with_limits, parse_type_system_document,
+  parse_type_system_document_with_limits, profile,
 };
 
 // Beside the roots, and named for the symmetry: `parse_document(src) -> Parse`,

--- a/smear-parser/src/graphql/lossless/runner.rs
+++ b/smear-parser/src/graphql/lossless/runner.rs
@@ -1,6 +1,7 @@
 //! The Sink runner: binds a source to a `cst::Sink`, drives the document production, and
 //! materializes a `rowan` tree.
 
+use smear_lexer::limits::LosslessLimits;
 use tokora::{
   Source,
   cst::{Cst, CstProfile, KindValidator, parse_lossless},
@@ -106,7 +107,26 @@ pub type Parse = crate::lossless::runner::Parse<crate::graphql::kinds::GraphQLLa
 /// filter to write afterwards — see [`parse_type_system_document`] and
 /// [`parse_executable_document`]. The difference is not cosmetic: those roots reject the other
 /// half *at the parser's own position*, which a caller walking a mixed tree cannot reconstruct.
+///
+/// # The nesting ceiling
+///
+/// [`LosslessLimits::default`], so at most
+/// [`MAX_NESTING_DEPTH`](smear_lexer::limits::MAX_NESTING_DEPTH) simultaneously open brackets;
+/// the next one is reported. That default is derived against a 2 MiB stack, which is what
+/// `std::thread::spawn`, a tokio worker and the libtest harness each give a thread. A caller on a
+/// different stack, or with deeper documents, uses [`parse_document_with_limits`].
 pub fn parse_document(src: &str) -> Parse {
+  parse_document_with_limits(src, LosslessLimits::default())
+}
+
+/// [`parse_document`] under a caller-chosen resource budget.
+///
+/// The reason to reach for this is a stack that is not the 2 MiB
+/// [`MAX_NESTING_DEPTH`](smear_lexer::limits::MAX_NESTING_DEPTH) is derived against — a server on
+/// an 8 MiB main thread can afford roughly four times the depth, and a worker deliberately spawned
+/// smaller can afford less. The cost of one level is measured on
+/// [`MAX_NESTING_DEPTH`](smear_lexer::limits::MAX_NESTING_DEPTH) itself.
+pub fn parse_document_with_limits(src: &str, limits: LosslessLimits) -> Parse {
   // `parse_lossless` is the only door that mints a `Sink`: it takes the source ONCE and uses
   // that one argument for both the sink and the input, so the buffer the tree's text comes from
   // and the buffer the parse reads cannot be two different buffers. Argument order is
@@ -128,7 +148,7 @@ pub fn parse_document(src: &str) -> Parse {
   let (cst, _out) =
     parse_lossless::<GraphqlLosslessLexer<'_, str>, crate::graphql::GraphQL, _, _, _, _>(
       src,
-      Default::default(),
+      limits,
       LosslessEmitter::default(),
       profile::<str>(),
       tokora::cache::DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),
@@ -158,12 +178,19 @@ pub fn parse_document(src: &str) -> Parse {
 /// assert!(!parse_type_system_document("type T { f: Int }").has_errors());
 /// ```
 pub fn parse_type_system_document(src: &str) -> Parse {
+  parse_type_system_document_with_limits(src, LosslessLimits::default())
+}
+
+/// [`parse_type_system_document`] under a caller-chosen resource budget.
+///
+/// See [`parse_document_with_limits`] for when to reach for one.
+pub fn parse_type_system_document_with_limits(src: &str, limits: LosslessLimits) -> Parse {
   // The turbofishes and the `_entry` suffix are `parse_document`'s, for `parse_document`'s
   // reasons; see the comment there rather than a second copy of it here.
   let (cst, _out) =
     parse_lossless::<GraphqlLosslessLexer<'_, str>, crate::graphql::GraphQL, _, _, _, _>(
       src,
-      Default::default(),
+      limits,
       LosslessEmitter::default(),
       profile::<str>(),
       tokora::cache::DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),
@@ -188,10 +215,17 @@ pub fn parse_type_system_document(src: &str) -> Parse {
 /// assert!(!parse_executable_document("query Q { f }").has_errors());
 /// ```
 pub fn parse_executable_document(src: &str) -> Parse {
+  parse_executable_document_with_limits(src, LosslessLimits::default())
+}
+
+/// [`parse_executable_document`] under a caller-chosen resource budget.
+///
+/// See [`parse_document_with_limits`] for when to reach for one.
+pub fn parse_executable_document_with_limits(src: &str, limits: LosslessLimits) -> Parse {
   let (cst, _out) =
     parse_lossless::<GraphqlLosslessLexer<'_, str>, crate::graphql::GraphQL, _, _, _, _>(
       src,
-      Default::default(),
+      limits,
       LosslessEmitter::default(),
       profile::<str>(),
       tokora::cache::DefaultCache::<GraphqlLosslessLexer<'_, str>>::default(),

--- a/smear-parser/src/graphql/lossless/selection.rs
+++ b/smear-parser/src/graphql/lossless/selection.rs
@@ -232,6 +232,8 @@ lossless_production! {
   /// progress on everything else. Deleting that guarantee hangs the suite rather than failing
   /// it.
   fn selection_set<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::SelectionSet.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphql/lossless/ty.rs
+++ b/smear-parser/src/graphql/lossless/ty.rs
@@ -104,6 +104,8 @@ lossless_production! {
   /// consumes at least one token whenever input remains, which is this loop's whole termination
   /// argument.
   fn list_type<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ListType.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphql/lossless/value.rs
+++ b/smear-parser/src/graphql/lossless/value.rs
@@ -250,6 +250,8 @@ lossless_production! {
   /// `[ Value* ]` — `[ Value[Const]* ]` when `konst` says so, the parameter riding down to
   /// every element.
   fn list_value<'inp, Src, Ctx>(inp, konst: Constness) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ListValue.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {
@@ -275,6 +277,8 @@ lossless_production! {
 
   /// `{ ObjectField* }` — const-parameterised exactly as [`list_value`] is.
   fn object_value<'inp, Src, Ctx>(inp, konst: Constness) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ObjectValue.raw(),
       |inp: &mut GraphqlLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphqlx/lossless/definition.rs
+++ b/smear-parser/src/graphqlx/lossless/definition.rs
@@ -129,6 +129,8 @@ lossless_production! {
   /// `arguments`' loop with a different member and the opposite emptiness ruling: `syntactic/`
   /// accepts the lenient `()` for `Arguments` and rejects it here.
   fn arguments_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ArgumentsDefinition.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -178,6 +180,8 @@ lossless_production! {
 
   /// `{ FieldDefinition+ }`
   fn fields_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::FieldsDefinition.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -209,6 +213,8 @@ lossless_production! {
   /// shared one, because the two blocks admit different members and a typed accessor that had to
   /// distinguish them at run time would be paying for a difference the grammar already makes.
   fn input_fields_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::InputFieldsDefinition.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -374,6 +380,8 @@ lossless_production! {
 
   /// `{ EnumValueDefinition+ }`
   fn enum_values_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::EnumValuesDefinition.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -427,6 +435,8 @@ lossless_production! {
 
   /// `{ RootOperationTypeDefinition+ }`
   fn root_operation_types_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::RootOperationTypesDefinition.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphqlx/lossless/directive.rs
+++ b/smear-parser/src/graphqlx/lossless/directive.rs
@@ -83,6 +83,8 @@ lossless_production! {
   /// `Err` and abort the whole list, so `(a: 1, !, b: 2)` would cost the rest of the parse instead
   /// of one token.
   fn arguments<'inp, Src, Ctx>(inp, konst: Constness) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::Arguments.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphqlx/lossless/executable.rs
+++ b/smear-parser/src/graphqlx/lossless/executable.rs
@@ -167,6 +167,8 @@ lossless_production! {
   /// `Arguments`. Gate 1 compares the two suites' verdicts input by input, so the two rulings are
   /// followed one production at a time rather than unified into a house rule.
   fn variables_definition<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::VariablesDefinition.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphqlx/lossless/generic.rs
+++ b/smear-parser/src/graphqlx/lossless/generic.rs
@@ -104,6 +104,8 @@ lossless_production! {
   /// would eat that `>` — a closer is a depth-zero sync point — and the list would then run to end
   /// of input hunting a closer it had already swallowed.
   fn definition_type_generics<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::DefinitionTypeGenerics.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -160,6 +162,8 @@ lossless_production! {
   /// get wrong by editing one copy. It is also what a typed accessor distinguishes them by, since
   /// `< T >` is the same bytes in both positions.
   fn angle_name_list<'inp, Src, Ctx>(inp, kind: K) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       kind.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphqlx/lossless/import.rs
+++ b/smear-parser/src/graphqlx/lossless/import.rs
@@ -112,6 +112,8 @@ lossless_production! {
   /// Nonempty (`import.rs:257` is `.at_least(1)`), and the empty form is reported with the
   /// non-consuming recovery so the `}` stays the loop's.
   fn import_list<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ImportList.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphqlx/lossless/mod.rs
+++ b/smear-parser/src/graphqlx/lossless/mod.rs
@@ -255,5 +255,7 @@ pub mod value;
 // one. A consumer picks a root here, once, rather than parsing the mixed form and filtering the
 // tree.
 pub use runner::{
-  Parse, parse_document, parse_executable_document, parse_type_system_document, profile,
+  Parse, parse_document, parse_document_with_limits, parse_executable_document,
+  parse_executable_document_with_limits, parse_type_system_document,
+  parse_type_system_document_with_limits, profile,
 };

--- a/smear-parser/src/graphqlx/lossless/mod.rs
+++ b/smear-parser/src/graphqlx/lossless/mod.rs
@@ -32,7 +32,10 @@ use tokora::{
   // macros in `crate::lossless` reach this dialect's lexer by — and a trait and a type alias share
   // one namespace.
   Lexer as TokoraLexer,
+  SimpleSpan,
   Source,
+  error::RecursionLimitReached,
+  input::Descent,
   state::tracker::LimitExceeded,
   utils::Expected,
 };
@@ -43,6 +46,7 @@ use crate::{
     GraphQLx,
     error::{Error as DialectError, ErrorData, Errors as DialectErrors, Expectation},
   },
+  lossless::depth::FromNestingLimit,
 };
 
 pub use crate::graphqlx::kinds::GraphQLxLang;
@@ -95,12 +99,13 @@ where
 = InputRef<'inp, 'input, GraphqlxLosslessLexer<'inp, Src>, Ctx, GraphQLx>;
 
 // ---------------------------------------------------------------------------------------------
-// The seven names the shared macros in `crate::lossless` reach this dialect by.
+// The eight names the shared macros in `crate::lossless` reach this dialect by.
 //
 // Aliases, not renames, exactly as GraphQL's are: the `GraphqlxLossless*` spellings stay, because
 // they are what every signature in this suite reads. What these buy is that
 // `lossless_production!` and `lossless_drivers!` — written once, over `Input`, `Error`, `Token`,
-// `Lexer`, `Brand`, `TokenKind` and `Keyword` — apply here with nothing but a `dialect =` header.
+// `Lexer`, `LexerState`, `Brand`, `TokenKind` and `Keyword` — apply here with nothing but a
+// `dialect =` header.
 //
 // The macros take **two fixed idents** (`graphqlx::lossless`), not a `$dialect:path`. That is not
 // a style choice: a `:path` fragment is an opaque AST node, so `$dialect::Input<…>` parses as an
@@ -126,6 +131,15 @@ pub type Keyword = smear_lexer::graphqlx::ContextualKeyword;
 #[allow(type_alias_bounds)]
 pub type Lexer<'inp, Src: Source<usize> + ?Sized> = GraphqlxLosslessLexer<'inp, Src>;
 
+/// The resource budget this dialect's lossless lex runs under — the Logos `Extras`, and the
+/// [`Lexer::State`](tokora::Lexer::State) the shared production bundle pins.
+///
+/// Pinned rather than left as a projection because a production has to *read* it: the nesting
+/// ceiling a parse was configured with lives here, and this module's `descend` hands it to the
+/// parser-frame budget. Over a generic `Src` the projection has nothing to normalize against
+/// without the equality, exactly as the token's `Kind` does not.
+pub type LexerState = smear_lexer::limits::LosslessLimits;
+
 /// [`GraphqlxLosslessToken`], under the name the shared macros reach it by.
 #[allow(type_alias_bounds)]
 pub type Token<'inp, Src: Source<usize> + ?Sized> = GraphqlxLosslessToken<'inp, Src>;
@@ -138,6 +152,44 @@ pub type Input<'inp, 'input, Src: Source<usize> + ?Sized, Ctx> =
 /// [`GraphqlxLosslessError`], under the name the shared macros reach it by.
 #[allow(type_alias_bounds)]
 pub type Error<'inp, Src: Source<usize> + ?Sized, Ctx> = GraphqlxLosslessError<'inp, Src, Ctx>;
+
+/// Enters one level of parser recursion under this dialect's configured nesting ceiling.
+///
+/// The whole body is reading the ceiling off the lexer state and handing it to
+/// [`crate::lossless::depth::descend`], which is where the reasoning lives. It exists per dialect
+/// only because the substrate may not name `smear-lexer`, so the number has to be read on this
+/// side of the line.
+///
+/// **Bind the guard for the whole frame** — `let mut frame = descend(inp)?; let inp = &mut *frame;`
+/// — because dropping it early releases the level before the recursion it was taken for, which
+/// type-checks and silently reinstates the unbounded descent.
+#[inline]
+pub(crate) fn descend<'r, 'inp, 'input, Src, Ctx>(
+  inp: &'r mut GraphqlxLosslessInput<'inp, 'input, Src, Ctx>,
+) -> Result<
+  Descent<'r, 'inp, 'input, GraphqlxLosslessLexer<'inp, Src>, Ctx, GraphQLx>,
+  GraphqlxLosslessError<'inp, Src, Ctx>,
+>
+where
+  Src: Source<usize> + ?Sized,
+  GraphqlxLosslessToken<'inp, Src>: tokora::Token<'inp, Kind = TokenKind>
+    + tokora::lexer::FromLogos<'inp>
+    + Clone
+    + tokora::utils::DowncastRef<Keyword>,
+  GraphqlxLosslessLexer<'inp, Src>: TokoraLexer<
+      'inp,
+      Token = GraphqlxLosslessToken<'inp, Src>,
+      Span = SimpleSpan,
+      Offset = usize,
+      State = LexerState,
+    >,
+  Ctx: tokora::ParseContext<'inp, GraphqlxLosslessLexer<'inp, Src>, GraphQLx>,
+  GraphqlxLosslessError<'inp, Src, Ctx>:
+    From<RecursionLimitReached<usize, GraphQLx>> + FromNestingLimit,
+{
+  let ceiling = inp.state().max_nesting_depth();
+  crate::lossless::depth::descend(inp, ceiling)
+}
 
 /// One error value a GraphQLx lossless parse can record.
 ///

--- a/smear-parser/src/graphqlx/lossless/runner.rs
+++ b/smear-parser/src/graphqlx/lossless/runner.rs
@@ -1,6 +1,7 @@
 //! The Sink runner: binds a source to a `cst::Sink`, drives the document production, and
 //! materializes a `rowan` tree.
 
+use smear_lexer::limits::LosslessLimits;
 use tokora::{
   Source,
   cst::{Cst, CstProfile, KindValidator, parse_lossless},
@@ -111,7 +112,26 @@ pub type Parse = crate::lossless::runner::Parse<crate::graphqlx::kinds::GraphQLx
 /// filter to write afterwards — see [`parse_type_system_document`] and
 /// [`parse_executable_document`]. The difference is not cosmetic: those roots reject the other
 /// half *at the parser's own position*, which a caller walking a mixed tree cannot reconstruct.
+///
+/// # The nesting ceiling
+///
+/// [`LosslessLimits::default`], so at most
+/// [`MAX_NESTING_DEPTH`](smear_lexer::limits::MAX_NESTING_DEPTH) simultaneously open brackets;
+/// the next one is reported. That default is derived against a 2 MiB stack, which is what
+/// `std::thread::spawn`, a tokio worker and the libtest harness each give a thread. A caller on a
+/// different stack, or with deeper documents, uses [`parse_document_with_limits`].
 pub fn parse_document(src: &str) -> Parse {
+  parse_document_with_limits(src, LosslessLimits::default())
+}
+
+/// [`parse_document`] under a caller-chosen resource budget.
+///
+/// The reason to reach for this is a stack that is not the 2 MiB
+/// [`MAX_NESTING_DEPTH`](smear_lexer::limits::MAX_NESTING_DEPTH) is derived against — a server on
+/// an 8 MiB main thread can afford roughly four times the depth, and a worker deliberately spawned
+/// smaller can afford less. The cost of one level is measured on
+/// [`MAX_NESTING_DEPTH`](smear_lexer::limits::MAX_NESTING_DEPTH) itself.
+pub fn parse_document_with_limits(src: &str, limits: LosslessLimits) -> Parse {
   // `parse_lossless` is the only door that mints a `Sink`: it takes the source ONCE and uses
   // that one argument for both the sink and the input, so the buffer the tree's text comes from
   // and the buffer the parse reads cannot be two different buffers. Argument order is
@@ -128,7 +148,7 @@ pub fn parse_document(src: &str) -> Parse {
   let (cst, _out) =
     parse_lossless::<GraphqlxLosslessLexer<'_, str>, crate::graphqlx::GraphQLx, _, _, _, _>(
       src,
-      Default::default(),
+      limits,
       LosslessEmitter::default(),
       profile::<str>(),
       tokora::cache::DefaultCache::<GraphqlxLosslessLexer<'_, str>>::default(),
@@ -160,12 +180,19 @@ pub fn parse_document(src: &str) -> Parse {
 /// assert!(!parse_type_system_document("type T { f: Int }").has_errors());
 /// ```
 pub fn parse_type_system_document(src: &str) -> Parse {
+  parse_type_system_document_with_limits(src, LosslessLimits::default())
+}
+
+/// [`parse_type_system_document`] under a caller-chosen resource budget.
+///
+/// See [`parse_document_with_limits`] for when to reach for one.
+pub fn parse_type_system_document_with_limits(src: &str, limits: LosslessLimits) -> Parse {
   // The turbofishes and the `_entry` suffix are `parse_document`'s, for `parse_document`'s
   // reasons; see the comment there rather than a second copy of it here.
   let (cst, _out) =
     parse_lossless::<GraphqlxLosslessLexer<'_, str>, crate::graphqlx::GraphQLx, _, _, _, _>(
       src,
-      Default::default(),
+      limits,
       LosslessEmitter::default(),
       profile::<str>(),
       tokora::cache::DefaultCache::<GraphqlxLosslessLexer<'_, str>>::default(),
@@ -190,10 +217,17 @@ pub fn parse_type_system_document(src: &str) -> Parse {
 /// assert!(!parse_executable_document("query Q { f }").has_errors());
 /// ```
 pub fn parse_executable_document(src: &str) -> Parse {
+  parse_executable_document_with_limits(src, LosslessLimits::default())
+}
+
+/// [`parse_executable_document`] under a caller-chosen resource budget.
+///
+/// See [`parse_document_with_limits`] for when to reach for one.
+pub fn parse_executable_document_with_limits(src: &str, limits: LosslessLimits) -> Parse {
   let (cst, _out) =
     parse_lossless::<GraphqlxLosslessLexer<'_, str>, crate::graphqlx::GraphQLx, _, _, _, _>(
       src,
-      Default::default(),
+      limits,
       LosslessEmitter::default(),
       profile::<str>(),
       tokora::cache::DefaultCache::<GraphqlxLosslessLexer<'_, str>>::default(),

--- a/smear-parser/src/graphqlx/lossless/selection.rs
+++ b/smear-parser/src/graphqlx/lossless/selection.rs
@@ -236,6 +236,8 @@ lossless_production! {
   /// [`selection`] dispatches only on heads its arms consume, and `unexpected` guarantees progress
   /// on everything else.
   fn selection_set<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::SelectionSet.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {

--- a/smear-parser/src/graphqlx/lossless/ty.rs
+++ b/smear-parser/src/graphqlx/lossless/ty.rs
@@ -93,6 +93,8 @@ lossless_production! {
   /// a path with no arguments. The first element is parsed unconditionally and the loop handles the
   /// rest, which is what makes the emptiness a diagnostic instead of a silently accepted shape.
   fn type_generics<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::TypeGenerics.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -165,6 +167,8 @@ lossless_production! {
   /// input arrives. `unexpected` consumes at least one token whenever input remains, which is this
   /// loop's whole termination argument.
   fn list_type<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ListType.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -197,6 +201,8 @@ lossless_production! {
   /// The caller has already crossed the leading trivia at its dispatch peek, so the mark is minted
   /// after that trivia is committed and the node starts at its own `<`.
   fn set_or_map_type<'inp, Src, Ctx>(inp) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     let mark = inp.cst_mark();
     expect::<Src, Ctx>(inp, Kind::LAngle)?;
     let open = opener_span(inp.span().end());

--- a/smear-parser/src/graphqlx/lossless/value.rs
+++ b/smear-parser/src/graphqlx/lossless/value.rs
@@ -232,6 +232,8 @@ lossless_production! {
   /// `[ Value* ]` — `[ Value[Const]* ]` when `konst` says so, the parameter riding down to every
   /// element.
   fn list_value<'inp, Src, Ctx>(inp, konst: Constness) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ListValue.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -255,6 +257,8 @@ lossless_production! {
 
   /// `{ ObjectField* }` — const-parameterised exactly as [`list_value`] is.
   fn object_value<'inp, Src, Ctx>(inp, konst: Constness) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     node(
       K::ObjectValue.raw(),
       |inp: &mut GraphqlxLosslessInput<'inp, '_, Src, Ctx>| {
@@ -323,6 +327,8 @@ lossless_production! {
     konst: Constness,
     collection: Collection,
   ) {
+    let mut frame = super::descend::<Src, Ctx>(inp)?;
+    let inp = &mut *frame;
     let kind = match collection {
       Collection::Set => K::SetValue,
       Collection::Map => K::MapValue,

--- a/smear-parser/src/graphqlx/syntactic/generic/tests.rs
+++ b/smear-parser/src/graphqlx/syntactic/generic/tests.rs
@@ -2,7 +2,7 @@
 
 use std::{format, string::String};
 
-use smear_lexer::graphqlx::syntactic::SyntacticTokenKind;
+use smear_lexer::{graphqlx::syntactic::SyntacticTokenKind, limits::SyntacticLimits};
 use tokora::{FatalContext, Parse, Parser, SimpleSpan, utils::cmp::Equivalent};
 
 use super::super::{GraphqlxInput, GraphqlxLexer};
@@ -30,6 +30,26 @@ fn drive_str<'inp, O>(
     f,
   )
   .parse_str(input)
+}
+
+/// [`drive_str`] with the nesting ceiling raised for the one probe that needs it.
+///
+/// GraphQLx counts `<` and `>` on the same tally as `{`, `[` and `(`, so a type path nested past
+/// `smear_lexer::limits::MAX_NESTING_DEPTH` angle brackets is refused by the lexer before any
+/// production sees it (smear issue #61). One test below deliberately nests 33 deep — its subject
+/// is that the where-clause's *structural lookahead* has no window of its own, and a probe of that
+/// has to be deeper than any window could plausibly be. Lowering it to fit the ceiling would
+/// weaken the claim it makes, so the ceiling moves instead, which is what the knob is for.
+fn drive_str_deep<'inp, O>(
+  f: impl for<'c> FnMut(
+    &mut GraphqlxInput<'inp, 'c, str, StrCtx<'inp>>,
+  ) -> Result<O, GraphqlxErrors<&'inp str>>,
+  input: &'inp str,
+) -> Result<O, GraphqlxErrors<&'inp str>> {
+  Parser::with_parser::<'inp, GraphqlxLexer<'inp, str>, O, GraphqlxErrors<&'inp str>, _, GraphQLx>(
+    f,
+  )
+  .parse_str_with_state(input, SyntacticLimits::with_max_nesting_depth(128))
 }
 
 fn drive_slice<'inp, O>(
@@ -346,7 +366,9 @@ fn where_clause_lookahead_leaves_an_ordinary_definition_head_for_the_caller() {
 
   let nested = (0..33).fold(String::from("T"), |path, _| format!("Wrapper<{path}>"));
   let source = format!("where First: Node {nested}: Serializable type Query");
-  let (predicate_count, following) = drive_str(
+  // `drive_str_deep`, not `drive_str`: 33 angle brackets are past the default nesting ceiling and
+  // the lexer would refuse the source before the lookahead under test ran. See that function.
+  let (predicate_count, following) = drive_str_deep(
     |inp| {
       let clause = ast::WhereClause::graphqlx(inp)?;
       let following = super::super::name(inp)?;

--- a/smear-parser/src/lossless/depth.rs
+++ b/smear-parser/src/lossless/depth.rs
@@ -1,0 +1,150 @@
+//! The **parser-frame** nesting bound: one level per recursive production entry, released by an
+//! RAII guard on every exit path.
+//!
+//! # Why this exists beside the lexer's bracket tally
+//!
+//! The lexer already carries a nesting counter, and #61's first fix put a measured ceiling on it.
+//! That counter is a **proxy**: it tallies every `{`, `[`, `(` — and, in GraphQLx, `<` and `>` —
+//! pair-blind, one saturating scalar, decrementing on *any* closer regardless of which opener the
+//! parser is actually inside. The parse's own recursion is a different quantity, and recovery is
+//! where the two come apart:
+//!
+//! - a selection set's loop meets a closer no opener matched;
+//! - [`recover::unexpected`](super::recover::unexpected) reports it, `sync_balanced` finds it is
+//!   itself a sync point and skips nothing, so the fallback consumes it into an `Error` node;
+//! - the loop continues, and the next `f {` opens **another** selection set.
+//!
+//! Over `{ ) f { ) f { …` the tally therefore oscillates between 1 and 0 for the whole document
+//! while every level leaves a `field` frame and a `selection_set` frame live. Measured on this
+//! tree at `6f39cb9`: the tally's maximum is **1** at every depth, the ceiling never fires, and a
+//! 3.5 KB document aborts a 2 MiB thread with `fatal runtime error: stack overflow` at 702 levels
+//! (GraphQLx: 700, with `)` and with its angle closer `>` alike). That is the failure #61 is
+//! about, reached past the fix for it.
+//!
+//! # What is counted here, and why it is every delimiter rather than the shape that was reported
+//!
+//! One level per **nesting delimiter the parse actually descends through** — the same population
+//! the lexer tallies, counted by the side that recurses. A production reaches this exactly where
+//! it commits an opener it will parse the interior of: `selection_set`, `arguments`,
+//! `variable_definitions`, `list_value`, `object_value`, `list_type`, every `{ … }` member block,
+//! and GraphQLx's generic `< … >`. So `MAX_NESTING_DEPTH` keeps the meaning it was derived with —
+//! "simultaneously open brackets" — and the derivation behind the number is untouched. What
+//! changed is that a closer no opener matched can no longer discount a level, because a level is
+//! now released by leaving the frame rather than by seeing a byte.
+//!
+//! **The selection-set shape is not the only cycle, and that is measured rather than assumed.**
+//! `{ f(a: [ ) [ ) [ …` runs `list_value` into `list_value` and `{ f(a: { ) k: { ) k: …` runs
+//! `object_value` into `object_value`, both with the tally pinned at 3, and both abort a 2 MiB
+//! thread at 2 000 levels when only `selection_set` holds a level. A fix derived from the
+//! reported exemplar would have left them live; `nesting_depth.rs` pins all three.
+//!
+//! # The cell, and why it is tokora's rather than the lexer state's
+//!
+//! [`InputRef::descend`](tokora::InputRef::descend)'s, whose [`Descent`] guard releases the level
+//! on return, on `?` and on an unwind alike. It is deliberately **not** in
+//! [`Lexer::State`], where the lexer's tally lives, and the difference is
+//! not stylistic:
+//!
+//! - a [`Checkpoint`](tokora::input::Checkpoint) carries `L::State`, so a speculative branch's
+//!   rollback would restore a depth whose frames are still live;
+//! - a **cached** token carries the state that lexed it, and committing it installs that state —
+//!   so a token read during lookahead at one depth would reset the cell when it is committed at
+//!   another.
+//!
+//! Both are correct for a lexer tally, which is a function of the token prefix and nothing else,
+//! and both are wrong for a control-stack fact. tokora's cell is outside the checkpoint set for
+//! exactly that reason.
+//!
+//! # The ceiling arrives as a `usize`, not as a type
+//!
+//! This module may not name `smear-lexer` — the substrate is dialect-generic and
+//! `lossless_isolation.rs` enforces it — so the caller reads
+//! `inp.state().max_nesting_depth()` and passes the number. Each dialect's `lossless/mod.rs` has a
+//! one-line `descend` wrapper that does exactly that, so a production still writes one call.
+//!
+//! # The upstream ceiling above smear's
+//!
+//! tokora's own parse-side budget defaults to depth **64** and is set by
+//! `InputContext::new`, which [`parse_lossless`](tokora::cst::parse_lossless) calls without a
+//! hook: neither `parse_document_with_limits` nor any other smear entry point can raise it. The
+//! effective bound is therefore `min(the caller's ceiling, 64)`, and [`descend`] reads tokora's
+//! `limitation()` so that the trip is **reported by smear** rather than surfacing as an
+//! unemitted `RecursionLimitReached` on the discarded `Result`. At the shipped
+//! `MAX_NESTING_DEPTH` of 24 the two are 2.7x apart and only smear's fires; a caller who raises
+//! past 64 gets a clean, positioned diagnostic at 64 rather than the depth they asked for. That
+//! is a limitation of the door, recorded here because it is invisible at the call site.
+
+use tokora::{
+  InputRef, Lexer, ParseContext, SimpleSpan, error::RecursionLimitReached, input::Descent,
+  span::Spanned,
+};
+
+use crate::combinator::ErrorOf;
+
+/// A dialect error container that can name a refused descent.
+///
+/// One method rather than a `From` impl, because the payload is three plain numbers and a span
+/// rather than a type: a `From<…>` would need a shared error struct in the substrate, and the
+/// substrate may not put a type into a dialect's error enum.
+pub trait FromNestingLimit {
+  /// The parse tried to enter level `attempted` under a ceiling of `limit`.
+  ///
+  /// `span` is empty and sits at the parse's committed end — the position the descent was refused
+  /// at. A refused frame has consumed nothing of its own yet, so there is no lexeme to point at.
+  fn nesting_limit_exceeded(span: SimpleSpan, attempted: usize, limit: usize) -> Self;
+}
+
+/// Enters one level of parser recursion, or reports and refuses.
+///
+/// **Bind the guard for the whole frame.** It is `#[must_use]` and dropping it early releases the
+/// level before the recursion it was taken for — tokora's `Descent` docs measure four spellings
+/// that do exactly that and only one of which warns. The shape every call site here writes is:
+///
+/// ```text
+/// let mut frame = super::descend::<Src, Ctx>(inp)?;
+/// let inp = &mut *frame;
+/// ```
+///
+/// # The trip is emitted *and* returned
+///
+/// Emitted because the lossless door discards the parser's `Result` — `parse_document` keeps the
+/// tree and the diagnostics — so a trip that only rode the `Result` would leave a consumer with a
+/// truncated tree, no diagnostic and no way to ask. Returned because the frame must not run: the
+/// error unwinds every live production, and the document entry's drain then commits the tail, so
+/// the tree still covers every byte.
+///
+/// The check runs **before** the descent, so tokora's own budget can never trip unreported: this
+/// refuses at `min(ceiling, tokora's limitation)`, which is at or below where
+/// [`InputRef::descend`](tokora::InputRef::descend) would.
+#[inline]
+pub fn descend<'r, 'inp, 'closure, L, Ctx, Lang>(
+  inp: &'r mut InputRef<'inp, 'closure, L, Ctx, Lang>,
+  ceiling: usize,
+) -> Result<Descent<'r, 'inp, 'closure, L, Ctx, Lang>, ErrorOf<'inp, L, Ctx, Lang>>
+where
+  Lang: ?Sized,
+  L: Lexer<'inp, Span = SimpleSpan, Offset = usize>,
+  Ctx: ParseContext<'inp, L, Lang>,
+  ErrorOf<'inp, L, Ctx, Lang>: From<RecursionLimitReached<usize, Lang>> + FromNestingLimit,
+{
+  let live = inp.recursion().depth();
+  // `min`, because the caller's ceiling is not the only one: see the module header's note on
+  // tokora's own 64. Reading it here is what keeps every refusal reported.
+  let limit = ceiling.min(inp.recursion().limitation());
+  if live >= limit {
+    let end = inp.span().end();
+    let span = SimpleSpan::new(end, end);
+    inp.emit_error(Spanned::new(
+      span,
+      ErrorOf::<'inp, L, Ctx, Lang>::nesting_limit_exceeded(span, live + 1, limit),
+    ))?;
+    return Err(ErrorOf::<'inp, L, Ctx, Lang>::nesting_limit_exceeded(
+      span,
+      live + 1,
+      limit,
+    ));
+  }
+
+  // Cannot trip: `live < limit <= inp.recursion().limitation()`.
+  inp.descend()
+}

--- a/smear-parser/src/lossless/macros.rs
+++ b/smear-parser/src/lossless/macros.rs
@@ -57,11 +57,16 @@
 /// }
 /// ```
 ///
-/// # The seven names a dialect owes this macro
+/// # The eight names a dialect owes this macro
 ///
-/// `Input`, `Error`, `Token`, `Lexer`, `Brand`, `TokenKind` and `Keyword`, at
+/// `Input`, `Error`, `Token`, `Lexer`, `LexerState`, `Brand`, `TokenKind` and `Keyword`, at
 /// `crate::<dialect>::lossless`. They are aliases over whatever that dialect already calls those
 /// things, so adopting the macro renames nothing.
+///
+/// `LexerState` is the eighth and the newest: the `State =` pin on the `Lexer` clause is what lets
+/// a production read the resource budget the parse runs under — which is where the nesting
+/// ceiling lives — through `inp.state()`. Without the equality the projection has nothing to
+/// normalize against over a generic `Src`, exactly as `Kind =` does not for the token.
 ///
 /// # Why the bundle is one block, and why it is here rather than per dialect
 ///
@@ -91,6 +96,11 @@
 /// - **`Ctx::Emitter: CstEmitter`** — the structural gate on the whole `node` family.
 /// - **the three error conversions** — `UnexpectedEot` for every peek, `UnexpectedToken` for every
 ///   declined `expect`, and `FromUnclosed` for the unterminated-delimiter reports.
+/// - **`RecursionLimitReached` and `FromNestingLimit`** — the parser-frame descent
+///   ([`crate::lossless::depth`]). The first is [`InputRef::descend`](tokora::InputRef::descend)'s
+///   own where-clause; the second is how the refusal reaches the dialect's error container. They
+///   ride the whole bundle rather than only the delimiter productions because the bundle is one
+///   block and a per-production subset is the drift this macro exists to prevent.
 ///
 /// # The clause that used to be here and is not
 ///
@@ -138,6 +148,7 @@ macro_rules! lossless_production {
           Token = $crate::$dm::$dl::Token<$lt, $src>,
           Span = ::tokora::SimpleSpan,
           Offset = usize,
+          State = $crate::$dm::$dl::LexerState,
         >,
       $ctx: ::tokora::ParseContext<
         $lt,
@@ -166,7 +177,11 @@ macro_rules! lossless_production {
             $lt,
             $crate::$dm::$dl::Lexer<$lt, $src>,
             $crate::$dm::$dl::Brand,
-          >,
+          >
+          + ::core::convert::From<
+            ::tokora::error::RecursionLimitReached<usize, $crate::$dm::$dl::Brand>,
+          >
+          + $crate::lossless::depth::FromNestingLimit,
     $body
   )*};
 }
@@ -501,6 +516,57 @@ macro_rules! lossless_error_impls {
           )
           .into(),
         }
+      }
+    }
+
+    /// The **parser-frame** nesting refusal, landed in the dialect container.
+    ///
+    /// Raised by [`crate::lossless::depth::descend`] when a production tries to enter one level
+    /// more than the budget admits, and reported at an empty span on the parse's committed end:
+    /// the refused frame has consumed nothing of its own, so there is no lexeme to point at.
+    ///
+    /// **The payload is a message, not a variant, and that is the same ruling the lexer's own
+    /// trip already carries.** A depth trip reaches a consumer through
+    /// [`Parse::diagnostics`](crate::lossless::runner::Parse::diagnostics), which keeps the span
+    /// and the severity and drops the typed payload to stay lifetime-free — so a dedicated
+    /// `ErrorData` variant would be observable nowhere the trip is actually read. The residual is
+    /// the one `lossless/runner.rs` already records: a consumer sees a positioned error rather
+    /// than "this document is too deeply nested", and closing that is a change to the *diagnostic
+    /// surface*, not to this conversion.
+    impl<S> $crate::lossless::depth::FromNestingLimit for $errors<S> {
+      #[inline]
+      fn nesting_limit_exceeded(
+        span: ::tokora::SimpleSpan,
+        _attempted: usize,
+        _limit: usize,
+      ) -> Self {
+        $value::new(
+          span,
+          $error_data::Other(::std::borrow::Cow::Borrowed("nesting limit exceeded")),
+        )
+        .into()
+      }
+    }
+
+    /// tokora's own descent trip, landed on the same message.
+    ///
+    /// [`InputRef::descend`](::tokora::InputRef::descend) carries this conversion as a
+    /// where-clause, so it has to exist for a production to descend at all. It is **not** the
+    /// path a trip normally takes: `depth::descend` checks against tokora's `limitation()` too
+    /// and refuses first, precisely so that every refusal is emitted rather than riding a
+    /// `Result` the lossless door discards. This impl is what makes that check spellable, and the
+    /// backstop if tokora ever trips somewhere smear did not look.
+    impl<S, Lang: ?Sized>
+      ::core::convert::From<::tokora::error::RecursionLimitReached<usize, Lang>> for $errors<S>
+    {
+      #[inline]
+      fn from(err: ::tokora::error::RecursionLimitReached<usize, Lang>) -> Self {
+        let off = err.offset();
+        $value::new(
+          ::tokora::SimpleSpan::new(off, off),
+          $error_data::Other(::std::borrow::Cow::Borrowed("nesting limit exceeded")),
+        )
+        .into()
       }
     }
   };

--- a/smear-parser/src/lossless/mod.rs
+++ b/smear-parser/src/lossless/mod.rs
@@ -32,6 +32,8 @@ pub mod ast;
 
 pub mod coverage;
 
+pub mod depth;
+
 // Gated on there being a dialect assembly to consume them. `rowan` alone — which is what
 // `cargo hack --each-feature` builds, and what `lossless-coverage` implies — compiles this
 // substrate with no dialect in the crate, and three macros nobody invokes are three

--- a/smear-parser/src/lossless/project.rs
+++ b/smear-parser/src/lossless/project.rs
@@ -607,7 +607,10 @@ pub fn verify_source_at<K>(
 ) -> Result<(), ProjectError<K>> {
   // Recursive rather than an explicit stack, which would need a `Vec` this walk otherwise has no
   // reason to allocate. The depth is the tree's, and the tree's is the lexer's bracket budget
-  // (tokora's `RecursionLimiter`, 500) plus a grammar constant — a few tens of KiB of frames.
+  // (the lexer crate's `MAX_NESTING_DEPTH`) plus a grammar constant. That budget used to be
+  // tokora's inherited 500, which put this walk at a few tens of KiB of frames; smear issue #61
+  // replaced it with a number measured against a 2 MiB stack, so the bound this comment relies on
+  // got an order of magnitude cheaper rather than merely staying true.
   fn walk(green: &GreenNodeData, source: &[u8], offset: &mut usize) -> Result<(), Range<usize>> {
     for child in green.children() {
       match child {

--- a/smear-parser/src/lossless/runner.rs
+++ b/smear-parser/src/lossless/runner.rs
@@ -120,13 +120,14 @@ impl<L: rowan::Language> Parse<L> {
 /// **Both of those are reachable from ordinary input**, so under `finish` they were a panic on a
 /// public entry point:
 ///
-/// - The nesting budget is the **lexer's**, not the parser's. Every `{`, `[` and `(` steps the
-///   budget carried in the Logos `Extras`, and nothing in this crate descends through
-///   [`InputRef::descend`](tokora::InputRef::descend), so the parser-side limiter is never
-///   consulted at all. That budget's ceiling is now the lexer crate's own `MAX_NESTING_DEPTH`,
-///   chosen against a measured native-stack boundary; when #57 was filed it was tokora's
-///   general-purpose **500**, inherited — see issue #61 for why an inherited ceiling was not a
-///   ceiling.
+/// - When #57 was filed the nesting budget was the **lexer's** alone: every `{`, `[` and `(`
+///   stepped the budget carried in the Logos `Extras`, nothing in this crate descended through
+///   [`InputRef::descend`](tokora::InputRef::descend), and its ceiling was tokora's inherited,
+///   general-purpose **500**. Both halves of that have since moved — see issue #61 for why an
+///   inherited ceiling was not a ceiling, and [`crate::lossless::depth`] for why a pair-blind
+///   lexer tally was not the parse's recursion. The lexer's counter is still there, still steps
+///   on every delimiter, and is still what latches the boundary below; what it is no longer is
+///   the only thing between a document and the stack.
 /// - The bracket **past** the budget therefore fails its lex, and a resource-limit trip *latches a
 ///   poison boundary*: the scanner refuses to rebuild a lexer past that offset. No token and no
 ///   diagnostic can ever cover the tail, and a dialect's `document_entry` `skip_while` drain

--- a/smear-parser/src/lossless/runner.rs
+++ b/smear-parser/src/lossless/runner.rs
@@ -121,23 +121,52 @@ impl<L: rowan::Language> Parse<L> {
 /// public entry point:
 ///
 /// - The nesting budget is the **lexer's**, not the parser's. Every `{`, `[` and `(` steps the
-///   [`Limiter`](tokora::state::tracker::Limiter) carried in the Logos `Extras`, and that
-///   tracker's inherited ceiling is tokora's *general-purpose* **500**
-///   ([`RecursionLimiter::new`](tokora::state::recursion_tracker::RecursionLimiter)), not the
-///   parser-facing 64 — nothing in this crate descends through
+///   budget carried in the Logos `Extras`, and nothing in this crate descends through
 ///   [`InputRef::descend`](tokora::InputRef::descend), so the parser-side limiter is never
-///   consulted at all.
-/// - The **501st** simultaneously-open bracket therefore fails its lex, and a resource-limit trip
-///   *latches a poison boundary*: the scanner refuses to rebuild a lexer past that offset. No
-///   token and no diagnostic can ever cover the tail, and a dialect's `document_entry`
-///   `skip_while` drain cannot reach it either — that drain is the mechanism which otherwise
-///   guarantees coverage.
+///   consulted at all. That budget's ceiling is now the lexer crate's own `MAX_NESTING_DEPTH`,
+///   chosen against a measured native-stack boundary; when #57 was filed it was tokora's
+///   general-purpose **500**, inherited — see issue #61 for why an inherited ceiling was not a
+///   ceiling.
+/// - The bracket **past** the budget therefore fails its lex, and a resource-limit trip *latches a
+///   poison boundary*: the scanner refuses to rebuild a lexer past that offset. No token and no
+///   diagnostic can ever cover the tail, and a dialect's `document_entry` `skip_while` drain
+///   cannot reach it either — that drain is the mechanism which otherwise guarantees coverage.
 /// - So `finish` reported `UncoveredGap` and `parse_document` panicked, at 501 open brackets, for
 ///   input an IDE produces by typing. That was smear issue #57.
 ///
 /// Under this door the same parse hands back a tree over every byte (`tree.text() == source`
 /// still holds, the un-lexable tail tiled as gaps) plus the limit trip already on the diagnostic
 /// channel, which is where a consumer routes on it.
+///
+/// # The trip ends the document, deliberately — smear issue #61's second half
+///
+/// The latch above is tokora's design and smear **keeps** it, which is a posture and therefore
+/// owes a reason. The reason is what the boundary means: a depth trip is a *resource refusal*, not
+/// a syntax error, and `poison_boundary` states exactly that — "no amount of further input will
+/// fix this". Resuming past it would mean re-entering the same unbounded descent the budget exists
+/// to stop, on a document that has already proved it goes there; a ceiling that is re-armed after
+/// every trip bounds one region and not the parse.
+///
+/// The case against it is an IDE, where one over-deep region voiding the rest of the file is close
+/// to the worst available behaviour, and #61 is right that lowering the ceiling from 500 to a
+/// stack-derived number makes the latch that much easier to reach. Three measured facts are why it
+/// is still the right posture:
+///
+/// - **It is not reachable by typing.** A trip needs more simultaneously open brackets than the
+///   ceiling. The deepest GraphQL document in this repository — 472 fixtures, real-world subgraph
+///   schemas included — reaches **11**. A file that trips is machine-generated or hostile.
+/// - **The alternative is worse for the same consumer.** The tree still covers every byte and the
+///   prefix is fully structured; a parse that refused the *whole* document on a depth trip would
+///   give an IDE strictly less.
+/// - **The syntactic door cannot express the question.** There the whole parse returns `Err`, so
+///   there is no partial result for a latch to void. Keeping the two doors' answers the same is
+///   what the acceptance-parity gate compares.
+///
+/// What the latch costs is that a consumer sees the trip as an ordinary error diagnostic on the
+/// tripping bracket plus one opaque region, rather than as "this document is too deeply nested".
+/// [`Diagnostic`] drops the typed payload at this boundary on purpose — that is what keeps
+/// [`Parse`] lifetime-free — so distinguishing the two would be a change to the diagnostic
+/// surface rather than to the latch, and it is recorded here as the residual it is.
 ///
 /// Nothing else is relaxed. Balance underflow, close identity, retro-wrap integrity, kind
 /// hygiene, span discipline and the token-channel wall are enforced identically through both

--- a/smear/src/json/tests.rs
+++ b/smear/src/json/tests.rs
@@ -484,7 +484,10 @@ use core::fmt;
 
 use graphql_proto::{Executor, Leaf, Response, Values};
 use smear_compiler::Schema;
-use smear_lexer::tokora::{Parse as _, Parser, state::recursion_tracker::RecursionLimiter};
+use smear_lexer::{
+  limits::SyntacticLimits,
+  tokora::{Parse as _, Parser},
+};
 use smear_parser::graphql::{
   GraphQL,
   ast::{ExecutableDocument, TypeSystemDocument},
@@ -557,7 +560,7 @@ fn parse_executable(query: &str, nesting: usize) -> Result<ExecutableDocument<&s
     _,
     GraphQL,
   >(executable_document)
-  .parse_str_with_state(query, RecursionLimiter::with_limitation(nesting))
+  .parse_str_with_state(query, SyntacticLimits::with_max_nesting_depth(nesting))
   .map_err(|_| ())
 }
 
@@ -579,7 +582,7 @@ fn run<T>(
     _,
     GraphQL,
   >(type_system_document)
-  .parse_str_with_state(sdl, RecursionLimiter::with_limitation(nesting))
+  .parse_str_with_state(sdl, SyntacticLimits::with_max_nesting_depth(nesting))
   .expect("the SDL parses");
   let schema = Schema::build(&schema_document).expect("the SDL is a schema");
   let document = parse_executable(query, nesting).expect("the query parses");

--- a/smear/tests/lossless_isolation.rs
+++ b/smear/tests/lossless_isolation.rs
@@ -224,6 +224,7 @@ const ALLOWED_CRATE_ROOTS: &[(&str, &[&str])] = &[
       "crate::lossless",
       "crate::type_system",
       "smear_lexer::graphql",
+      "smear_lexer::limits",
     ],
   ),
   (
@@ -233,6 +234,7 @@ const ALLOWED_CRATE_ROOTS: &[(&str, &[&str])] = &[
       "crate::graphqlx",
       "crate::lossless",
       "smear_lexer::graphqlx",
+      "smear_lexer::limits",
     ],
   ),
 ];

--- a/smear/tests/lossless_runner.rs
+++ b/smear/tests/lossless_runner.rs
@@ -153,10 +153,13 @@ fn brace_offset(level: usize) -> usize {
 ///
 /// # Which of the two candidate defects it was
 ///
-/// Neither, as the issue framed them. The budget is not the parser's: nothing in this crate
-/// descends through `InputRef::descend`, so tokora's parser-facing `RecursionLimiter` (64) is
-/// never consulted, and no amount of nesting trips it. It is the **lexer's** — every `{`, `[` and
-/// `(` steps the budget carried in the Logos `Extras`.
+/// Neither, as the issue framed them. The budget that trips *here* is the **lexer's** — every
+/// `{`, `[` and `(` steps the one carried in the Logos `Extras`, and it is what latches the
+/// boundary this test is about. When #57 was filed it was also the only budget: nothing descended
+/// through `InputRef::descend`. That is no longer true — the lossless productions now take a
+/// parser-frame level per delimiter (`smear-parser`'s `lossless::depth`, issue #61's second
+/// half) — but the lexer runs ahead of the parse, so on a document whose closers match, the tally
+/// still reaches the ceiling first and this test's shape is unchanged by it.
 ///
 /// It does trip, and what follows the trip is what broke. A resource-limit trip **latches a
 /// poison boundary**: the scanner refuses to rebuild a lexer past that offset, so nothing — not

--- a/smear/tests/lossless_runner.rs
+++ b/smear/tests/lossless_runner.rs
@@ -1,8 +1,11 @@
 #![cfg(all(feature = "rowan", feature = "graphql"))]
 
-use smear::parser::graphql::{
-  kinds::SyntaxKind as K,
-  lossless::{parse_document, runner::test_support::open_raw_kind},
+use smear::{
+  lexer::limits::MAX_NESTING_DEPTH,
+  parser::graphql::{
+    kinds::SyntaxKind as K,
+    lossless::{parse_document, runner::test_support::open_raw_kind},
+  },
 };
 
 #[test]
@@ -136,24 +139,24 @@ fn brace_offset(level: usize) -> usize {
 
 /// The nesting budget is a **report**, not a panic — smear issue #57.
 ///
-/// # The boundary, measured
+/// # The boundary
 ///
-/// **The 501st simultaneously-open bracket**, exactly. Bisected: 500 nested selection sets are
-/// accepted with no diagnostic at all and 501 trip, while `{ f(a: [[[…]]]) }` trips at 499 nested
-/// lists — its two enclosing brackets count toward the same tally, which is what identifies the
-/// budget as one global bracket-depth counter rather than anything per-production.
+/// The bracket **past** [`MAX_NESTING_DEPTH`], exactly, and the count is one global tally over
+/// `{`, `[` and `(` rather than anything per-production: `{ f(a: [[[…]]]) }` trips two lists
+/// earlier than this shape does, because its enclosing brace and paren are on the same counter.
 ///
-/// The issue reported "roughly 512" from two sampled points, and read the clean parse at 256 as
-/// the budget working at lower depths. Neither is what the code does: 256 is not a report, it is
-/// silence — nothing is consulted until the 501st bracket.
+/// The number itself is not this test's subject and is deliberately not spelled here — it is
+/// [`MAX_NESTING_DEPTH`]'s, derived and gated in `nesting_depth.rs`. When #57 was filed it was
+/// tokora's inherited general-purpose 500, and the issue reported "roughly 512" from two sampled
+/// points while reading the clean parse at 256 as the budget working at lower depths. Neither was
+/// what the code did: below the ceiling there is not a softer report, there is silence.
 ///
 /// # Which of the two candidate defects it was
 ///
 /// Neither, as the issue framed them. The budget is not the parser's: nothing in this crate
 /// descends through `InputRef::descend`, so tokora's parser-facing `RecursionLimiter` (64) is
 /// never consulted, and no amount of nesting trips it. It is the **lexer's** — every `{`, `[` and
-/// `(` steps the `Limiter` carried in the Logos `Extras`, whose inherited ceiling is tokora's
-/// general-purpose 500.
+/// `(` steps the budget carried in the Logos `Extras`.
 ///
 /// It does trip, and what follows the trip is what broke. A resource-limit trip **latches a
 /// poison boundary**: the scanner refuses to rebuild a lexer past that offset, so nothing — not
@@ -165,32 +168,32 @@ fn brace_offset(level: usize) -> usize {
 ///
 /// # GraphQLx
 ///
-/// The same three assertions hold for GraphQLx's `parse_document`, at the identical count,
-/// measured on the Phase B branch where that dialect exists. It shares this lexer's `Limiter`
-/// and this runner's materialization step, so it inherits the fix rather than needing its own;
-/// Phase B's own gates cover it.
+/// The same three assertions hold for GraphQLx's `parse_document`, at the identical count. It
+/// shares this lexer's budget type and this runner's materialization step, so it inherits the fix
+/// rather than needing its own; `nesting_depth.rs` holds it to that.
 #[test]
 fn nesting_past_the_lexer_budget_reports_instead_of_panicking() {
-  // The last depth inside the budget: unchanged by the fix, and the control that proves the
-  // assertions below measure the boundary rather than "deep input reports".
-  let inside = nested_selection_sets(500);
+  // The last depth inside the budget: the control that proves the assertions below measure the
+  // boundary rather than "deep input reports".
+  let inside = nested_selection_sets(MAX_NESTING_DEPTH);
   let parse = parse_document(&inside);
   assert!(
     !parse.has_errors(),
-    "500 open brackets is inside the budget and must still parse clean"
+    "{MAX_NESTING_DEPTH} open brackets is inside the budget and must still parse clean"
   );
   assert!(
     parse.diagnostics().is_empty(),
-    "500 open brackets must report nothing at all, not merely no error"
+    "{MAX_NESTING_DEPTH} open brackets must report nothing at all, not merely no error"
   );
   assert_eq!(parse.syntax().text().to_string(), inside);
 
   // One past it. Every assertion here was unreachable before the fix: the call panicked.
-  let over = nested_selection_sets(501);
+  let over = nested_selection_sets(MAX_NESTING_DEPTH + 1);
   let parse = parse_document(&over);
   assert!(
     parse.has_errors(),
-    "501 open brackets must be reported, not accepted"
+    "{} open brackets must be reported, not accepted",
+    MAX_NESTING_DEPTH + 1
   );
   assert_eq!(
     parse.syntax().text().to_string(),
@@ -204,12 +207,14 @@ fn nesting_past_the_lexer_budget_reports_instead_of_panicking() {
     .expect("the trip must be on the diagnostic channel");
   assert_eq!(
     first.span(),
-    brace_offset(501)..brace_offset(501) + 1,
+    brace_offset(MAX_NESTING_DEPTH + 1)..brace_offset(MAX_NESTING_DEPTH + 1) + 1,
     "the diagnostic must sit on the brace that exceeded the budget"
   );
   assert_eq!(first.severity(), tokora::emitter::Severity::Error);
 
-  // Far past it, because a fix that merely moved the cliff would pass everything above.
+  // Far past it, because a fix that merely moved the cliff would pass everything above. Safe to
+  // run only because the two assertions above have already proved the ceiling holds; see
+  // `nesting_depth.rs` for why that ordering is the whole reason this can live in the suite.
   let far = nested_selection_sets(2_000);
   let parse = parse_document(&far);
   assert!(parse.has_errors());

--- a/smear/tests/nesting_depth.rs
+++ b/smear/tests/nesting_depth.rs
@@ -1,0 +1,330 @@
+#![cfg(feature = "parser")]
+
+//! The nesting ceiling, and the `SIGABRT` it exists to stop — smear issue #61.
+//!
+//! # What was wrong
+//!
+//! A **valid** GraphQL document of about a kilobyte — `{ ... on Query { ... on Query { … } } }`
+//! nested 58 deep — overflowed the native stack of a 2 MiB thread and killed the process. Nothing
+//! rejected it and there was no diagnostic, because there was no return. The only ceiling in the
+//! path was tokora's *general-purpose* 500 on the lexer's bracket counter, inherited rather than
+//! chosen, and 500 sat an order of magnitude above where the stack actually died, so it could not
+//! fire first.
+//!
+//! A `SIGABRT` is not catchable. `catch_unwind` does not see it, a server cannot turn it into a
+//! 400, and one request takes every other request on the process with it.
+//!
+//! # How this suite can hold that without killing the runner
+//!
+//! It is the same hazard: a regression here is a process abort, and an abort does not fail a test,
+//! it kills the harness. Two things keep this file out of that, and the first is not in this file
+//! at all:
+//!
+//! 1. **`MAX_NESTING_DEPTH` cannot be raised past its own derivation, at compile time.** A `const`
+//!    assertion beside the constant fails the *build* if it is. That is not where the check
+//!    naturally wants to live, and it is there because the obvious placement was measured and
+//!    found not to work: a runtime test asserting the same arithmetic was planted against
+//!    `MAX_NESTING_DEPTH = 200`, and the harness died with `SIGABRT` in a *different* test in this
+//!    file before the arithmetic one ran. libtest gives no ordering, so no test can guard a
+//!    constant that makes its siblings lethal.
+//! 2. **Given (1), nothing here is deep.** Every boundary assertion sits at the ceiling and one
+//!    past it — a few dozen brackets, which no stack notices — and
+//!    [`deep_input_returns_rather_than_aborting`] re-checks the boundary as its own first
+//!    statement before handing the parser anything deep.
+//!
+//! # The reproduction proper
+//!
+//! Deliberately not here. Bisecting a stack overflow needs one parse per *process*, on an
+//! explicitly sized thread, with the bisection reading the child's exit status — a shape a test
+//! harness cannot host. `MAX_NESTING_DEPTH`'s own documentation carries the resulting table.
+
+use smear::lexer::limits::MAX_NESTING_DEPTH;
+
+/// `{ ... on Query { … } }` nested `depth` deep: `depth + 1` simultaneously open braces.
+///
+/// The shape from the issue, and the most expensive one measured — an inline fragment spends more
+/// native stack per level than a plain field selection, a list value or an input object.
+fn inline_fragments(depth: usize) -> String {
+  let mut src = String::with_capacity(depth * 16 + 32);
+  src.push('{');
+  for _ in 0..depth {
+    src.push_str(" ... on Query {");
+  }
+  src.push_str(" __typename ");
+  for _ in 0..depth {
+    src.push('}');
+  }
+  src.push('}');
+  src
+}
+
+/// The greatest `depth` [`inline_fragments`] may use and stay inside the budget.
+const DEEPEST_ACCEPTED: usize = MAX_NESTING_DEPTH - 1;
+
+/// The ceiling is [`MAX_NESTING_DEPTH`] open brackets, and it is what an **unconfigured** parse
+/// gets.
+///
+/// "Unconfigured" is the whole point of #61's fix. The number does not arrive through an argument
+/// a caller has to remember: it is the `Default` of the lexer's own state type, which is what
+/// `Parser::with_parser(…).parse_str(src)` — the form this workspace's README, `smear-compiler`'s
+/// crate docs and `smear-schema`'s builder all use — seeds a parse with. A ceiling that only
+/// applied when asked for would have left the abort exactly where it was.
+#[cfg(feature = "graphql")]
+#[test]
+fn the_syntactic_door_reports_at_the_ceiling_instead_of_descending() {
+  use smear::{
+    lexer::tokora::{Parse as _, Parser},
+    parser::graphql::{
+      GraphQL,
+      ast::Document,
+      error::GraphqlErrors,
+      syntactic::{GraphqlLexer, document},
+    },
+  };
+
+  fn parse(src: &str) -> bool {
+    Parser::with_parser::<GraphqlLexer<'_, str>, Document<&str>, GraphqlErrors<&str>, _, GraphQL>(
+      document,
+    )
+    .parse_str(src)
+    .is_ok()
+  }
+
+  assert!(
+    parse(&inline_fragments(DEEPEST_ACCEPTED)),
+    "{MAX_NESTING_DEPTH} open brackets is inside the budget and must parse"
+  );
+  assert!(
+    !parse(&inline_fragments(DEEPEST_ACCEPTED + 1)),
+    "{} open brackets must be refused, and refused by returning",
+    MAX_NESTING_DEPTH + 1
+  );
+}
+
+/// The GraphQLx syntactic door answers identically.
+///
+/// It is a separate lexer with its own SIMD dispatch loop, and it is the *worse* of the two per
+/// level — 53 against GraphQL's 57 on a 2 MiB debug thread — so a ceiling proved only on GraphQL
+/// would be proved on the wrong dialect.
+#[cfg(feature = "graphqlx")]
+#[test]
+fn the_graphqlx_syntactic_door_reports_at_the_same_ceiling() {
+  use smear::{
+    lexer::tokora::{Parse as _, Parser},
+    parser::graphqlx::{
+      GraphQLx,
+      ast::Document,
+      error::GraphqlxErrors,
+      syntactic::{GraphqlxLexer, document},
+    },
+  };
+
+  fn parse(src: &str) -> bool {
+    Parser::with_parser::<GraphqlxLexer<'_, str>, Document<&str>, GraphqlxErrors<&str>, _, GraphQLx>(
+      document,
+    )
+    .parse_str(src)
+    .is_ok()
+  }
+
+  assert!(parse(&inline_fragments(DEEPEST_ACCEPTED)));
+  assert!(!parse(&inline_fragments(DEEPEST_ACCEPTED + 1)));
+}
+
+/// The lossless door reports the trip on the diagnostic channel and still covers every byte.
+#[cfg(all(feature = "rowan", feature = "graphql"))]
+#[test]
+fn the_lossless_door_reports_at_the_same_ceiling() {
+  use smear::parser::graphql::lossless::parse_document;
+
+  let inside = inline_fragments(DEEPEST_ACCEPTED);
+  let parse = parse_document(&inside);
+  assert!(!parse.has_errors());
+  assert!(
+    parse.diagnostics().is_empty(),
+    "inside the budget the ceiling must be silent, not merely non-fatal"
+  );
+
+  let over = inline_fragments(DEEPEST_ACCEPTED + 1);
+  let parse = parse_document(&over);
+  assert!(parse.has_errors());
+  assert_eq!(
+    parse.syntax().text().to_string(),
+    over,
+    "the lossless guarantee survives the trip"
+  );
+}
+
+/// A caller who wants a different ceiling gets one, in both directions.
+///
+/// This is the half of #61 that says the number must be a decision a deployment can revisit: a
+/// server on an 8 MiB main thread can afford roughly four times the default, and a worker
+/// deliberately spawned smaller can afford less. Both directions are asserted because a knob that
+/// only loosens is not a knob.
+#[cfg(all(feature = "rowan", feature = "graphql"))]
+#[test]
+fn the_ceiling_is_configurable_in_both_directions() {
+  use smear::{
+    lexer::limits::LosslessLimits, parser::graphql::lossless::parse_document_with_limits,
+  };
+
+  // Deeper than the default, accepted because the caller raised the ceiling.
+  let deeper = inline_fragments(MAX_NESTING_DEPTH * 2);
+  assert!(parse_document_with_limits(&deeper, LosslessLimits::default()).has_errors());
+  assert!(
+    !parse_document_with_limits(
+      &deeper,
+      LosslessLimits::with_max_nesting_depth(MAX_NESTING_DEPTH * 4)
+    )
+    .has_errors(),
+    "a caller on a larger stack must be able to raise the ceiling"
+  );
+
+  // Shallower than the default, refused because the caller lowered it.
+  let shallow = inline_fragments(3);
+  assert!(!parse_document_with_limits(&shallow, LosslessLimits::default()).has_errors());
+  assert!(
+    parse_document_with_limits(&shallow, LosslessLimits::with_max_nesting_depth(2)).has_errors(),
+    "a caller on a smaller stack must be able to lower the ceiling"
+  );
+}
+
+/// A document far deeper than any stack could hold **returns**, at both doors.
+///
+/// This is issue #61 itself: before the fix this input did not return, it aborted the process. It
+/// is safe to run here only because of the ordering stated in this module's header and repeated
+/// in the body — the boundary is re-checked first, so a regressed ceiling fails a test instead of
+/// killing the harness.
+#[cfg(feature = "graphql")]
+#[test]
+fn deep_input_returns_rather_than_aborting() {
+  use smear::{
+    lexer::tokora::{Parse as _, Parser},
+    parser::graphql::{
+      GraphQL,
+      ast::Document,
+      error::GraphqlErrors,
+      syntactic::{GraphqlLexer, document},
+    },
+  };
+
+  fn parse(src: &str) -> bool {
+    Parser::with_parser::<GraphqlLexer<'_, str>, Document<&str>, GraphqlErrors<&str>, _, GraphQL>(
+      document,
+    )
+    .parse_str(src)
+    .is_ok()
+  }
+
+  // THE GUARD, AND IT MUST STAY FIRST. If the ceiling has regressed upward, this fails and the
+  // deep parse below is never reached. Reordering these two turns a red test into a dead runner.
+  assert!(
+    !parse(&inline_fragments(DEEPEST_ACCEPTED + 1)),
+    "the ceiling must hold before anything deep is handed to the parser"
+  );
+
+  // The issue's own depth, then far past every stack this could run on. Both were `SIGABRT`.
+  for depth in [58, 1_000, 100_000] {
+    assert!(
+      !parse(&inline_fragments(depth)),
+      "depth {depth} must return a refusal rather than overflow the native stack"
+    );
+  }
+}
+
+/// Every document this repository contains stays clear of the ceiling.
+///
+/// The compile-time assertion beside `MAX_NESTING_DEPTH` holds the constant against the *deepest
+/// fixture* as a recorded number (11). This holds that recorded number against the fixtures
+/// themselves, so a corpus that grows deeper than the constant assumed cannot pass silently — the
+/// two checks together are what make "24 costs a real document nothing" a fact rather than a
+/// claim, and neither is sufficient alone.
+#[cfg(feature = "graphql")]
+#[test]
+fn no_fixture_in_the_tree_comes_near_the_ceiling() {
+  fn bracket_depth(src: &str) -> usize {
+    let (mut depth, mut max) = (0usize, 0usize);
+    let bytes = src.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+      match bytes[i] {
+        // Block string: skip to its terminator so quoted brackets do not count.
+        b'"' if bytes[i..].starts_with(b"\"\"\"") => {
+          i = bytes[i + 3..]
+            .windows(3)
+            .position(|w| w == b"\"\"\"")
+            .map_or(bytes.len(), |p| i + 3 + p + 3);
+          continue;
+        }
+        b'"' => {
+          i += 1;
+          while i < bytes.len() && bytes[i] != b'"' {
+            i += if bytes[i] == b'\\' { 2 } else { 1 };
+          }
+        }
+        b'#' => {
+          while i < bytes.len() && bytes[i] != b'\n' {
+            i += 1;
+          }
+          continue;
+        }
+        b'{' | b'[' | b'(' => {
+          depth += 1;
+          max = max.max(depth);
+        }
+        b'}' | b']' | b')' => depth = depth.saturating_sub(1),
+        _ => {}
+      }
+      i += 1;
+    }
+    max
+  }
+
+  fn walk(dir: &std::path::Path, worst: &mut (usize, std::path::PathBuf), seen: &mut usize) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+      return;
+    };
+    for entry in entries.flatten() {
+      let path = entry.path();
+      if path.is_dir() {
+        walk(&path, worst, seen);
+      } else if path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| matches!(e, "graphql" | "graphqls" | "gql"))
+      {
+        let Ok(src) = std::fs::read_to_string(&path) else {
+          continue;
+        };
+        *seen += 1;
+        let depth = bracket_depth(&src);
+        if depth > worst.0 {
+          *worst = (depth, path);
+        }
+      }
+    }
+  }
+
+  // Up from `smear/` to the workspace root, so the sweep covers every member's fixtures.
+  let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+    .parent()
+    .expect("the workspace root is this package's parent")
+    .to_path_buf();
+  let mut worst = (0usize, root.clone());
+  let mut seen = 0usize;
+  walk(&root, &mut worst, &mut seen);
+
+  assert!(
+    seen > 100,
+    "the sweep found only {seen} GraphQL fixtures, so it is measuring the wrong tree"
+  );
+  assert!(
+    worst.0 * 2 <= MAX_NESTING_DEPTH,
+    "{} nests {} brackets deep, which is no longer clear of MAX_NESTING_DEPTH ({}) by 2x. Either \
+     the ceiling was re-derived upward, or DEEPEST_DOCUMENT_IN_TREE in smear-lexer's `limits` no \
+     longer describes this corpus.",
+    worst.1.display(),
+    worst.0,
+    MAX_NESTING_DEPTH
+  );
+}

--- a/smear/tests/nesting_depth.rs
+++ b/smear/tests/nesting_depth.rs
@@ -328,3 +328,232 @@ fn no_fixture_in_the_tree_comes_near_the_ceiling() {
     MAX_NESTING_DEPTH
   );
 }
+
+/// `{ ) f { ) f { …` — the shape that walked past the first fix, and the second half of #61.
+///
+/// # What it does to the lexer's counter
+///
+/// Every level opens one brace and closes **one bracket the parser never opened**. The lexer's
+/// tally is one saturating scalar over every opener and every closer, pair-blind, so the `)`
+/// undoes the `{` and the tally oscillates 1, 0, 1, 0 for the whole document — measured maximum
+/// **1**, at every depth. Recovery, meanwhile, reports the `)` and consumes it (a closer is a
+/// sync point, so the balanced skip crosses nothing and the fallback eats one token), the
+/// selection-set loop continues, and the `f {` after it opens **another** selection set.
+///
+/// So the ceiling could not fire, and at `6f39cb9` this aborted a 2 MiB thread at 702 levels —
+/// 3.5 KB of input, from a counter that never exceeded 1. `crate::…` cannot cite it: the
+/// bisection lives outside the suite, in `scratchpad/depth-probe`, for the reason this module's
+/// header gives.
+///
+/// # Why the first assertion is the ordering guard
+///
+/// The same discipline [`deep_input_returns_rather_than_aborting`] uses, and it needs a
+/// **discriminating** signal rather than `has_errors`: this input is an error document either
+/// way, since every `)` is reported. What separates the two worlds is how deep the parse
+/// *recursed*, and the tree records exactly that — one `SelectionSet` node per live frame. The
+/// shallow probe below asserts the tree stops nesting at the ceiling; only then is anything deep
+/// handed to the parser.
+#[cfg(all(feature = "rowan", feature = "graphql"))]
+#[test]
+fn the_recovery_bypass_returns_rather_than_aborting() {
+  use smear::parser::graphql::{kinds::SyntaxKind as K, lossless::parse_document};
+
+  // One `{` per level, and one closer per level that no opener matched.
+  fn bypass(levels: usize) -> String {
+    let mut src = String::with_capacity(levels * 5 + 1);
+    src.push('{');
+    for _ in 0..levels {
+      src.push_str(" ) f {");
+    }
+    src
+  }
+
+  // THE GUARD, AND IT MUST STAY FIRST — see this function's docs. A few dozen levels cannot
+  // overflow anything, so this assertion is reachable even if the budget has regressed.
+  let shallow = parse_document(&bypass(MAX_NESTING_DEPTH + 8));
+  let deepest = shallow
+    .syntax()
+    .descendants()
+    .filter(|n| n.kind() == K::SelectionSet)
+    .map(|n| {
+      n.ancestors()
+        .filter(|a| a.kind() == K::SelectionSet)
+        .count()
+    })
+    .max()
+    .unwrap_or(0);
+  assert!(
+    deepest <= MAX_NESTING_DEPTH,
+    "the parse nested {deepest} selection sets under a ceiling of {MAX_NESTING_DEPTH}: the budget \
+     is being counted on something other than the frames that recurse"
+  );
+
+  // Past the native boundary this shape had at `6f39cb9`: 702 levels aborted a 2 MiB thread, so
+  // 2 000 is 2.8x beyond it. The depth stops there rather than at 100 000 for a cost reason
+  // measured on this branch and recorded in the report: `resync_to_definition`'s scan is
+  // quadratic in the length of a run it can find no definition head in — pre-existing, and
+  // reproduced on a control shape (`! ! ! …`) that this branch does not touch. 2 000 levels cost
+  // 0.44 s; 100 000 cost 407 s, which is a gate nobody would keep.
+  for levels in [100, 2_000] {
+    let parse = parse_document(&bypass(levels));
+    assert!(
+      parse.has_errors(),
+      "{levels} levels of unmatched closers must be reported"
+    );
+    assert_eq!(
+      parse.syntax().text().to_string(),
+      bypass(levels),
+      "the lossless guarantee survives the refusal"
+    );
+  }
+}
+
+/// GraphQLx answers identically, **and with its own fourth closer**.
+///
+/// `>` steps the same tally as `)`, `]` and `}` — that dialect delimits generics with `<` and `>`
+/// — and it is a sync point in its recovery, so it is consumed and the loop continues exactly as
+/// `)` is. Measured at `6f39cb9`: both families abort a 2 MiB thread at 700 levels. A gate on `)`
+/// alone would have proved the dialect and missed the pair that is only GraphQLx's.
+#[cfg(all(feature = "rowan", feature = "graphqlx"))]
+#[test]
+fn the_graphqlx_recovery_bypass_returns_with_both_closer_families() {
+  use smear::parser::graphqlx::{kinds::SyntaxKind as K, lossless::parse_document};
+
+  fn bypass(levels: usize, closer: char) -> String {
+    let mut src = String::with_capacity(levels * 5 + 1);
+    src.push('{');
+    for _ in 0..levels {
+      src.push(' ');
+      src.push(closer);
+      src.push_str(" f {");
+    }
+    src
+  }
+
+  for closer in [')', '>'] {
+    // The ordering guard, per closer family.
+    let shallow = parse_document(&bypass(MAX_NESTING_DEPTH + 8, closer));
+    let deepest = shallow
+      .syntax()
+      .descendants()
+      .filter(|n| n.kind() == K::SelectionSet)
+      .map(|n| {
+        n.ancestors()
+          .filter(|a| a.kind() == K::SelectionSet)
+          .count()
+      })
+      .max()
+      .unwrap_or(0);
+    assert!(
+      deepest <= MAX_NESTING_DEPTH,
+      "`{closer}` nested {deepest} selection sets under a ceiling of {MAX_NESTING_DEPTH}"
+    );
+
+    for levels in [100, 2_000] {
+      let parse = parse_document(&bypass(levels, closer));
+      assert!(parse.has_errors());
+      assert_eq!(parse.syntax().text().to_string(), bypass(levels, closer));
+    }
+  }
+}
+
+/// The converse: a document with far **more** delimiters than the ceiling, none of them nested,
+/// is still accepted.
+///
+/// Moving the count from the lexer's tally to the parse's own frames is only safe if it stays a
+/// *depth* count. A budget that accumulated instead of releasing — a guard bound to the wrong
+/// scope, or one released after the recursion rather than around it — would refuse this document,
+/// and every existing gate in this file would stay green, because they are all about depth and
+/// this one is about width.
+///
+/// Both axes are exercised: siblings at the top level, and siblings *inside* a subtree that is
+/// itself near the ceiling, which is where a leaked level would show first.
+#[cfg(all(feature = "rowan", feature = "graphql"))]
+#[test]
+fn width_costs_nothing_because_the_budget_is_a_depth() {
+  use smear::parser::graphql::lossless::parse_document;
+
+  // `{ a } { b } …` — 8x the ceiling in delimiters, never more than one open at a time.
+  let wide: String = (0..MAX_NESTING_DEPTH * 8)
+    .map(|i| format!("{{ f{i} }}\n"))
+    .collect();
+  let parse = parse_document(&wide);
+  assert!(
+    !parse.has_errors(),
+    "{} sequential selection sets must cost one level, not {}",
+    MAX_NESTING_DEPTH * 8,
+    MAX_NESTING_DEPTH * 8
+  );
+
+  // The same **at** the ceiling: every sibling re-enters the deepest three levels in turn.
+  //
+  // Each `g(x: [1])` spends three of the budget on its own — the selection set it sits in, its
+  // argument list, and its list value — so the outer nesting is sized to put the innermost of
+  // those exactly at `MAX_NESTING_DEPTH`. A budget that leaked one level per sibling would refuse
+  // the second one; a budget that leaked a fraction would refuse a later one.
+  let outer = MAX_NESTING_DEPTH - 3;
+  let mut deep_and_wide = String::new();
+  for _ in 0..outer {
+    deep_and_wide.push_str("{ f ");
+  }
+  for i in 0..MAX_NESTING_DEPTH * 4 {
+    deep_and_wide.push_str(&format!(" g{i}(x: [1]) "));
+  }
+  for _ in 0..outer {
+    deep_and_wide.push('}');
+  }
+  let parse = parse_document(&deep_and_wide);
+  assert!(
+    !parse.has_errors(),
+    "siblings at the deepest accepted level must each be entered and left, not accumulated: {:?}",
+    parse.diagnostics()
+  );
+}
+
+/// The same bypass, aimed at the **value** cycles rather than the selection-set one.
+///
+/// Codex's finding named `{ ) f {`, which is `selection_set` recursing through `field`. It is not
+/// the only cycle a stray closer can drive: `{ f(a: [ ) [ ) [ …` runs `list_value` into
+/// `list_value`, and `{ f(a: { ) k: { ) k: …` runs `object_value` into `object_value`, with the
+/// lexer's tally pinned at **3** in both cases because the `)` cancels each `[` or `{`.
+///
+/// Both were measured to abort a 2 MiB thread at 2 000 levels with only `selection_set` guarded —
+/// which is why the budget is taken at *every* production that commits a nesting delimiter rather
+/// than at the one shape the finding named. Deriving the fix from the exemplar would have left
+/// two live cycles behind it.
+#[cfg(all(feature = "rowan", feature = "graphql"))]
+#[test]
+fn the_value_cycles_have_the_same_bypass_and_the_same_bound() {
+  use smear::parser::graphql::{kinds::SyntaxKind as K, lossless::parse_document};
+
+  // `{ f(a: ` + one opener and one unmatched `)` per level.
+  fn bypass(open: &str, levels: usize) -> String {
+    let mut src = String::from("{ f(a: ");
+    for _ in 0..levels {
+      src.push_str(open);
+    }
+    src
+  }
+
+  for (open, kind) in [("[ ) ", K::ListValue), ("{ ) k: ", K::ObjectValue)] {
+    // THE ORDERING GUARD, per cycle, on an input too shallow to overflow anything.
+    let shallow = parse_document(&bypass(open, MAX_NESTING_DEPTH + 8));
+    let deepest = shallow
+      .syntax()
+      .descendants()
+      .filter(|n| n.kind() == kind)
+      .map(|n| n.ancestors().filter(|a| a.kind() == kind).count())
+      .max()
+      .unwrap_or(0);
+    assert!(
+      deepest <= MAX_NESTING_DEPTH,
+      "{kind:?} nested {deepest} deep under a ceiling of {MAX_NESTING_DEPTH}"
+    );
+
+    // Past where this cycle aborted with only `selection_set` guarded.
+    let deep = bypass(open, 2_000);
+    let parse = parse_document(&deep);
+    assert!(parse.has_errors());
+    assert_eq!(parse.syntax().text().to_string(), deep);
+  }
+}

--- a/smear/tests/oracle.rs
+++ b/smear/tests/oracle.rs
@@ -239,8 +239,9 @@ fn graphql_syntactic_simd_oracle() {
 
 // ─── Low-recursion-limit SIMD parity ───────────────────────────────────────
 //
-// The frozen oracle above runs at the default limit (500), which no fixture
-// approaches, so it cannot catch a fast-path arm that emits a token while the
+// The frozen oracle above runs at `smear_lexer::limits::MAX_NESTING_DEPTH`,
+// which no fixture approaches — the deepest reaches 11 — so it cannot catch a
+// fast-path arm that emits a token while the
 // depth is already over the limit. `LogosLexer::lex` re-checks the limiter
 // after every successful token and, while over the limit, returns the
 // recursion error in the token's place; every SIMD fast-path emission must do
@@ -259,7 +260,7 @@ fn graphql_syntactic_simd_oracle() {
 #[cfg(feature = "graphql")]
 #[test]
 fn graphql_syntactic_simd_low_recursion_parity() {
-  use tokora::state::recursion_tracker::RecursionLimiter;
+  use smear::lexer::limits::SyntacticLimits;
 
   // Each input exercises a different set of gated arms past the first
   // over-limit bracket: identifier + close-bracket, nested brackets, the
@@ -361,7 +362,7 @@ fn graphql_syntactic_simd_low_recursion_parity() {
   for (src, expected) in CASES {
     let simd = render_stream!(SyntacticLexer::<str>::with_state(
       src,
-      RecursionLimiter::with_limitation(0),
+      SyntacticLimits::with_max_nesting_depth(0),
     ));
     assert_eq!(&simd, expected, "low-limit stream mismatch for {src:?}");
   }
@@ -916,8 +917,7 @@ fn graphqlx_syntactic_simd_oracle() {
 #[cfg(feature = "graphqlx")]
 #[test]
 fn graphqlx_syntactic_simd_low_recursion_parity() {
-  use smear::lexer::graphqlx::syntactic::SyntacticLexer;
-  use tokora::state::recursion_tracker::RecursionLimiter;
+  use smear::lexer::{graphqlx::syntactic::SyntacticLexer, limits::SyntacticLimits};
 
   const CASES: &[(&str, &str)] = &[
     (
@@ -1022,7 +1022,7 @@ fn graphqlx_syntactic_simd_low_recursion_parity() {
   for (src, expected) in CASES {
     let simd = render_stream!(SyntacticLexer::<str>::with_state(
       src,
-      RecursionLimiter::with_limitation(0),
+      SyntacticLimits::with_max_nesting_depth(0),
     ));
     assert_eq!(&simd, expected, "low-limit stream mismatch for {src:?}");
   }

--- a/smear/tests/validator_merge.rs
+++ b/smear/tests/validator_merge.rs
@@ -22,7 +22,10 @@
 use std::{string::String, thread, time::Instant, vec::Vec};
 
 use smear::{
-  lexer::tokora::{Parse as _, Parser},
+  lexer::{
+    limits::SyntacticLimits,
+    tokora::{Parse as _, Parser},
+  },
   parser::graphql::{
     GraphQL,
     ast::{ExecutableDocument, TypeSystemDocument},
@@ -106,6 +109,22 @@ fn build() -> Schema {
   Schema::build(&document).expect("the SDL is a schema")
 }
 
+/// The nesting ceiling these fixtures parse under, and it is **not** the default.
+///
+/// `smear_lexer::limits::MAX_NESTING_DEPTH` is sized against a 2 MiB thread (smear issue #61),
+/// which is what a caller who has not thought about it gets. These tests have thought about it:
+/// they run on [`on_a_deep_stack`]'s 64 MiB worker precisely so that a 200-level document is a
+/// document rather than a stack overflow, and raising the ceiling to match is the API's own answer
+/// for a caller who has arranged the stack.
+///
+/// It is also the ordering that makes the merge budget below testable at all. The parser's ceiling
+/// is a **native-stack** bound and the validator's `merge_depth` is a **work** bound, and the two
+/// are now ordered the other way round from how they read: at the shipped defaults the parser
+/// refuses at 24, long before the validator's 128 has anything to refuse. So `merge_depth` defends
+/// a document only a caller who raised this ceiling can produce — which is exactly the caller
+/// these tests impersonate.
+const FIXTURE_NESTING_CEILING: usize = 512;
+
 fn parse(source: &str) -> ExecutableDocument<&str> {
   Parser::with_parser::<
     GraphqlLexer<'_, str>,
@@ -114,7 +133,10 @@ fn parse(source: &str) -> ExecutableDocument<&str> {
     _,
     GraphQL,
   >(executable_document)
-  .parse_str(source)
+  .parse_str_with_state(
+    source,
+    SyntacticLimits::with_max_nesting_depth(FIXTURE_NESTING_CEILING),
+  )
   .unwrap_or_else(|errors| panic!("fixture query does not parse: {errors:?}"))
 }
 


### PR DESCRIPTION
Closes #61.
