### PR TITLE
perf(proto)!: the operation lookup is charged, and returns the operation rather than a key to it

### DIFF
--- a/graphql-proto/src/execute.rs
+++ b/graphql-proto/src/execute.rs
@@ -533,7 +533,11 @@ pub struct Limits {
   /// | the in-flight slab index | [`max_in_flight`](Limits::max_in_flight) |
   /// | `fail_at`'s location index | [`max_response_metadata`](Limits::max_response_metadata), which `fail_at` now charges, plus at most one for the root's fallback — and `try_from`-checked besides |
   /// | the interner's arena offset, entry length and id | [`max_interned_bytes`](Limits::max_interned_bytes), and each `try_from`-checked independently of it |
-  /// | the operation index in `operation_index` | the document's own length, which no ceiling here bounds and nothing in this module creates |
+  ///
+  /// The row this table used to end on is gone rather than answered: draft §6.1's lookup produced
+  /// an operation *index* whose only bound was the document's own length, and
+  /// [`Executor::operation_definition`] now returns the definition itself. There is no narrowing
+  /// left to bound.
   pub max_response_slots: NonZeroU32,
 
   /// How many merged field selections the executor will record across the whole response.
@@ -562,10 +566,19 @@ pub struct Limits {
   /// How much work draft §6.3's collection may do, across the whole operation.
   ///
   /// Charged per selection *looked at*, surviving or not; per entry a name lookup compares, before
-  /// it compares it; and per definition and fragment the fragment index's one pass handles. The
-  /// first is the difference between this and every other ceiling here, and it is deliberate: the
-  /// others count what was produced, and a document built out of fragments that collect nothing
-  /// produces nothing while walking as far as it likes.
+  /// it compares it; per definition and fragment the fragment index's one pass handles; and per
+  /// definition draft §6.1's operation lookup reads. The first is the difference between this and
+  /// every other ceiling here, and it is deliberate: the others count what was produced, and a
+  /// document built out of fragments that collect nothing produces nothing while walking as far as
+  /// it likes.
+  ///
+  /// **The last of those is the one charge taken outside collection, and it is why this ceiling
+  /// can refuse a `start` before a response exists.** Draft §6.1 walks the definitions to find the
+  /// operation, once per [`start`](Executor::start), over a count the document chooses; it was the
+  /// module's last uncharged walk over a client quantity (al8n/smear#144) and it now spends this
+  /// budget like the rest. The refusal is
+  /// [`StartError::OperationLookupRefused`](StartError::OperationLookupRefused) rather than a
+  /// field error, because §7.1.2 has no response for a failure raised before execution begins.
   ///
   /// The rest is what makes the first a bound rather than a bound on one factor. Both tables hash
   /// text the *document* chose, and the shared multiply-fold is unkeyed and invertible, so a client
@@ -893,8 +906,11 @@ enum Exhausted {
 
 /// Why [`Executor::start`] refused.
 ///
-/// Every variant is a draft §6.1 `GetOperation` failure — a *request* error, raised before
-/// execution begins, which is why it is returned rather than collected into the response.
+/// Every variant is a draft §7.1.2 *request* error — raised before execution begins, which is why
+/// it is returned rather than collected into the response. Most of them are draft §6.1
+/// `GetOperation` failures; the draft §6.2.3.1 refusals below are not, and neither is
+/// [`ResponseStreamOpen`](Self::ResponseStreamOpen), which is about the executor rather than the
+/// request.
 ///
 /// # A valid document reaches this, and there is a response shape for it
 ///
@@ -1002,6 +1018,20 @@ pub enum StartError {
   /// [`SourceSelectionRefused`](Self::SourceSelectionRefused) for why, and note that upstream does
   /// carry it. This is an unmet "should" of §7.1.6's `locations`, recorded as one.
   SourceFieldArguments,
+  /// The document holds more definitions than
+  /// [`max_selection_visits`](Limits::max_selection_visits) left the draft §6.1 lookup room to
+  /// read.
+  ///
+  /// Draft §6.1 selects the operation by walking the document's definitions, which is a quantity
+  /// the *client* chooses — so the walk is charged the same unit every other document-sized walk
+  /// in this crate is charged, and this is what the refusal looks like. It is reachable only by a
+  /// document with more definitions than the ceiling, so the remedy is a larger
+  /// `max_selection_visits` or a smaller document, and never a change to the operation name.
+  ///
+  /// **A named lookup that finds its operation early is not refused for the definitions behind
+  /// it**: the charge is taken per definition read rather than for the slice, so the walk stops
+  /// where the answer does. See [`Executor::operation_definition`].
+  OperationLookupRefused,
   /// A draft §7.1.2 response stream is still open, so beginning another operation would orphan the
   /// source stream behind it.
   ///
@@ -1041,6 +1071,9 @@ impl fmt::Display for StartError {
       }
       Self::SourceFieldArguments => {
         "the subscription's source field has an argument the request does not satisfy"
+      }
+      Self::OperationLookupRefused => {
+        "the document has more definitions than `max_selection_visits` leaves room to read"
       }
       Self::ResponseStreamOpen => {
         "a response stream is still open, and its source stream must be cancelled through \
@@ -1457,6 +1490,15 @@ where
   merged: std::vec::Vec<&'a Field<S>>,
   locations: std::vec::Vec<SimpleSpan>,
   interner: Interner,
+  /// Definitions the draft §6.1 operation lookup has read, over the executor's whole life.
+  ///
+  /// Counted for the reason `collect::Fragments`'s `walked` is: the lookup charges one unit before
+  /// each definition it reads, so the budget and the read count agree by construction and a
+  /// version that charged *after* the read — or charged the slice length and then walked it —
+  /// would agree with itself just as well. Only a count taken at the read itself can say a refused
+  /// lookup read nothing.
+  #[cfg(test)]
+  operation_definitions_walked: u64,
   errors: std::vec::Vec<Row>,
   /// The draft §7.1.7 *Extensions* entry for this operation, or `None` when the response has none.
   ///
@@ -1616,6 +1658,8 @@ where
       merged: std::vec::Vec::new(),
       locations: std::vec::Vec::new(),
       interner: Interner::new(limits.max_interned_bytes.get()),
+      #[cfg(test)]
+      operation_definitions_walked: 0,
       errors: std::vec::Vec::new(),
       extensions: None,
       inflight: std::vec::Vec::new(),
@@ -1726,15 +1770,7 @@ where
       return Err(StartError::ResponseStreamOpen);
     }
     self.reset();
-    let index = self.operation_index(operation)?;
-    let definition = self
-      .document
-      .definitions()
-      .get(index as usize)
-      .map(|described| described.node());
-    let Some(ExecutableDefinition::Operation(op)) = definition else {
-      return Err(StartError::NoOperation);
-    };
+    let op = self.operation_definition(operation)?;
     // Enumerated rather than tested with `is_query()`, so that a fourth operation keyword would be
     // a compile error here instead of an operation silently executed as a query.
     let (set, operation, missing) = match op {
@@ -3704,6 +3740,13 @@ where
     self.interner.compares()
   }
 
+  /// Definitions the draft §6.1 operation lookup has read, counted independently of what it
+  /// charged. See the field.
+  #[cfg(test)]
+  fn operation_definitions_walked(&self) -> u64 {
+    self.operation_definitions_walked
+  }
+
   /// Links draft §6.2.2's serial release has followed. See [`serial_next`](Self::serial_next).
   ///
   /// The separator for the one product a mutation could have brought back: a scan over the root's
@@ -3824,9 +3867,56 @@ where
     self.delivered = false;
   }
 
-  fn operation_index(&self, name: Option<&str>) -> Result<u32, StartError> {
+  /// Draft §6.1 `GetOperation`: the operation `name` selects, charged **before** each definition
+  /// it reads.
+  ///
+  /// # It is a walk over a quantity the client controls, so it is charged like every other one
+  ///
+  /// This used to be the module's one uncharged scan (al8n/smear#144), performed once per
+  /// [`start`](Self::start) over `definitions()` — an amount the *document* chooses, against no
+  /// ceiling at all. Everything else that walks a document-sized population charges
+  /// [`max_selection_visits`](Limits::max_selection_visits) for it, and this now does too, in the
+  /// unit the rest of the module uses: one per definition.
+  ///
+  /// **Charged per definition rather than `definitions.len()` up front**, which is where it
+  /// departs from `collect::Fragments::build`'s counting pass, and the difference is a wrong
+  /// answer rather than a rounding. That pass reads every definition, so a slice length is what it
+  /// costs; this one **early-returns** on a named match, so a document of ten thousand definitions
+  /// whose named operation is the third costs three. Charging the length would refuse a lookup
+  /// that had budget for the work it was actually going to do. Taking a unit before each read
+  /// keeps "units spent" equal to "definitions read" at every instant, which is also what lets the
+  /// walk be abandoned at the ceiling instead of after it.
+  ///
+  /// # Preferring an index was considered and is a loss here, which is worth recording
+  ///
+  /// The standing preference is to delete a walk rather than price it. An index over the
+  /// operations would have to be built by the same walk, and it can only live on the **executor** —
+  /// `Executor` borrows the document and cannot attach anything to it. So it amortises only across
+  /// repeated [`start`](Self::start) calls on one executor, and it is pure loss under the pattern
+  /// `collect::Fragments` documents, where a service caches the *parse* and builds an executor per
+  /// execution: there the table is built once, probed once, and dropped. The charge is right under
+  /// both patterns; the index is right under one.
+  ///
+  /// What the walk being unnecessary *did* delete is the second lookup. This returned a `u32` that
+  /// `start` immediately resolved back through `definitions()` and re-matched against
+  /// [`ExecutableDefinition::Operation`] — an arm that cannot fail, guarded by a refusal that
+  /// cannot run — which is the same shape `collect::Fragments` removed by carrying the definition
+  /// instead of a key to one. It also removes an `as u32` narrowing whose only bound was the
+  /// document's own length, which is the row [`Limits::max_response_slots`]'s table no longer has
+  /// to answer for.
+  fn operation_definition(
+    &mut self,
+    name: Option<&str>,
+  ) -> Result<&'a OperationDefinition<S>, StartError> {
     let mut found = None;
-    for (index, described) in self.document.definitions().iter().enumerate() {
+    for described in self.document.definitions() {
+      if !self.visits.take(1) {
+        return Err(StartError::OperationLookupRefused);
+      }
+      #[cfg(test)]
+      {
+        self.operation_definitions_walked += 1;
+      }
       let ExecutableDefinition::Operation(operation) = described.node() else {
         continue;
       };
@@ -3835,7 +3925,7 @@ where
           if found.is_some() {
             return Err(StartError::AmbiguousOperation);
           }
-          found = Some(index as u32);
+          found = Some(operation);
         }
         Some(wanted) => {
           if let OperationDefinition::Named(named) = operation
@@ -3843,14 +3933,14 @@ where
               .name()
               .is_some_and(|name| name.source().as_ref() == wanted.as_bytes())
           {
-            return Ok(index as u32);
+            return Ok(operation);
           }
         }
       }
     }
     match (name, found) {
       (Some(_), _) => Err(StartError::UnknownOperation),
-      (None, Some(index)) => Ok(index),
+      (None, Some(operation)) => Ok(operation),
       (None, None) => Err(StartError::NoOperation),
     }
   }

--- a/graphql-proto/src/execute.rs
+++ b/graphql-proto/src/execute.rs
@@ -536,7 +536,7 @@ pub struct Limits {
   ///
   /// The row this table used to end on is gone rather than answered: draft §6.1's lookup produced
   /// an operation *index* whose only bound was the document's own length, and
-  /// [`Executor::operation_definition`] now returns the definition itself. There is no narrowing
+  /// `Executor::operation_definition` now returns the definition itself. There is no narrowing
   /// left to bound.
   pub max_response_slots: NonZeroU32,
 
@@ -1030,7 +1030,7 @@ pub enum StartError {
   ///
   /// **A named lookup that finds its operation early is not refused for the definitions behind
   /// it**: the charge is taken per definition read rather than for the slice, so the walk stops
-  /// where the answer does. See [`Executor::operation_definition`].
+  /// where the answer does.
   OperationLookupRefused,
   /// A draft §7.1.2 response stream is still open, so beginning another operation would orphan the
   /// source stream behind it.

--- a/graphql-proto/src/execute/tests.rs
+++ b/graphql-proto/src/execute/tests.rs
@@ -325,18 +325,21 @@ fn collection_work(sdl: &str, query: &str) -> u32 {
   executor.collection_work()
 }
 
-/// `n` repeats of one response key charge exactly `2n - 1`, and the second term is the interner.
+/// `n` repeats of one response key charge exactly `2n`, and the middle term is the interner.
 ///
 /// The exact-value case, and it is exact rather than bounded because nothing about it depends on
 /// the hash: one key means one bucket with one entry, so the first selection interns after
-/// comparing nothing and every later one matches on its first comparison. `n` selections examined
-/// plus `n - 1` comparisons is the whole of it.
+/// comparing nothing and every later one matches on its first comparison. Draft §6.1's lookup over
+/// the document's one definition, plus `n` selections examined, plus `n - 1` comparisons is the
+/// whole of it.
 ///
-/// **This is the plant against an uncharged lookup.** Deleting the charge leaves `n`, and nothing
-/// about the response changes.
+/// **This is the plant against an uncharged lookup.** Deleting the charge leaves `n + 1`, and
+/// nothing about the response changes.
 #[test]
 fn a_repeated_response_key_charges_one_comparison_each_time() {
   const REPEATS: u32 = 1024;
+  /// The document is one shorthand operation, which is what draft §6.1's lookup reads.
+  const LOOKUP: u32 = 1;
 
   let mut query = std::string::String::from("{");
   for _ in 0..REPEATS {
@@ -346,9 +349,10 @@ fn a_repeated_response_key_charges_one_comparison_each_time() {
 
   assert_eq!(
     collection_work(ONE_FIELD, &query),
-    2 * REPEATS - 1,
-    "{REPEATS} selections examined, and {} comparisons to find the one interned key each time \
-     after the first; a smaller total means a name lookup is not charging what it compares",
+    LOOKUP + 2 * REPEATS - 1,
+    "one definition read by draft §6.1, {REPEATS} selections examined, and {} comparisons to find \
+     the one interned key each time after the first; a smaller total means a name lookup is not \
+     charging what it compares",
     REPEATS - 1
   );
 }
@@ -390,8 +394,9 @@ fn distinct_response_keys_are_linear() {
 /// walk stopped spending native frames but still scanned every definition in the document once per
 /// spread, so a chain that no longer killed the process still took quadratic time to answer.
 ///
-/// Four terms, all linear in the chain: the index pass over the definitions, one push per fragment,
-/// one visit per selection, and about one comparison per spread.
+/// Five terms, all linear in the chain: draft §6.1's lookup over the definitions, the index pass
+/// over them again, one push per fragment, one visit per selection, and about one comparison per
+/// spread.
 #[test]
 fn a_flat_fragment_chain_is_linear() {
   const LINKS: u32 = 4096;
@@ -561,8 +566,13 @@ fn fragment_chain(links: u32) -> std::string::String {
 #[test]
 fn a_refused_index_pass_reserves_no_fragment_storage() {
   const LINKS: u32 = 256;
-  /// One selection, then one unit per definition walked. The fragment charge is what will not fit.
-  const UP_TO_THE_POPULATION: u32 = 1 + LINKS + 2;
+  /// Definitions in `fragment_chain(LINKS)`: the operation and `LINKS + 1` fragments.
+  const DEFINITIONS: u32 = LINKS + 2;
+  /// Draft §6.1's lookup, which reads every definition because no operation name is given.
+  const LOOKUP: u32 = DEFINITIONS;
+  /// The lookup, one selection, then one unit per definition the index pass walks. The fragment
+  /// charge is what will not fit.
+  const UP_TO_THE_POPULATION: u32 = LOOKUP + 1 + DEFINITIONS;
 
   let query = fragment_chain(LINKS);
   let (schema, document) = compile_against(ONE_FIELD, &query);
@@ -581,12 +591,13 @@ fn a_refused_index_pass_reserves_no_fragment_storage() {
     .expect("the operation resolves");
 
   let spent = refused.collection_work();
-  assert!(
-    spent >= LINKS + 2,
-    "the fixture only says anything if the definitions charge was accepted and the fragment charge \
-     was the one refused; {spent} units spent is short of the {} the definitions cost, so this run \
-     was refused before the population was ever priced",
-    LINKS + 2
+  assert_eq!(
+    spent, UP_TO_THE_POPULATION,
+    "the fixture only says anything if the index pass's definitions charge was accepted and the \
+     fragment charge was the one refused. {spent} units against the {UP_TO_THE_POPULATION} this \
+     ceiling admits means the run was refused somewhere earlier — at draft §6.1's own lookup, \
+     which now spends {LOOKUP} of them before collection begins, or at the definitions charge \
+     itself"
   );
   let errors = {
     let response = refused.poll_response().expect("nothing is outstanding");
@@ -646,11 +657,18 @@ fn a_refused_index_pass_reserves_no_fragment_storage() {
 /// # The document and the ceiling
 ///
 /// `OPERATIONS` named operations and one fragment, spread by the operation the run selects — which
-/// is the first, so draft §6.1's lookup stops at it and contributes nothing to the walk under test.
-/// The ceiling is what the request costs to the unit: the root's one spread, the pass, the one
-/// comparison that finds the fragment, and the one field inside it. It sits in the window the
-/// defect lives in — above `DEFINITIONS + FRAGMENTS`, so the pass is admitted and the request is
-/// served, and far below `2 × DEFINITIONS + FRAGMENTS`, so the second walk is one nobody paid for.
+/// is the **first**, so draft §6.1's lookup stops at it, reads one definition and contributes
+/// nothing to the walk under test. The ceiling is what the request costs to the unit: that one
+/// definition, the root's one spread, the pass, the one comparison that finds the fragment, and
+/// the one field inside it. It sits in the window the defect lives in — above
+/// `DEFINITIONS + FRAGMENTS`, so the pass is admitted and the request is served, and far below
+/// `2 × DEFINITIONS + FRAGMENTS`, so the second walk is one nobody paid for.
+///
+/// **The `LOOKUP` term is one and not `DEFINITIONS`, which is the second thing this fixture pins.**
+/// `Executor::operation_definition` charges before each definition it reads rather than for the
+/// slice it may read, so a named lookup that matches on the first definition costs one — and a
+/// version charging the length up front needs `DEFINITIONS` more units than this ceiling has and
+/// refuses a request it had the budget to serve.
 ///
 /// **The plant.** Give `Paid` the definitions slice back and let `fill` filter it into `defs`
 /// instead of moving the selection in, counting what it reads as every reader in that module does.
@@ -664,9 +682,11 @@ fn the_index_pass_reads_each_definition_once() {
   const FRAGMENTS: u32 = 1;
   /// What one walk of the document reads.
   const DEFINITIONS: u32 = OPERATIONS + FRAGMENTS;
-  /// The whole request: the root's spread, the pass, the comparison that finds the fragment, and
-  /// the field inside it.
-  const BUDGET: u32 = DEFINITIONS + FRAGMENTS + 3;
+  /// Draft §6.1's lookup, which matches `Op0` on the document's first definition and stops.
+  const LOOKUP: u32 = 1;
+  /// The whole request: the lookup, the root's spread, the pass, the comparison that finds the
+  /// fragment, and the field inside it.
+  const BUDGET: u32 = LOOKUP + DEFINITIONS + FRAGMENTS + 3;
 
   let mut query = std::string::String::from("query Op0 { ...F }\n");
   for index in 1..OPERATIONS {
@@ -733,6 +753,10 @@ const COLLIDING_DEFINITIONS: u32 = COLLIDING as u32 + 1;
 /// pushed.
 const COLLIDING_INDEX: u32 = COLLIDING_DEFINITIONS + COLLIDING as u32;
 
+/// Draft §6.1's lookup over a colliding fixture, which every one of them enters with no operation
+/// name — so it reads every definition, because ambiguity is only decidable at the end.
+const COLLIDING_LOOKUP: u32 = COLLIDING_DEFINITIONS;
+
 /// `COLLIDING` fragment names that the index puts in **one** bucket, in the order it will see them.
 fn colliding_fragment_names() -> std::vec::Vec<std::string::String> {
   colliding_names("f", (COLLIDING.next_power_of_two() * 2 - 1) as u32)
@@ -788,13 +812,13 @@ fn indexing_the_documents_fragments_is_charged() {
   let query = colliding_document(&names, &head);
   let (schema, document) = compile_against(ONE_FIELD, &query);
 
-  let refused = collected_under(&schema, &document, COLLIDING_INDEX - 1);
+  let refused = collected_under(&schema, &document, COLLIDING_LOOKUP + COLLIDING_INDEX - 1);
   assert!(
     refused.is_some(),
     "a budget one unit short of the index pass must refuse rather than index for free"
   );
 
-  let served = collected_under(&schema, &document, COLLIDING_INDEX + 8);
+  let served = collected_under(&schema, &document, COLLIDING_LOOKUP + COLLIDING_INDEX + 8);
   assert_eq!(
     served, None,
     "and eight units past it is enough for the spread, its one comparison and the field it reaches"
@@ -813,10 +837,10 @@ fn a_colliding_fragment_table_costs_one_unit_per_definition_and_fragment() {
   let head = names.last().expect("the set is not empty").clone();
   let query = colliding_document(&names, &head);
 
-  // The index pass, the root's one selection, the one comparison that finds the bucket head, and
-  // the one field inside the fragment. Interning that field's key compares nothing: it is the first
-  // name in an empty arena.
-  let expected = COLLIDING_INDEX + 3;
+  // Draft §6.1's lookup over every definition, the index pass, the root's one selection, the one
+  // comparison that finds the bucket head, and the one field inside the fragment. Interning that
+  // field's key compares nothing: it is the first name in an empty arena.
+  let expected = COLLIDING_LOOKUP + COLLIDING_INDEX + 3;
   assert_eq!(
     collection_work(ONE_FIELD, &query),
     expected,
@@ -848,14 +872,24 @@ fn a_refused_probe_run_stops_at_the_refusal() {
   let (schema, document) = compile_against(ONE_FIELD, &query);
 
   let mut space = Space;
+  let budget = COLLIDING_LOOKUP + COLLIDING_INDEX + 1 + SLACK;
   let limits = Limits {
-    max_selection_visits: NonZeroU32::new(COLLIDING_INDEX + 1 + SLACK).expect("not zero"),
+    max_selection_visits: NonZeroU32::new(budget).expect("not zero"),
     ..Limits::default()
   };
   let mut executor = Executor::with_limits(&schema, &document, limits);
   executor
     .start(&mut space, None, Value::Obj)
     .expect("the operation resolves");
+
+  // Everything but `SLACK` has to have been spent before the probe run begins, or the run is not
+  // the thing the ceiling refused and the bound below holds for a reason the fixture is not about.
+  let spent = executor.collection_work();
+  assert!(
+    spent > COLLIDING_LOOKUP + COLLIDING_INDEX,
+    "{spent} units spent means this run was refused before it reached the bucket — at draft §6.1's \
+     lookup or at the index pass — so the comparison bound below is vacuous"
+  );
 
   let compares = executor.fragment_compares();
   assert!(
@@ -930,6 +964,175 @@ fn a_colliding_set_of_document_variables_cannot_outrun_the_budget() {
      document-derived name without charging lets {COLLIDING} colliding spellings cost about {} \
      comparisons, none of them collection and none of them seen by any ceiling",
     COLLIDING * COLLIDING / 2
+  );
+}
+
+// ------------------------------------------------------------------------------------------
+// Draft §6.1's own walk, which was the last uncharged one
+// ------------------------------------------------------------------------------------------
+//
+// al8n/smear#144. `Executor::operation_definition` walks the document's definitions once per
+// `start` to find the operation, over a count the client chooses, and it used to be charged to
+// nothing at all — outside both fences #143 built, in the one site those fences do not reach.
+//
+// It is charged now, one unit before each definition it reads. Two things about that cannot be
+// seen from a verdict and are therefore pinned by a count taken at the read:
+//
+// - **the charge is per definition read, not for the slice it might read**, so a named lookup that
+//   matches early is not refused for definitions it never touches — a version charging
+//   `definitions.len()` up front refuses requests it had the budget to serve, and
+//   `the_index_pass_reads_each_definition_once` is tuned to catch exactly that;
+// - **the charge is taken before the read**, so a refused lookup stops at the ceiling. A version
+//   that walked first and charged afterwards produces the same `OperationLookupRefused` for the
+//   same document, having read the whole of it.
+
+/// A document of `count` named operations, `Op0` first.
+fn many_operations(count: u32) -> std::string::String {
+  let mut query = std::string::String::new();
+  for index in 0..count {
+    query.push_str(&std::format!("query Op{index} {{ a }}\n"));
+  }
+  query
+}
+
+/// Draft §6.1's lookup charges one unit per definition it reads, and reads only what it needs.
+///
+/// Three exact totals over one document, which is what makes them a statement about the *walk*
+/// rather than about a constant: the same 512 definitions cost 1, 512 and 512 units depending only
+/// on which operation is asked for and whether ambiguity has to be decided.
+///
+/// **The plant.** Delete the `visits.take(1)` and the first total falls to one, the second to two
+/// and the third to two, while every response in the file is unchanged.
+#[test]
+fn the_operation_lookup_charges_one_unit_per_definition_read() {
+  const OPERATIONS: u32 = 512;
+
+  let query = many_operations(OPERATIONS);
+  let (schema, document) = compile_against(ONE_FIELD, &query);
+  let mut space = Space;
+
+  // The first operation, by name: the walk stops on the definition that answers.
+  let mut executor = Executor::new(&schema, &document);
+  executor
+    .start(&mut space, Some("Op0"), Value::Obj)
+    .expect("the operation resolves");
+  assert_eq!(
+    executor.operation_definitions_walked(),
+    1,
+    "a named lookup that matches the first definition read one definition and no more"
+  );
+  assert_eq!(
+    executor.collection_work(),
+    2,
+    "and it cost one unit for that definition plus one for the field it collects"
+  );
+
+  // The last operation, by name: every definition before it has to be read.
+  let wanted = std::format!("Op{}", OPERATIONS - 1);
+  let mut executor = Executor::new(&schema, &document);
+  executor
+    .start(&mut space, Some(&wanted), Value::Obj)
+    .expect("the operation resolves");
+  assert_eq!(
+    executor.operation_definitions_walked(),
+    u64::from(OPERATIONS),
+    "the last operation is behind every other definition, so the walk reads all of them"
+  );
+  assert_eq!(
+    executor.collection_work(),
+    OPERATIONS + 1,
+    "and pays one unit for each, plus the field"
+  );
+
+  // No name: the walk cannot stop early, because ambiguity is only decidable at the second
+  // operation — which here is the second definition.
+  let mut executor = Executor::new(&schema, &document);
+  let refused = executor
+    .start(&mut space, None, Value::Obj)
+    .expect_err("the document holds more than one operation");
+  assert_eq!(refused, StartError::AmbiguousOperation);
+  assert_eq!(
+    executor.operation_definitions_walked(),
+    2,
+    "ambiguity is decided by the second operation, so the walk stops there rather than at the end"
+  );
+}
+
+/// With no operation name the walk reads the whole document, because it must.
+///
+/// The other of the lookup's two modes, and the one an index has to answer as carefully as the
+/// named one: a single operation followed by fragments is only *unambiguous* once every definition
+/// has been read, so there is nothing to stop early on and the charge is the document.
+#[test]
+fn an_unnamed_lookup_reads_every_definition_before_it_can_say_the_operation_is_the_only_one() {
+  const LINKS: u32 = 64;
+  /// `fragment_chain` is one operation and `LINKS + 1` fragments.
+  const DEFINITIONS: u32 = LINKS + 2;
+
+  let query = fragment_chain(LINKS);
+  let (schema, document) = compile_against(ONE_FIELD, &query);
+  let mut space = Space;
+  let mut executor = Executor::new(&schema, &document);
+  executor
+    .start(&mut space, None, Value::Obj)
+    .expect("the operation resolves");
+
+  assert_eq!(
+    executor.operation_definitions_walked(),
+    u64::from(DEFINITIONS),
+    "one operation and {} fragments, and the lookup has to read every one of them to know the \
+     operation is the only one",
+    LINKS + 1
+  );
+}
+
+/// A refused lookup stops at the ceiling instead of reading the document and refusing afterwards.
+///
+/// # The verdict cannot see this, which is the whole reason the count exists
+///
+/// `OperationLookupRefused` is the answer under both versions and on every retry: `reset` rebuilds
+/// `Visits`, so the same document under the same ceiling reads the same no. What moves is how much
+/// of the document a refusal reads — the work an adversary gets for a request that is going to be
+/// turned away regardless, which is the same property `Fragments::compares` was added for one
+/// table over.
+///
+/// **The plant.** Take the charge after the read instead of before it, or spend
+/// `definitions.len()` up front. The first leaves `walked` at `OPERATIONS`, the second at zero;
+/// the refusal, the message and every response in this file are identical under both.
+#[test]
+fn a_refused_operation_lookup_reads_nothing_past_the_ceiling() {
+  const OPERATIONS: u32 = 512;
+  /// Definitions the ceiling has room for, which is what the walk must stop at.
+  const BUDGET: u32 = 8;
+
+  let query = many_operations(OPERATIONS);
+  let (schema, document) = compile_against(ONE_FIELD, &query);
+  let wanted = std::format!("Op{}", OPERATIONS - 1);
+  let mut space = Space;
+  let mut executor = Executor::with_limits(
+    &schema,
+    &document,
+    Limits {
+      max_selection_visits: NonZeroU32::new(BUDGET).expect("not zero"),
+      ..Limits::default()
+    },
+  );
+
+  let refused = executor
+    .start(&mut space, Some(&wanted), Value::Obj)
+    .expect_err("the document has more definitions than the ceiling admits");
+  assert_eq!(refused, StartError::OperationLookupRefused);
+  assert_eq!(
+    executor.operation_definitions_walked(),
+    u64::from(BUDGET),
+    "the walk read {} definitions against a ceiling of {BUDGET}; a charge taken after the read \
+     lets the whole document be walked before the refusal arrives",
+    executor.operation_definitions_walked()
+  );
+  assert_eq!(
+    executor.collection_work(),
+    BUDGET,
+    "and it spent exactly what it read, which is what makes the two counts separable at all"
   );
 }
 

--- a/smear/tests/proto_execute.rs
+++ b/smear/tests/proto_execute.rs
@@ -2961,15 +2961,27 @@ fn a_flat_fragment_chain_no_longer_ends_the_process() {
 /// caught by something *only* the counter can catch. This document collects a single field and
 /// walks thousands of fragments to reach it: with the counter removed the metadata ceiling sees
 /// two entries and is content, and the walk is free.
+///
+/// The budget is the document's definitions plus the visits under test, because draft §6.1's
+/// operation lookup is charged the same ceiling and reads every definition before collection
+/// begins — a budget of `WALK` alone refuses this document at the lookup, which is a real refusal
+/// of a different thing.
 #[test]
 fn collection_that_appends_nothing_is_still_charged() {
+  const LINKS: usize = 4_000;
+  /// The operation plus `LINKS + 1` fragments, which is what draft §6.1's lookup reads.
+  const LOOKUP: u32 = LINKS as u32 + 2;
+  /// What is left for the walk once the lookup is paid for.
+  const WALK: u32 = 64;
+  const BUDGET: u32 = LOOKUP + WALK;
+
   let limits = Limits {
-    max_selection_visits: NonZeroU32::new(64).expect("not zero"),
+    max_selection_visits: NonZeroU32::new(BUDGET).expect("not zero"),
     ..Limits::default()
   };
   let (_, errors) = run_bounded(
     "type Query { a: String }",
-    &fragment_chain(4_000),
+    &fragment_chain(LINKS),
     obj(vec![("a", J::Str("A".to_owned()))]),
     limits,
   );
@@ -2978,12 +2990,13 @@ fn collection_that_appends_nothing_is_still_charged() {
     errors
       .iter()
       .any(|(kind, ..)| *kind == Kind::ResponseBudget),
-    "4,000 spreads cannot be walked within 64 visits, though they append two entries in total"
+    "{LINKS} spreads cannot be walked within {WALK} visits, though they append two entries in \
+     total: {errors:?}"
   );
   assert!(
     errors
       .iter()
-      .any(|(_, message, _)| message.contains("64 selection visits")),
+      .any(|(_, message, _)| message.contains(&std::format!("{BUDGET} selection visits"))),
     "and the message names the budget that stopped it: {errors:?}"
   );
 }
@@ -3075,22 +3088,25 @@ fn collection_inside_the_visit_budget_is_unchanged() {
 ///
 /// # The numbers
 ///
-/// A chain of `LINKS` links defines `LINKS + 1` fragments in `LINKS + 2` definitions, so the index
-/// pass costs `2 · LINKS + 3`, and walking it afterwards costs about the same again — one visit per
-/// selection and about one comparison per spread. The ceiling is the pass plus `LINKS`: comfortably
-/// past the pass, so the first run reaches the walk and leaves the table built, and comfortably
-/// short of pass-plus-walk, so it is refused. A second run that skipped the pass would have the
+/// A chain of `LINKS` links defines `LINKS + 1` fragments in `LINKS + 2` definitions, so draft
+/// §6.1's lookup costs `LINKS + 2` and the index pass costs `2 · LINKS + 3`, and walking the chain
+/// afterwards costs about the same again — one visit per selection and about one comparison per
+/// spread. The ceiling is the lookup plus the pass plus `LINKS`: comfortably past both, so the
+/// first run reaches the walk and leaves the table built, and comfortably short of
+/// lookup-plus-pass-plus-walk, so it is refused. A second run that skipped the pass would have the
 /// whole walk inside what is left.
 #[test]
 fn a_refused_request_is_refused_again_on_the_same_executor() {
   const LINKS: usize = 16;
+  /// One unit per definition, read by draft §6.1 before collection begins.
+  const LOOKUP: u32 = LINKS as u32 + 2;
   /// One unit per definition walked and one per fragment pushed.
   const INDEX: u32 = 2 * LINKS as u32 + 3;
 
   let query = fragment_chain(LINKS);
   let (schema, document) = compile("type Query { a: String }", &query);
   let limits = Limits {
-    max_selection_visits: NonZeroU32::new(INDEX + LINKS as u32).expect("not zero"),
+    max_selection_visits: NonZeroU32::new(LOOKUP + INDEX + LINKS as u32).expect("not zero"),
     ..Limits::default()
   };
   let mut space = Space::default();
@@ -3338,10 +3354,11 @@ fn an_impossible_type_that_cannot_be_quoted_still_says_what_went_wrong() {
 /// A driver message the *work* ceiling refused says so, rather than blaming the arena.
 #[test]
 fn a_driver_message_refused_for_work_names_the_work_ceiling() {
-  // Exactly what `{ a }` costs: one selection examined, and an intern into an empty table that
-  // compares nothing. So the budget is spent when the driver's failure arrives.
+  // Exactly what `{ a }` costs: draft §6.1's lookup over the document's one definition, one
+  // selection examined, and an intern into an empty table that compares nothing. So the budget is
+  // spent when the driver's failure arrives.
   let limits = Limits {
-    max_selection_visits: NonZeroU32::new(1).expect("not zero"),
+    max_selection_visits: NonZeroU32::new(2).expect("not zero"),
     ..Limits::default()
   };
   let (_, errors) = run_bounded(
@@ -3358,7 +3375,7 @@ fn a_driver_message_refused_for_work_names_the_work_ceiling() {
     "the driver's failure is still the finding, whichever ceiling ate the text: {errors:?}"
   );
   assert!(
-    errors[0].1.contains("1 selection visits"),
+    errors[0].1.contains("2 selection visits"),
     "and the message names the ceiling that refused, which is the knob an operator can move: {}",
     errors[0].1
   );
@@ -3372,12 +3389,13 @@ fn a_driver_message_refused_for_work_names_the_work_ceiling() {
 /// An impossible runtime type the *work* ceiling could not quote says so too.
 #[test]
 fn an_impossible_type_refused_for_work_names_the_work_ceiling() {
-  // One selection at the root and an intern that compares nothing, as above. The driver then names
-  // `pet` as the runtime type: the schema knows the spelling — it is a field — so `sym` answers and
-  // `type_of_sym` does not, which is the "not a possible type" branch, and the name it wants to
-  // quote is the response key already sitting in that bucket.
+  // Draft §6.1's lookup over one definition, one selection at the root and an intern that compares
+  // nothing, as above. The driver then names `pet` as the runtime type: the schema knows the
+  // spelling — it is a field — so `sym` answers and `type_of_sym` does not, which is the "not a
+  // possible type" branch, and the name it wants to quote is the response key already sitting in
+  // that bucket.
   let limits = Limits {
-    max_selection_visits: NonZeroU32::new(1).expect("not zero"),
+    max_selection_visits: NonZeroU32::new(2).expect("not zero"),
     ..Limits::default()
   };
   let (_, errors) = run_bounded(
@@ -3394,7 +3412,7 @@ fn an_impossible_type_refused_for_work_names_the_work_ceiling() {
     "still the driver naming a type the position cannot hold: {errors:?}"
   );
   assert!(
-    errors[0].1.contains("1 selection visits"),
+    errors[0].1.contains("2 selection visits"),
     "and it names the ceiling that silenced the quote; this arm used to render the arena's cap \
      unconditionally, so it read `16777216 interned bytes` against an arena that was empty: {}",
     errors[0].1
@@ -5986,7 +6004,7 @@ fn request_error_result(
 /// than against a transcribed string: the wording is prose that may be improved, and what has to
 /// hold is that the entry is this error's and not a neighbour's.
 ///
-/// **Nine of `StartError`'s ten variants, and the tenth is unreachable from here rather than
+/// **Ten of `StartError`'s eleven variants, and the eleventh is unreachable from here rather than
 /// omitted.** `NoQueryRoot` needs a schema with no query root, and `Schema::build` refuses one —
 /// `MissingQueryRootOperationType`, observed — so there is no built `Schema` that can produce it
 /// and no `Executor` to raise it. That is what `StartError`'s own header means by `start` being
@@ -5999,7 +6017,11 @@ fn request_error_result(
 /// fourth, `SourceFieldArguments`, is reachable with a validated document: which variables a
 /// request supplies is not a property §5 can see.
 ///
-/// `ResponseStreamOpen` is the ninth and it is built separately, because it is the one refusal that
+/// `OperationLookupRefused` is draft §6.1's own walk meeting `max_selection_visits`, which is the
+/// row al8n/smear#144 added: the lookup is charged per definition it reads, so a ceiling below the
+/// document's definition count refuses before collection begins.
+///
+/// `ResponseStreamOpen` is the tenth and it is built separately, because it is the one refusal that
 /// is not a property of the document, the schema or the request at all: it needs an executor with a
 /// live §6.2.3 subscription, which the fixture below deliberately cannot produce. Its §7.1.3 result
 /// is the same shape as every other refusal's, and that is what this case is for — the driver that
@@ -6071,6 +6093,17 @@ fn the_errors_entry_is_the_one_refusal_start_raised() {
       None,
       Limits::default(),
       StartError::SourceFieldArguments,
+    ),
+    (
+      both,
+      // Three definitions and room to read two, so draft §6.1's walk stops inside the document.
+      "query one { a } query two { a } fragment F on Query { a }",
+      Some("two"),
+      Limits {
+        max_selection_visits: NonZeroU32::new(1).expect("one is not zero"),
+        ..Limits::default()
+      },
+      StartError::OperationLookupRefused,
     ),
   ] {
     let (raised, result) = request_error_result(sdl, query, operation, limits);


### PR DESCRIPTION
Closes #144. 
