### PR TITLE
fix(proto): a name it cannot read must not become a name it can

### DIFF
--- a/ci/source_census/src/exempt.rs
+++ b/ci/source_census/src/exempt.rs
@@ -36,6 +36,14 @@
 //! it, so nothing in that signature says the document is already in hand. The three together are
 //! the clearest calibration the table has — same module, same concrete type, opposite verdicts,
 //! each for a reason read off the signature.
+//!
+//! It is also the table's one worked example of a conviction being **answered** rather than
+//! carried. It sat here as `Tracked` against al8n/smear#139 with a reason that ended "Recorded,
+//! not accepted"; #139 read the signature, found that the parameter is not the document's type at
+//! all but the *request's* key space, and decided not to widen it. So the entry is `Structural`
+//! now and names no issue. What the rule caught was real — the two readers of that key space had
+//! drifted apart, and one of them substituted a name — and none of it was the parameter's type.
+//! A conviction the table records is a question, and this is what an answer looks like.
 
 /// The shortest reason the census will accept. Long enough that "rowan" or "#121" alone does not
 /// clear it, short enough that a genuine one-line reason does.
@@ -310,22 +318,32 @@ pub const EXEMPTIONS: &[Exemption] = &[
              one and not the other would leave half the projection's doors narrow under a table \
              that had stopped naming them.",
   },
-  // ── §6 execution, the driver's value trait — al8n/smear#139 ──────────────────────────────────
+  // ── §6 execution, the driver's value trait — al8n/smear#139, DECIDED ─────────────────────────
   Exemption {
     module: "smear::proto::values",
     entry: "Values::variable",
     param: "name",
-    kind: Kind::Tracked,
-    issue: Some(139),
-    reason: "The executor is `Executor<'a, S, V> where S: AsRef<[u8]>` and a variable's name is a \
-             slice of that document, so spelling the driver's lookup key `&str` puts a UTF-8 \
-             conversion between the two. Both call sites perform it and they disagree: draft \
-             §6.4.1's does `from_utf8(..).unwrap_or(\"\")` and asks the driver about a variable \
-             named `\"\"`, draft §6.3's condition does `.ok()` and raises. Draft §2.1.9 makes a \
-             lexed name ASCII, so neither failure branch is reachable from a parsed document — but \
-             `Name::new` is public, so a rewritten one reaches the branch that substitutes a name \
-             for the name it could not read. #139 owns the signature and the fallback together. \
-             Recorded, not accepted.",
+    kind: Kind::Structural,
+    // No issue, and that is the record: al8n/smear#139 asked whether this parameter should widen,
+    // and the answer was no. A `Tracked` entry naming a closed issue is the stale exemption this
+    // table exists to refuse — debt with a home that nobody lives in any more.
+    issue: None,
+    reason: "Not a narrowing of the document's type: the two ends of this call are two different \
+             key spaces, and only one of them is the document. Draft §6.1's `CoerceVariableValues` \
+             runs over the *request's* `variableValues`, whose keys arrive as text and are the \
+             driver's own `&str`, while a variable's spelling is a slice of an `S: AsRef<[u8]>`. \
+             Widening this parameter would not delete the conversion — it would move it inside \
+             every driver, once per implementation, where `from_utf8(..).unwrap_or(\"\")` could be \
+             written again and no gate in this repository would see it. #139 decided the opposite \
+             direction: the conversion stays on the side that knows both spaces, happens exactly \
+             once (`proto::collect::variable_key`), is called by both readers, and refuses rather \
+             than substitutes — a spelling that is not a key names no variable the request could \
+             have supplied, so draft §6.4.1 step 5.d and draft §6.3's `VariableMissing` are the \
+             answer and the driver is not asked. `graphql-proto/tests/unreadable_name.rs` pins the \
+             two readers taking that same branch, and pins the control where a readable spelling \
+             reaches the driver unchanged from both. STRUCTURAL rather than TRACKED because there \
+             is nothing left to remove; if the driver's key space ever stops being text, this is \
+             the entry that decision is about.",
   },
   // ── Not narrowings: the rule's default-convict misfiring ─────────────────────────────────────
   //

--- a/ci/source_census/src/exempt.rs
+++ b/ci/source_census/src/exempt.rs
@@ -335,15 +335,20 @@ pub const EXEMPTIONS: &[Exemption] = &[
              Widening this parameter would not delete the conversion — it would move it inside \
              every driver, once per implementation, where `from_utf8(..).unwrap_or(\"\")` could be \
              written again and no gate in this repository would see it. #139 decided the opposite \
-             direction: the conversion stays on the side that knows both spaces, happens exactly \
-             once (`proto::collect::variable_key`), is called by both readers, and refuses rather \
-             than substitutes — a spelling that is not a key names no variable the request could \
-             have supplied, so draft §6.4.1 step 5.d and draft §6.3's `VariableMissing` are the \
-             answer and the driver is not asked. `graphql-proto/tests/unreadable_name.rs` pins the \
-             two readers taking that same branch, and pins the control where a readable spelling \
-             reaches the driver unchanged from both. STRUCTURAL rather than TRACKED because there \
-             is nothing left to remove; if the driver's key space ever stops being text, this is \
-             the entry that decision is about.",
+             direction: the conversion is ONE IMPLEMENTATION — `proto::variable_key`, which is \
+             `pub` for this reason — and it refuses rather than substitutes. A spelling that is \
+             not a draft §2.1.9 `Name` names no variable the request could have supplied, so \
+             draft §6.4.1 step 5.d and draft §6.3's `VariableMissing` are the answer and the \
+             driver is not asked. One implementation and NOT one call site, which is the claim an \
+             earlier draft of this entry overstated: draft §6.4.1 step 5.j leaves a literal's \
+             contents to the driver, so a variable nested in a list or an input object reaches it \
+             inside `ArgumentSource::Literal` and the driver resolves that one — with this \
+             function, which is what the variant's own documentation now says. \
+             `graphql-proto/tests/unreadable_name.rs` pins the executor's two readers taking that \
+             same branch, pins the nested case reaching the driver unread, and pins the control \
+             where a readable spelling reaches the driver unchanged from both. STRUCTURAL rather \
+             than TRACKED because there is nothing left to remove; if the driver's key space ever \
+             stops being text, this is the entry that decision is about.",
   },
   // ── Not narrowings: the rule's default-convict misfiring ─────────────────────────────────────
   //

--- a/graphql-proto/src/collect.rs
+++ b/graphql-proto/src/collect.rs
@@ -1136,9 +1136,16 @@ impl Interner {
   /// # `&str` and not `&[u8]`
   ///
   /// The arena's readers hand a `&str` back — to a diagnostic and to a response key — so the
-  /// question "what if these bytes are not a name" has to be answered *somewhere*, and a parameter
-  /// is the only place it can be answered once. Taking bytes here answered it twice, in two
-  /// readers, and both answered it the same wrong way. See the type's own header.
+  /// question "can these bytes be printed" has to be answered *somewhere*, and taking bytes here
+  /// left it to the two readers, which both answered it the same wrong way. See the type's own
+  /// header.
+  ///
+  /// It is not the *whole* question, and reading it as the whole question is what
+  /// [`name_key`](super::name_key) exists to stop. This parameter admits every `&str`, which is
+  /// right: the arena also holds a resolver's message and a driver's `type_name`, and neither is a
+  /// draft §2.1.9 `Name` nor should be made one. "Is this spelling a name" is a question only the
+  /// *caller* knows to ask, so it is answered at each admission point rather than here — and for
+  /// the two names that come out of a document, by one function.
   ///
   /// # There is no uncharged way in, and that is the point
   ///
@@ -1616,7 +1623,12 @@ where
         // than skipped: the client asked for this position, and a response that quietly lacks a
         // key it asked for is the one outcome with nothing in `errors` to account for it. Draft
         // §2.1.9 puts this beyond a lexed document, so only an assembled one reaches it.
-        let Ok(name) = core::str::from_utf8(spelling) else {
+        //
+        // `name_key` and not `from_utf8`: the question is draft §2.1.9's and not "do these bytes
+        // print". This line checked only the conversion for one round, and `""`, `1abc`, `a b` and
+        // `🙂` were all interned and handed back as a `Segment::Field` — while `variable_key`, in
+        // this same module, refused every one of them. See `name_key`.
+        let Some(name) = name_key(spelling) else {
           return Err(Fault {
             raw: Raw::ResponseKeyUnreadable,
             location: *field.span(),
@@ -1791,14 +1803,12 @@ where
 /// one key in any driver that normalises, which is the collapse this whole issue is about arriving
 /// through the readable branch.
 ///
-/// [`is_name`] is the schema arena's own admission rule, reused rather than respelled: the
-/// executor's two name spaces — the schema's and the document's — are then admitted by one
-/// predicate, and a second spelling of draft §2.1.9 cannot drift from the first.
-///
-/// The conversion after it cannot fail, because a `Name` is ASCII. It is still written as the
-/// total conversion: this crate has no `unsafe`, and the alternative to a second pass over a name
-/// that is at most a few bytes is exactly the kind of claim that stops being true when someone
-/// changes [`is_name`].
+/// The admission rule is [`is_name`], the schema arena's own, reused rather than respelled — and
+/// reached through the *same private function* draft §7.1.2's response key is admitted by, so the
+/// executor's name spaces share one predicate by calling it rather than by saying so. That
+/// distinction is the whole of al8n/smear#139's third round: an earlier revision of this paragraph
+/// claimed the sharing while the response key's site still checked UTF-8 alone, and a claim in
+/// prose is not something a compiler can read.
 ///
 /// # `None` is a refusal, and specifically not a substitution
 ///
@@ -1816,6 +1826,48 @@ where
 /// nothing after it. See al8n/smear#139.
 #[inline]
 pub fn variable_key(spelling: &[u8]) -> Option<&str> {
+  name_key(spelling)
+}
+
+/// The `&str` `spelling` names, or `None` when it is not a draft §2.1.9 `Name`.
+///
+/// # One function, because the defect was a site that performed half of it
+///
+/// Every name this executor admits **out of a document** is admitted here: draft §7.1.2's response
+/// key, and draft §6.1's variable key through [`variable_key`]. They were not always: the response
+/// key's site checked UTF-8 alone, so `1abc`, `a b`, `🙂` and the empty spelling were interned and
+/// handed back as [`Segment::Field`](super::Segment) with no error — and the round that introduced
+/// that guard is the one whose prose said both spaces shared a predicate. Two sites spelling
+/// "predicate, then conversion" is exactly the shape one of them can write half of; one function
+/// is not.
+///
+/// The predicate is [`is_name`], the schema arena's own admission rule, so the *third* name space
+/// the executor reads — the schema's, which `Schema::build` already gates with it — is admitted by
+/// the same rule rather than by a second spelling of draft §2.1.9 that can drift from the first.
+///
+/// The conversion after it cannot fail, because a `Name` is ASCII. It is still written as the
+/// total conversion: this crate has no `unsafe`, and the alternative to a second pass over a name
+/// that is at most a few bytes is exactly the kind of claim that stops being true when someone
+/// changes [`is_name`].
+///
+/// # What is deliberately *not* admitted here
+///
+/// A spelling this crate never reads as a name does not come through this door, and pushing it
+/// through would refuse readable input for nothing. Three kinds:
+///
+/// - **Byte-exact identity inside one document** — a fragment spread against its definition, an
+///   operation name against the one [`Executor::start`](super::Executor::start) was given. Nothing
+///   is interned, nothing is rendered, and byte equality cannot map two spellings onto one, which
+///   is the failure this whole repair is about.
+/// - **A lookup in a key space that is already gated** — a field name, a type condition, an
+///   argument name, a directive name, a driver's `type_name`. Each is matched against the schema's
+///   arena or against an ASCII literal, and a spelling that is not a `Name` is in neither, so the
+///   miss *is* the refusal. A second check here would be the redundant spelling the paragraph
+///   above refuses.
+/// - **Text that was never a name** — a resolver's message, a draft §7.1.7 extensions key, which
+///   §7.1.7 puts under no lexical restriction at all.
+#[inline]
+pub(super) fn name_key(spelling: &[u8]) -> Option<&str> {
   if !is_name(spelling) {
     return None;
   }

--- a/graphql-proto/src/collect.rs
+++ b/graphql-proto/src/collect.rs
@@ -1082,7 +1082,22 @@ mod groups {
 /// [`max_interned_bytes`]: super::Limits::max_interned_bytes
 #[derive(Debug)]
 pub(super) struct Interner {
-  bytes: std::vec::Vec<u8>,
+  /// # A `String`, and that is the second half of al8n/smear#139
+  ///
+  /// This was a `Vec<u8>`, and both of its readers — [`Error::name`](super::Error) and the
+  /// response's [`Segment::Field`](super::Segment) — ended in
+  /// `core::str::from_utf8(..).unwrap_or("")`. That fallback is not a degraded reading, it is a
+  /// *different name*: every spelling it cannot read becomes the same one, so two response keys
+  /// collapse into one and a diagnostic quotes `$` with nothing after it. Both were reachable, and
+  /// the second one through the *honest* path — draft §6.3's condition refuses a spelling it
+  /// cannot read and then interns the raw bytes for its message, which rendered empty anyway.
+  ///
+  /// A `str` store moves the question to admission, where there is one caller per kind of name and
+  /// each has an answer. The driver's strings are already `&str`; the schema's arena is ASCII by
+  /// its own builder's admission rule; the two that come out of the document convert once, and
+  /// refuse rather than substitute. What is left is a reader that cannot fail, so there is no
+  /// fallback left to choose wrongly.
+  names: std::string::String,
   spans: std::vec::Vec<(u32, u32)>,
   /// Entries compared, over the executor's whole life. See [`Fragments::compares`].
   #[cfg(test)]
@@ -1105,7 +1120,7 @@ impl Interner {
   #[inline]
   pub(super) const fn new(cap: u32) -> Self {
     Self {
-      bytes: std::vec::Vec::new(),
+      names: std::string::String::new(),
       spans: std::vec::Vec::new(),
       #[cfg(test)]
       compares: 0,
@@ -1115,8 +1130,15 @@ impl Interner {
     }
   }
 
-  /// Returns the id for `bytes`, adding it if it is not already there, charging `visits` before
+  /// Returns the id for `name`, adding it if it is not already there, charging `visits` before
   /// **each** entry it compares.
+  ///
+  /// # `&str` and not `&[u8]`
+  ///
+  /// The arena's readers hand a `&str` back — to a diagnostic and to a response key — so the
+  /// question "what if these bytes are not a name" has to be answered *somewhere*, and a parameter
+  /// is the only place it can be answered once. Taking bytes here answered it twice, in two
+  /// readers, and both answered it the same wrong way. See the type's own header.
   ///
   /// # There is no uncharged way in, and that is the point
   ///
@@ -1142,7 +1164,8 @@ impl Interner {
   /// [`Unstored::Arena`] is a storage refusal and never a lookup failure: a name already present is
   /// always returned, whatever the ceiling says, so a full arena degrades what it *records* and
   /// never what it can still *read*.
-  pub(super) fn intern(&mut self, bytes: &[u8], visits: &mut Visits) -> Result<u32, Unstored> {
+  pub(super) fn intern(&mut self, name: &str, visits: &mut Visits) -> Result<u32, Unstored> {
+    let bytes = name.as_bytes();
     let hash = hash_bytes(bytes);
     if !self.heads.is_empty() {
       let mut id = self.heads[self.bucket(hash)];
@@ -1157,14 +1180,14 @@ impl Interner {
           self.compares += 1;
         }
         let (start, len) = self.spans[id as usize];
-        if &self.bytes[start as usize..(start + len) as usize] == bytes {
+        if &self.names.as_bytes()[start as usize..(start + len) as usize] == bytes {
           return Ok(id);
         }
         id = self.chain[id as usize];
       }
     }
     self
-      .insert(bytes, hash)
+      .insert(name, hash)
       .ok_or(Unstored::Arena { limit: self.cap })
   }
 
@@ -1183,25 +1206,25 @@ impl Interner {
   /// survive every operation this executor runs.
   #[cfg(test)]
   pub(super) fn capacity(&self) -> (usize, usize) {
-    (self.spans.capacity(), self.bytes.capacity())
+    (self.spans.capacity(), self.names.capacity())
   }
 
-  /// Appends `bytes` and links it, or `None` when the arena has no room.
+  /// Appends `name` and links it, or `None` when the arena has no room.
   ///
   /// Unbudgeted, and it does not need to be: it runs at most once per selection, which the caller
   /// has already charged, and the rehash it may trigger is amortised over those same insertions.
-  fn insert(&mut self, bytes: &[u8], hash: u64) -> Option<u32> {
+  fn insert(&mut self, name: &str, hash: u64) -> Option<u32> {
     // Checked, not reasoned about. The ceiling below makes each of these unreachable, and they
     // stay because "unreachable given the ceiling" is exactly the kind of claim that stops being
     // true when somebody sets a different ceiling.
-    let start = u32::try_from(self.bytes.len()).ok()?;
-    let len = u32::try_from(bytes.len()).ok()?;
+    let start = u32::try_from(self.names.len()).ok()?;
+    let len = u32::try_from(name.len()).ok()?;
     let end = start.checked_add(len)?;
     if end > self.cap {
       return None;
     }
     let id = u32::try_from(self.spans.len()).ok()?;
-    self.bytes.extend_from_slice(bytes);
+    self.names.push_str(name);
     self.spans.push((start, len));
     self.chain.push(NONE);
     if self.spans.len() > self.heads.len() {
@@ -1236,16 +1259,20 @@ impl Interner {
     self.heads.resize(buckets, NONE);
     for id in 0..self.spans.len() {
       let (start, len) = self.spans[id];
-      let hash = hash_bytes(&self.bytes[start as usize..(start + len) as usize]);
+      let hash = hash_bytes(&self.names.as_bytes()[start as usize..(start + len) as usize]);
       let bucket = self.bucket(hash);
       self.chain[id] = self.heads[bucket];
       self.heads[bucket] = id as u32;
     }
   }
 
+  /// The arena, as the `str` its readers slice.
+  ///
+  /// Every entry was appended whole through [`insert`](Interner::insert), so every `(start, len)`
+  /// in [`spans`](Interner::spans) is a pair of char boundaries and slicing by one cannot panic.
   #[inline]
-  pub(super) fn bytes(&self) -> &[u8] {
-    &self.bytes
+  pub(super) fn names(&self) -> &str {
+    &self.names
   }
 
   #[inline]
@@ -1254,7 +1281,7 @@ impl Interner {
   }
 
   pub(super) fn clear(&mut self) {
-    self.bytes.clear();
+    self.names.clear();
     self.spans.clear();
     self.chain.clear();
     // Emptied rather than refilled with the sentinel: writing `NONE` over every bucket would be
@@ -1271,7 +1298,7 @@ impl Interner {
   /// Where the arena stands, so a failed collection or expansion can put it back.
   #[inline]
   pub(super) fn mark(&self) -> (usize, usize) {
-    (self.bytes.len(), self.spans.len())
+    (self.names.len(), self.spans.len())
   }
 
   /// Undoes every name interned since `mark`.
@@ -1283,10 +1310,10 @@ impl Interner {
   ///
   /// The index is unwound before the arena, because unlinking an entry needs the bytes the
   /// truncation is about to remove.
-  pub(super) fn restore(&mut self, (bytes, spans): (usize, usize)) {
+  pub(super) fn restore(&mut self, (names, spans): (usize, usize)) {
     for id in (spans..self.spans.len()).rev() {
       let (start, len) = self.spans[id];
-      let hash = hash_bytes(&self.bytes[start as usize..(start + len) as usize]);
+      let hash = hash_bytes(&self.names.as_bytes()[start as usize..(start + len) as usize]);
       let bucket = self.bucket(hash);
       debug_assert_eq!(
         self.heads[bucket], id as u32,
@@ -1295,7 +1322,7 @@ impl Interner {
       );
       self.heads[bucket] = self.chain[id];
     }
-    self.bytes.truncate(bytes);
+    self.names.truncate(names);
     self.spans.truncate(spans);
     self.chain.truncate(spans);
   }
@@ -1580,9 +1607,21 @@ where
         if !included(field.directives(), ctx)? {
           continue;
         }
-        let name = match field.alias() {
+        let spelling = match field.alias() {
           Some(alias) => alias.name().source().as_ref(),
           None => field.name().source().as_ref(),
+        };
+        // Draft §7.1.2 makes the response key this spelling verbatim, so a spelling that is not a
+        // name is a key no response can carry. Raised rather than substituted, and raised rather
+        // than skipped: the client asked for this position, and a response that quietly lacks a
+        // key it asked for is the one outcome with nothing in `errors` to account for it. Draft
+        // §2.1.9 puts this beyond a lexed document, so only an assembled one reaches it.
+        let Ok(name) = core::str::from_utf8(spelling) else {
+          return Err(Fault {
+            raw: Raw::ResponseKeyUnreadable,
+            location: *field.span(),
+            name: None,
+          });
         };
         let key = match interner.intern(name, visits) {
           Ok(key) => key,
@@ -1752,6 +1791,36 @@ where
 /// non-`Boolean` variable at the `Boolean!` location — or a driver whose §6.1 did not coerce, so
 /// no conforming request can tell the two apart; and of the two answers only this one is safe
 /// under both senses.
+/// The key [`Values::variable`](super::Values::variable) looks a variable up by, or `None` when
+/// the document's spelling is not one.
+///
+/// # Why there is a conversion here at all
+///
+/// Not an impedance mismatch to be removed by widening the trait. The two ends genuinely differ:
+/// draft §6.1's `CoerceVariableValues` runs over the *request's* `variableValues`, whose keys
+/// arrive as text and are a driver's `&str`, while a document's spelling is a slice of an
+/// `S: AsRef<[u8]>` that nothing constrains. This is the one place the two key spaces meet, and a
+/// conversion at a boundary belongs on the side that knows both — here — rather than repeated
+/// inside every driver, where the same fallback could be written again and no gate would see it.
+///
+/// # `None` is a refusal, and specifically not a substitution
+///
+/// A spelling the driver's key space cannot express names no variable the request could have
+/// supplied, so both readers take their existing "not provided" branch: draft §6.4.1 step 5.d at a
+/// field argument, draft §6.3's [`ConditionFault::VariableMissing`] at a condition. Neither asks
+/// the driver, because there is no question to ask.
+///
+/// What this must never do is answer with a *different* name. `from_utf8(..).unwrap_or("")` did,
+/// at draft §6.4.1's site, and mapping every unreadable spelling onto one readable one merged two
+/// variables into one, asked the driver about a variable the document does not contain, carried
+/// that invented name to the resolver in
+/// [`ArgumentSource::Variable`](super::ArgumentSource::Variable) and printed it as `$` with
+/// nothing after it. See al8n/smear#139.
+#[inline]
+pub(super) fn variable_key(spelling: &[u8]) -> Option<&str> {
+  core::str::from_utf8(spelling).ok()
+}
+
 fn condition_is_true<'a, S, V>(directive: &'a Directive<S>, ctx: &mut V) -> Result<bool, Fault<'a>>
 where
   S: AsRef<[u8]>,
@@ -1786,10 +1855,7 @@ where
       // Read once. Interning the name costs a scan of the name table, so it happens only on the
       // branch that needs it for a message.
       let spelling = spelled.name().source().as_ref();
-      match core::str::from_utf8(spelling)
-        .ok()
-        .and_then(|name| ctx.variable(name))
-      {
+      match variable_key(spelling).and_then(|name| ctx.variable(name)) {
         // The variable was not supplied, and that is the finding whether or not its spelling can
         // be quoted — so an arena with no room shortens the message and keeps the diagnosis. The
         // spelling travels as bytes because the caller has an arena to restore before it can mint

--- a/graphql-proto/src/collect.rs
+++ b/graphql-proto/src/collect.rs
@@ -42,7 +42,7 @@ use smear_parser::graphql::ast::{
   Directive, Directives, ExecutableDocument, Field, FragmentDefinition, InputValue, Selection,
   SelectionSet,
 };
-use smear_schema::{Schema, TypeId, bucket, hash_bytes};
+use smear_schema::{Schema, TypeId, bucket, hash_bytes, is_name};
 
 use super::{
   Values,
@@ -1759,6 +1759,69 @@ where
   Ok(true)
 }
 
+/// The key [`Values::variable`](super::Values::variable) looks a variable up by, or `None` when
+/// the document's spelling is not a draft §2.1.9 `Name`.
+///
+/// # Why there is a conversion here at all
+///
+/// Not an impedance mismatch to be removed by widening the trait. The two ends genuinely differ:
+/// draft §6.1's `CoerceVariableValues` runs over the *request's* `variableValues`, whose keys
+/// arrive as text and are a driver's `&str`, while a document's spelling is a slice of an
+/// `S: AsRef<[u8]>` that nothing constrains. A conversion at a boundary belongs on the side that
+/// knows both key spaces rather than repeated inside every driver, where the same fallback could
+/// be written again and no gate in this repository would see it.
+///
+/// This is not the *only* place the two spaces meet, which is why the function is public rather
+/// than private to the executor. Draft §6.4.1 step 5.j — coercing a literal's contents — is the
+/// driver's, so a variable nested inside a list or an input object reaches it inside
+/// [`ArgumentSource::Literal`](super::ArgumentSource::Literal) and the driver resolves that one
+/// itself. What "the conversion happens once" can honestly mean is one *implementation*, called by
+/// every reader; a driver walking a literal calls this.
+///
+/// # The grammar, and not merely UTF-8
+///
+/// A UTF-8 check answers "can these bytes be printed", and the question is "can these bytes be a
+/// key the request supplied a value for". Draft §6.1 iterates the operation's
+/// `variableDefinitions`, whose names are `Name`s, so a `variableValues` entry that is not a
+/// `Name` matches no definition and names no variable. `$1abc`, `$ `, `$🙂`, an empty spelling and
+/// a decomposed spelling of a composed one are all valid UTF-8 and none of them is a `Name` — so a
+/// UTF-8 check handed every one of them to the driver as a lookup key, and a driver whose map
+/// happened to hold that key **satisfied** the argument with a value no variable in the document
+/// declared. The pair is the sharper case: two normalisations are two distinct `&str` keys here and
+/// one key in any driver that normalises, which is the collapse this whole issue is about arriving
+/// through the readable branch.
+///
+/// [`is_name`] is the schema arena's own admission rule, reused rather than respelled: the
+/// executor's two name spaces — the schema's and the document's — are then admitted by one
+/// predicate, and a second spelling of draft §2.1.9 cannot drift from the first.
+///
+/// The conversion after it cannot fail, because a `Name` is ASCII. It is still written as the
+/// total conversion: this crate has no `unsafe`, and the alternative to a second pass over a name
+/// that is at most a few bytes is exactly the kind of claim that stops being true when someone
+/// changes [`is_name`].
+///
+/// # `None` is a refusal, and specifically not a substitution
+///
+/// A spelling the driver's key space cannot express names no variable the request could have
+/// supplied, so both readers take their existing "not provided" branch: draft §6.4.1 step 5.d at a
+/// field argument, draft §6.3's `VariableMissing` — reported as
+/// [`Kind::DirectiveCondition`](super::Kind::DirectiveCondition) — at a condition. Neither asks the
+/// driver, because there is no question to ask.
+///
+/// What this must never do is answer with a *different* name. `from_utf8(..).unwrap_or("")` did,
+/// at draft §6.4.1's site, and mapping every unreadable spelling onto one readable one merged two
+/// variables into one, asked the driver about a variable the document does not contain, carried
+/// that invented name to the resolver in
+/// [`ArgumentSource::Variable`](super::ArgumentSource::Variable) and printed it as `$` with
+/// nothing after it. See al8n/smear#139.
+#[inline]
+pub fn variable_key(spelling: &[u8]) -> Option<&str> {
+  if !is_name(spelling) {
+    return None;
+  }
+  core::str::from_utf8(spelling).ok()
+}
+
 /// Whether the directive's `if` argument is `true`, or why it could not be read as a boolean.
 ///
 /// # Why a condition that cannot be read is an error and not a `false`
@@ -1791,36 +1854,6 @@ where
 /// non-`Boolean` variable at the `Boolean!` location — or a driver whose §6.1 did not coerce, so
 /// no conforming request can tell the two apart; and of the two answers only this one is safe
 /// under both senses.
-/// The key [`Values::variable`](super::Values::variable) looks a variable up by, or `None` when
-/// the document's spelling is not one.
-///
-/// # Why there is a conversion here at all
-///
-/// Not an impedance mismatch to be removed by widening the trait. The two ends genuinely differ:
-/// draft §6.1's `CoerceVariableValues` runs over the *request's* `variableValues`, whose keys
-/// arrive as text and are a driver's `&str`, while a document's spelling is a slice of an
-/// `S: AsRef<[u8]>` that nothing constrains. This is the one place the two key spaces meet, and a
-/// conversion at a boundary belongs on the side that knows both — here — rather than repeated
-/// inside every driver, where the same fallback could be written again and no gate would see it.
-///
-/// # `None` is a refusal, and specifically not a substitution
-///
-/// A spelling the driver's key space cannot express names no variable the request could have
-/// supplied, so both readers take their existing "not provided" branch: draft §6.4.1 step 5.d at a
-/// field argument, draft §6.3's [`ConditionFault::VariableMissing`] at a condition. Neither asks
-/// the driver, because there is no question to ask.
-///
-/// What this must never do is answer with a *different* name. `from_utf8(..).unwrap_or("")` did,
-/// at draft §6.4.1's site, and mapping every unreadable spelling onto one readable one merged two
-/// variables into one, asked the driver about a variable the document does not contain, carried
-/// that invented name to the resolver in
-/// [`ArgumentSource::Variable`](super::ArgumentSource::Variable) and printed it as `$` with
-/// nothing after it. See al8n/smear#139.
-#[inline]
-pub(super) fn variable_key(spelling: &[u8]) -> Option<&str> {
-  core::str::from_utf8(spelling).ok()
-}
-
 fn condition_is_true<'a, S, V>(directive: &'a Directive<S>, ctx: &mut V) -> Result<bool, Fault<'a>>
 where
   S: AsRef<[u8]>,

--- a/graphql-proto/src/error.rs
+++ b/graphql-proto/src/error.rs
@@ -156,9 +156,11 @@ pub(super) enum Raw {
   NameStorage { limit: u32 },
   /// A field's response key is not a name, so no response can carry it (draft §2.1.9, §7.1.2).
   ///
-  /// Carries nothing, and cannot: the whole finding is that the spelling has no rendering, so
-  /// quoting it is the one thing this must not do. Naming the *field* instead would name the same
-  /// unreadable bytes whenever the key is the field's own name rather than an alias.
+  /// Carries nothing. Half of what it refuses has no rendering at all — a response key need not be
+  /// UTF-8 — and the other half renders perfectly and is still not a name, so a variant that quoted
+  /// whenever it could would be two messages for one finding, and would spend the arena and the
+  /// visit budget on a diagnostic for a document that is not GraphQL. Naming the *field* instead
+  /// is no way out: the key **is** the field's name whenever there is no alias.
   ///
   /// Unreachable from a lexed document — draft §2.1.9 makes a name ASCII and both dialects spell
   /// exactly that — and reachable from an assembled one, which is an input

--- a/graphql-proto/src/error.rs
+++ b/graphql-proto/src/error.rs
@@ -154,6 +154,18 @@ pub(super) enum Raw {
   /// this one means a response key or a type name could not be recorded, so the position it
   /// belongs to cannot be built at all.
   NameStorage { limit: u32 },
+  /// A field's response key is not a name, so no response can carry it (draft §2.1.9, §7.1.2).
+  ///
+  /// Carries nothing, and cannot: the whole finding is that the spelling has no rendering, so
+  /// quoting it is the one thing this must not do. Naming the *field* instead would name the same
+  /// unreadable bytes whenever the key is the field's own name rather than an alias.
+  ///
+  /// Unreachable from a lexed document — draft §2.1.9 makes a name ASCII and both dialects spell
+  /// exactly that — and reachable from an assembled one, which is an input
+  /// [`Executor::new`](super::Executor::new) admits by signature. Raised rather than skipped
+  /// because the client asked for this position: dropping the key silently is the only outcome
+  /// with nothing in `errors` to account for it.
+  ResponseKeyUnreadable,
   /// The driver reported a field error whose message could not be recorded.
   ///
   /// The failure is the driver's and is reported; only its text is missing, which is why this is
@@ -258,6 +270,18 @@ pub enum Kind {
   /// request-error shape — a response with no `data` key — for a failure raised before execution
   /// begins. By the time a list is being completed, resolvers have already answered.
   ResponseBudget,
+  /// A field's response key is not a name, so no response can carry it (draft §2.1.9, §7.1.2).
+  ///
+  /// Not reachable from a document the lexer produced: draft §2.1.9's `Name` is
+  /// `[_A-Za-z][_0-9A-Za-z]*` and both dialects spell exactly that, so any key that was *lexed* is
+  /// ASCII whatever the source type is. It is reachable from a document that was **assembled** —
+  /// [`Executor::new`](super::Executor::new) takes any `&ExecutableDocument<S>` for any
+  /// `S: AsRef<[u8]>`, and a rewriter, a persisted-query store or an FFI bridge builds one.
+  ///
+  /// Its own kind rather than a shared one because a driver's remedy is unlike every other kind's:
+  /// nothing about the request's size, the schema or the resolved value is wrong, and the position
+  /// cannot be retried. Whatever produced the document produced something that is not GraphQL.
+  ResponseKeyUnreadable,
 }
 
 impl Raw {
@@ -281,6 +305,7 @@ impl Raw {
       | Self::CollectionBudget { .. }
       | Self::MetadataBudget { .. }
       | Self::NameStorage { .. } => Kind::ResponseBudget,
+      Self::ResponseKeyUnreadable => Kind::ResponseKeyUnreadable,
       Self::ResolverUnstorable { .. } => Kind::Resolver,
     }
   }
@@ -290,7 +315,7 @@ impl Raw {
 pub struct Error<'r, V> {
   pub(super) schema: &'r Schema,
   pub(super) slots: &'r [Slot<V>],
-  pub(super) names: &'r [u8],
+  pub(super) names: &'r str,
   pub(super) name_spans: &'r [(u32, u32)],
   pub(super) locations: &'r [SimpleSpan],
   pub(super) row: &'r Row,
@@ -333,9 +358,16 @@ impl<'r, V> Error<'r, V> {
     &self.locations[start as usize..(start + len) as usize]
   }
 
+  /// Returns one entry of the executor's name table.
+  ///
+  /// No conversion and no fallback. The arena is a `str` because a fallback here is not a degraded
+  /// reading — `unwrap_or("")` rendered every spelling it could not read as the *same* one, so
+  /// `ArgumentVariableMissing` printed `$` with nothing after it and two distinct names became one
+  /// message. Both spellings the arena can hold from a document now refuse at admission instead;
+  /// see [`Interner`](super::collect::Interner) and al8n/smear#139.
   fn name(&self, id: u32) -> &'r str {
     let (start, len) = self.name_spans[id as usize];
-    core::str::from_utf8(&self.names[start as usize..(start + len) as usize]).unwrap_or("")
+    &self.names[start as usize..(start + len) as usize]
   }
 }
 
@@ -562,6 +594,11 @@ impl<V> fmt::Display for Error<'_, V> {
       Raw::NameStorage { limit } => write!(
         f,
         "A name in this response would exceed the executor's limit of {limit} interned bytes."
+      ),
+      // No spelling, deliberately: see the variant. "not a name" is the whole finding, and the
+      // bytes that are not one have no rendering this could quote without inventing it.
+      Raw::ResponseKeyUnreadable => f.write_str(
+        "A field's response key is not a name and cannot appear in a response (draft \u{a7}2.1.9).",
       ),
       Raw::ResolverUnstorable { unstored } => match unstored {
         Unstored::Arena { limit } => write!(

--- a/graphql-proto/src/execute.rs
+++ b/graphql-proto/src/execute.rs
@@ -81,7 +81,9 @@ use smear_schema::{PackedType, RootOperation, Schema, Sym, TypeId, TypeKind, bui
 use super::{
   Argument, ArgumentSource, Error, Extensions, FieldRequest, Leaf, Node, ReqId, ResponseStream,
   SourceEventError, SourceField, Values,
-  collect::{Allowance, Fragments, Interner, Scratch, Unstored, Visits, collect_fields},
+  collect::{
+    Allowance, Fragments, Interner, Scratch, Unstored, Visits, collect_fields, variable_key,
+  },
   error::{ConditionFault, Raw, Row},
   request::name_bytes,
   response::{Key, NONE, Slot, State, node},
@@ -2044,7 +2046,7 @@ where
       id,
       schema: self.schema,
       slots: &self.slots,
-      names: self.interner.bytes(),
+      names: self.interner.names(),
       name_spans: self.interner.spans(),
       slot,
       field,
@@ -2121,7 +2123,7 @@ where
     // Through the same door, but not with the same message. The refusal is carried rather than
     // discarded, because the two doors are two different knobs and an operator told the wrong one
     // resizes an arena that was never the constraint.
-    let raw = match self.interner.intern(message.as_bytes(), &mut self.visits) {
+    let raw = match self.interner.intern(message, &mut self.visits) {
       Ok(message) => Raw::Resolver { message },
       Err(unstored) => Raw::ResolverUnstorable { unstored },
     };
@@ -2398,7 +2400,7 @@ where
       schema: self.schema,
       slots: &self.slots,
       depth: self.max_depth,
-      names: self.interner.bytes(),
+      names: self.interner.names(),
       name_spans: self.interner.spans(),
       locations: &self.locations,
       errors: &self.errors,
@@ -2976,7 +2978,7 @@ where
           // And when it cannot be, the message says which ceiling silenced it. This arm used to
           // render the arena's cap whatever had refused, so a visit budget exhausted by the probe
           // run reported itself as a full arena.
-          let raw = match self.interner.intern(name.as_bytes(), &mut self.visits) {
+          let raw = match self.interner.intern(name, &mut self.visits) {
             Ok(runtime) => Raw::AbstractNotPossible {
               abstract_ty: base,
               runtime,
@@ -3115,7 +3117,13 @@ where
             // the spelling is decoration on a finding that does not depend on it, so both ceilings
             // shorten the same sentence and the reader is not told about a resource at all. The
             // sites that *name* a ceiling carry the refusal instead — see `Unstored`.
-            variable: self.interner.intern(bytes, &mut self.visits).ok(),
+            //
+            // A spelling that is not a name shortens the same sentence, through `variable_key`'s
+            // `None` rather than through a ceiling. It used to be interned raw and rendered as
+            // `""` on the way out, so the honest branch printed `$` with nothing after it — see
+            // al8n/smear#139.
+            variable: variable_key(bytes)
+              .and_then(|name| self.interner.intern(name, &mut self.visits).ok()),
           },
         },
         (raw, _) => raw,
@@ -3201,7 +3209,7 @@ where
           // a name that is somebody else's: the position simply cannot be built.
           let interned = match self
             .interner
-            .intern(self.schema.name_bytes(name), &mut self.visits)
+            .intern(self.schema.name(name), &mut self.visits)
           {
             Ok(interned) => interned,
             Err(unstored) => {
@@ -3336,16 +3344,30 @@ where
       // The variable is read exactly once, here, and the value is kept rather than the name: what
       // reaches the driver has to be the value these steps checked, which is what
       // `ArgumentSource::Variable` carries and why it carries it.
+      //
+      // `variable`'s inner `Option<&str>` is the spelling *as a lookup key*, and `None` there is
+      // draft §6.3's answer read at draft §6.4.1's site: a spelling `variable_key` cannot express
+      // names no variable the request could have supplied, so step 5.d's `hasValue = false` is the
+      // conclusion and the driver is not asked. This used to be
+      // `from_utf8(..).unwrap_or("")`, which asked the driver about a variable named `""`, put
+      // that invented name in `ArgumentSource::Variable` for the resolver to read, and printed it
+      // as `$` with nothing after it — while §6.3's condition, three hundred lines away, refused
+      // the same input. al8n/smear#139.
       let (variable, has_value, is_null) = match supplied.map(|argument| argument.value()) {
         None => (None, false, false),
         Some(InputValue::Variable(spelled)) => {
-          let name = core::str::from_utf8(spelled.name().source().as_ref()).unwrap_or("");
-          match ctx.variable(name) {
-            None => (Some((name, None)), false, false),
-            Some(value) => {
-              let null = ctx.is_null(&value);
-              (Some((name, Some(value))), true, null)
-            }
+          match variable_key(spelled.name().source().as_ref()) {
+            // A variable *was* written, so this is step 5.d and not step 5.b: the outer `Some`
+            // keeps the error `ArgumentVariableMissing` rather than `ArgumentMissing`, which is
+            // the truthful one — the argument names a variable, and the variable has no value.
+            None => (Some((None, None)), false, false),
+            Some(name) => match ctx.variable(name) {
+              None => (Some((Some(name), None)), false, false),
+              Some(value) => {
+                let null = ctx.is_null(&value);
+                (Some((Some(name), Some(value))), true, null)
+              }
+            },
           }
         }
         Some(InputValue::Null(_)) => (None, true, true),
@@ -3358,9 +3380,8 @@ where
         // Step 5.h.i: a declared default applies whatever the type is, so it precedes the non-null
         // check rather than following it.
         if default {
-          let name = core::str::from_utf8(name_bytes).unwrap_or("");
           self.scratch_args.push(Argument {
-            name,
+            name: self.schema.name(argument.name()),
             ty,
             source: ArgumentSource::SchemaDefault,
           });
@@ -3383,7 +3404,10 @@ where
             // the argument is missing whatever the answer, so there is no knob to recommend and
             // nothing to say about a resource. That is the whole set of sites where `.ok()` is the
             // decision rather than an omission.
-            let variable = self.interner.intern(name.as_bytes(), &mut self.visits).ok();
+            //
+            // `and_then` for the same reason: a spelling that is not a name shortens the sentence
+            // exactly as a full arena does, and for a better reason — there is nothing to quote.
+            let variable = name.and_then(|name| self.interner.intern(name, &mut self.visits).ok());
             self.fail_at(
               slot,
               Raw::ArgumentVariableMissing {
@@ -3422,18 +3446,30 @@ where
         return false;
       }
 
-      let name = core::str::from_utf8(name_bytes).unwrap_or("");
       let source = match (variable, supplied.map(|argument| argument.value())) {
-        (Some((variable, Some(value))), _) => ArgumentSource::Variable {
+        // The inner `Some` is the reader: `has_value` is true, so the key was readable and the
+        // driver answered about it. An unreadable one never reaches here — it left at step 5.d.
+        (Some((Some(variable), Some(value))), _) => ArgumentSource::Variable {
           name: variable,
           value,
         },
         (None, Some(literal)) => ArgumentSource::Literal(literal),
         // `has_value` is true, so one of the arms above always matches: a variable with no value
-        // returned at the step 5.d branch above, and an absent argument at 5.b.
-        (Some((_, None)), _) | (None, None) => continue,
+        // returned at the step 5.d branch above — whether the driver said so or the spelling was
+        // never a key — and an absent argument at 5.b. The fourth combination is not a state the
+        // read above can construct at all: a spelling that is not a key is never handed to the
+        // driver, so it cannot come back carrying a value.
+        (Some((_, None)), _) | (Some((None, Some(_))), _) | (None, None) => continue,
       };
-      self.scratch_args.push(Argument { name, ty, source });
+      self.scratch_args.push(Argument {
+        // The *schema's* name for the argument, which its own arena already holds as a `str`: the
+        // builder admits nothing outside draft §2.1.9 (`smear_schema::is_name`), so there is no
+        // conversion to get wrong. The two `from_utf8(..).unwrap_or("")`s that used to stand here
+        // read the same arena the long way round.
+        name: self.schema.name(argument.name()),
+        ty,
+        source,
+      });
     }
     true
   }
@@ -3769,7 +3805,7 @@ where
       visits: self.visits.spent(),
       slots: self.slots.len(),
       metadata: self.merged.len() + self.locations.len(),
-      interned: self.interner.bytes().len(),
+      interned: self.interner.names().len(),
     }
   }
 
@@ -4481,7 +4517,7 @@ pub struct Response<'r, V> {
   schema: &'r Schema,
   slots: &'r [Slot<V>],
   depth: u32,
-  names: &'r [u8],
+  names: &'r str,
   name_spans: &'r [(u32, u32)],
   locations: &'r [SimpleSpan],
   errors: &'r [Row],

--- a/graphql-proto/src/execute/tests.rs
+++ b/graphql-proto/src/execute/tests.rs
@@ -1344,7 +1344,7 @@ fn a_withheld_top_level_field_is_in_the_tree_and_reads_as_null() {
   const ROOT: u32 = 0;
   let Node::Object(mut fields) = node(
     &executor.slots,
-    executor.interner.bytes(),
+    executor.interner.names(),
     executor.interner.spans(),
     ROOT,
   ) else {

--- a/graphql-proto/src/lib.rs
+++ b/graphql-proto/src/lib.rs
@@ -457,6 +457,7 @@ mod response;
 mod subscribe;
 mod values;
 
+pub use collect::variable_key;
 pub use error::{Error, Kind};
 pub use execute::{Executor, Limits, Response, SetExtensionsError, StartError};
 pub use extensions::{Ceiling, Extensions, Full};

--- a/graphql-proto/src/request.rs
+++ b/graphql-proto/src/request.rs
@@ -125,6 +125,21 @@ pub enum ArgumentSource<'a, S, V> {
   /// It may also be an input object or a list holding variables, which reach the driver
   /// unsubstituted. Coercing the contents is step 5.j's and therefore the driver's; see this
   /// module's header for where that line falls and what it costs.
+  ///
+  /// # Reading a name out of one
+  ///
+  /// A driver walking these contents meets the same two key spaces the executor does, and must
+  /// not answer the same question a different way. Turn a nested `$name`'s spelling into a lookup
+  /// key with [`variable_key`](super::variable_key) — the function draft §6.4.1's own variable
+  /// read uses — rather than with `from_utf8`, and specifically never with
+  /// `from_utf8(..).unwrap_or("")`, which is al8n/smear#139: it maps every spelling it cannot read
+  /// onto one readable one, so two variables become one and the driver is asked about a variable
+  /// the document does not contain.
+  ///
+  /// The other names in here — an input object's field names, an enum value — are the schema's
+  /// vocabulary rather than the request's, so the driver matches them against its own SDL and a
+  /// spelling that is not a `Name` matches nothing. That is the same refusal by a different route,
+  /// and it is the driver's because the schema is.
   Literal(&'a InputValue<S>),
   /// The document wrote `$name` and the request supplied a value for it: this value.
   ///

--- a/graphql-proto/src/request.rs
+++ b/graphql-proto/src/request.rs
@@ -200,7 +200,7 @@ pub struct FieldRequest<'r, 'a, S, V> {
   pub(super) id: ReqId,
   pub(super) schema: &'r Schema,
   pub(super) slots: &'r [Slot<V>],
-  pub(super) names: &'r [u8],
+  pub(super) names: &'r str,
   pub(super) name_spans: &'r [(u32, u32)],
   pub(super) slot: u32,
   pub(super) field: &'a Field<S>,

--- a/graphql-proto/src/response.rs
+++ b/graphql-proto/src/response.rs
@@ -376,7 +376,7 @@ const ELIDED: &str = "…";
 /// not an accessor. It existed, unused, and its shape was the shape the defect took.
 pub struct Path<'r, V> {
   slots: &'r [Slot<V>],
-  names: &'r [u8],
+  names: &'r str,
   name_spans: &'r [(u32, u32)],
   slot: u32,
 }
@@ -398,7 +398,7 @@ impl<'r, V> Path<'r, V> {
   #[inline]
   pub(super) const fn new(
     slots: &'r [Slot<V>],
-    names: &'r [u8],
+    names: &'r str,
     name_spans: &'r [(u32, u32)],
     slot: u32,
   ) -> Self {
@@ -942,7 +942,7 @@ impl<V> fmt::Debug for Node<'_, V> {
 /// The children of a list or an object, in response order.
 pub struct Children<'r, V> {
   slots: &'r [Slot<V>],
-  names: &'r [u8],
+  names: &'r str,
   name_spans: &'r [(u32, u32)],
   next: u32,
 }
@@ -991,18 +991,21 @@ impl<V> fmt::Debug for Children<'_, V> {
 
 /// Returns one entry of the executor's name table.
 ///
-/// GraphQL names are `[_A-Za-z][_0-9A-Za-z]*`, established by the lexer before any of this can
-/// run, so the slice is ASCII. The fallback is unreachable and costs nothing.
+/// No conversion and no fallback. This used to end in `unwrap_or("")`, justified by the lexer's
+/// draft §2.1.9 name production — a true statement about a *parsed* document, and this executor
+/// also runs assembled ones. What the fallback did there was worse than losing a key: two sibling
+/// response keys it could not read became the same readable one. The arena is a `str` now, and
+/// refuses at admission instead; see [`Interner`](super::collect::Interner).
 #[inline]
-fn interned<'r>(names: &'r [u8], name_spans: &[(u32, u32)], id: u32) -> &'r str {
+fn interned<'r>(names: &'r str, name_spans: &[(u32, u32)], id: u32) -> &'r str {
   let (start, len) = name_spans[id as usize];
-  core::str::from_utf8(&names[start as usize..(start + len) as usize]).unwrap_or("")
+  &names[start as usize..(start + len) as usize]
 }
 
 /// Renders the slot at `index` as a [`Node`].
 pub(super) fn node<'r, V>(
   slots: &'r [Slot<V>],
-  names: &'r [u8],
+  names: &'r str,
   name_spans: &'r [(u32, u32)],
   index: u32,
 ) -> Node<'r, V> {

--- a/graphql-proto/tests/unreadable_name.rs
+++ b/graphql-proto/tests/unreadable_name.rs
@@ -219,9 +219,11 @@ fn at_a_condition(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> 
 /// `{ spelling: greeting }` — draft §7.1.2's response key, which is the alias verbatim.
 ///
 /// The *second* place a document's bytes have to become a `&str`, and the one the issue's census
-/// does not name. The field's own name is looked up in the schema and a miss simply omits the
-/// position, so an unreadable field name never reaches a response — an unreadable **alias** on a
-/// resolvable field does.
+/// does not name. An alias rather than the field's own name because it is the case that survives
+/// every other guard: `greeting` resolves, the schema lookup succeeds, and the only thing standing
+/// between these bytes and a key in `data` is the admission rule at the collection site. The
+/// field's own name reaches that same rule — [`at_a_field_name`] is that branch — but a reader
+/// could believe the schema miss was what stopped it.
 fn at_a_response_key(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> {
   document(std::vec![Selection::Field(Field::new(
     span(),
@@ -231,6 +233,53 @@ fn at_a_response_key(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8
     None,
     None,
   ))])
+}
+
+/// `{ spelling }` — the same response key, taken from the field's **own** name.
+///
+/// The other arm of the one `match field.alias()` that decides a response key, and not a second
+/// site: draft §7.1.2 makes the key the alias *or* the name, so both arms hand their bytes to the
+/// same admission rule. Worth writing down because the refusal here is the collection's and not the
+/// schema's — draft §6.3 collects before draft §6.4 resolves, so a field name that is not a `Name`
+/// is refused with an error rather than silently omitted by a `sym` miss it never reaches.
+fn at_a_field_name(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> {
+  document(std::vec![Selection::Field(Field::new(
+    span(),
+    None,
+    name(spelling),
+    None,
+    None,
+    None,
+  ))])
+}
+
+/// `{ first: greeting second: greeting }` — two sibling response keys.
+///
+/// One key can be lost; two are what *collapse*, and the collapse is the finding. A response
+/// carrying one key where the document asked for two is indistinguishable, from the client's side,
+/// from a response that answered both.
+fn two_response_keys(
+  first: &'static [u8],
+  second: &'static [u8],
+) -> ExecutableDocument<&'static [u8]> {
+  document(std::vec![
+    Selection::Field(Field::new(
+      span(),
+      Some(Alias::new(span(), name(first))),
+      name(b"greeting"),
+      None,
+      None,
+      None,
+    )),
+    Selection::Field(Field::new(
+      span(),
+      Some(Alias::new(span(), name(second))),
+      name(b"greeting"),
+      None,
+      None,
+      None,
+    )),
+  ])
 }
 
 /// `{ filtered(filter: {flag: $spelling}) }` — a variable draft §6.4.1 step 5.j leaves to the
@@ -606,6 +655,82 @@ fn two_normalisations_of_one_spelling_are_neither_of_them_a_key() {
   );
   assert_eq!(composed.kinds, std::vec![Kind::ArgumentVariableMissing]);
   assert_eq!(decomposed.kinds, std::vec![Kind::ArgumentVariableMissing]);
+}
+
+/// A response key that is not a name is refused, exactly as a variable key is.
+///
+/// The same predicate applied to the *other* name space, and the reason these cells exist as their
+/// own test rather than as a line in the variable one: the round that introduced the response key's
+/// guard checked UTF-8 there and draft §2.1.9 at the variable, while claiming in prose that both
+/// spaces shared one predicate. Every spelling below converts, so a conversion-shaped guard interns
+/// it and hands it back as a [`Segment::Field`] — an empty JSON object key for `b""`, and `1abc`,
+/// `a b` or `🙂` for the rest, none of which any client asked a GraphQL service for.
+#[test]
+fn a_response_key_that_is_not_a_name_is_refused() {
+  let schema = schema();
+  for spelling in NOT_NAMES {
+    let rendered = core::str::from_utf8(spelling).expect("every NOT_NAMES entry converts");
+
+    for (shape, arm) in [
+      (
+        at_a_response_key as fn(&'static [u8]) -> ExecutableDocument<&'static [u8]>,
+        "alias",
+      ),
+      (at_a_field_name, "field name"),
+    ] {
+      let run = run(&schema, &shape(spelling), None);
+
+      assert_eq!(
+        run.kinds,
+        std::vec![Kind::ResponseKeyUnreadable],
+        "{arm} {spelling:?} was admitted as a response key: {:?}",
+        run.messages
+      );
+      assert!(
+        !run.keys.iter().any(|key| key == rendered),
+        "{arm} {spelling:?} became a key in `data`: {:?}",
+        run.keys
+      );
+      assert!(
+        !run.keys.iter().any(String::is_empty),
+        "a key stood in for {arm} {spelling:?}: {:?}",
+        run.keys
+      );
+    }
+  }
+}
+
+/// Two normalisations of one spelling are two response keys, and neither is one.
+///
+/// The response side of the pair, and the sharper half of it: two distinct `&str` keys reach a
+/// client as two entries of one JSON object, and a client that normalises before it indexes reads
+/// one. That is a response whose shape does not match the document, produced with nothing in
+/// `errors` to say so — so refusing both is what a UTF-8 guard cannot do, since both convert.
+#[test]
+fn two_normalisations_of_one_response_key_are_neither_of_them_a_key() {
+  let schema = schema();
+
+  let control = run(&schema, &two_response_keys(b"a", b"b"), None);
+  assert_eq!(
+    control.keys,
+    std::vec![String::from("a"), String::from("b")],
+    "two readable aliases are two keys, in document order: {:?}",
+    control.messages
+  );
+  assert!(control.kinds.is_empty(), "{:?}", control.messages);
+
+  let pair = run(&schema, &two_response_keys(NFC, NFD), None);
+  assert_eq!(
+    pair.kinds,
+    std::vec![Kind::ResponseKeyUnreadable],
+    "{:?}",
+    pair.messages
+  );
+  assert!(
+    pair.keys.is_empty(),
+    "a normalisation of `café` became a response key: {:?}",
+    pair.keys
+  );
 }
 
 /// [`variable_key`] is the whole key space, and a caller can ask it the same question.

--- a/graphql-proto/tests/unreadable_name.rs
+++ b/graphql-proto/tests/unreadable_name.rs
@@ -1,0 +1,365 @@
+//! What execution does with a name it cannot read.
+//!
+//! [`Executor::new`] accepts any `&ExecutableDocument<S>` for any `S: AsRef<[u8]>`, and says
+//! nothing about what those bytes are. Draft §2.1.9 makes a *lexed* name `[_A-Za-z][_0-9A-Za-z]*`,
+//! so a document that came out of the parser can only hold ASCII whatever `S` is — but a document
+//! that was **assembled** is the executor's input too, and a persisted-query store, a query
+//! rewriter or an FFI bridge holding foreign bytes assembles one. Every node of the AST has a
+//! public constructor for exactly that reason.
+//!
+//! So the fixtures here are built rather than parsed. That is not a way of reaching a private
+//! branch: it is the only way to write down the input the executor's own signature admits.
+//!
+//! Two paths read a variable's spelling — draft §6.4.1's `CoerceArgumentValues` at a field
+//! argument, and draft §6.3's `@skip`/`@include` condition — and they must reach the same
+//! conclusion about the same spelling. A conversion failure that yields a *different valid name*
+//! is worse than one that raises: it asks the driver about a variable the document does not
+//! contain, hands the resolver that invented name, and prints it in a diagnostic.
+
+use graphql_proto::{ArgumentSource, Executor, Kind, Leaf, Values};
+use smear_parser::{
+  graphql::{
+    GraphQL,
+    ast::{
+      Argument, ArgumentList, Described, Directive, Directives, ExecutableDefinition,
+      ExecutableDocument, Field, InputValue, Name, OperationDefinition, Selection, SelectionSet,
+      TypeSystemDocument, VariableValue,
+    },
+    error::GraphqlErrors,
+    syntactic::{GraphqlLexer, type_system_document},
+  },
+  lexer::tokora::{Parse as _, Parser},
+};
+use smear_schema::Schema;
+use tokora::SimpleSpan;
+
+/// A spelling no `S` can turn into a `&str`: `0xff` never begins a UTF-8 sequence.
+const UNREADABLE: &[u8] = b"\xff\x9f";
+
+/// A second one, so a repair that collapses every unreadable name onto one readable name is
+/// distinguishable from a repair that refuses to read either.
+const ALSO_UNREADABLE: &[u8] = b"\xfe\x9f";
+
+/// The spelling the control uses, which every conversion succeeds on.
+const READABLE: &[u8] = b"flagged";
+
+const SDL: &str = r"
+type Query {
+  greeting: String
+  guarded(flag: Boolean!): String
+}
+";
+
+/// The driver's values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Value {
+  Text,
+  True,
+}
+
+/// A driver that records every name it is asked about.
+///
+/// `supplied` is what it answers with, for **every** name. A driver that answers `Some` for a name
+/// it was never given is not a misbehaving driver here — it is the instrument: it makes the
+/// difference between "the executor asked" and "the executor did not" visible in the response as
+/// well as in the log.
+struct Space {
+  asked: Vec<Vec<u8>>,
+  supplied: Option<Value>,
+  /// Every `ArgumentSource::Variable` name the driver was handed, for the arguments it resolved.
+  received: Vec<Vec<u8>>,
+}
+
+impl Space {
+  fn new(supplied: Option<Value>) -> Self {
+    Self {
+      asked: Vec::new(),
+      supplied,
+      received: Vec::new(),
+    }
+  }
+}
+
+impl Values for Space {
+  type Value = Value;
+
+  fn is_null(&self, _: &Value) -> bool {
+    false
+  }
+
+  fn as_bool(&self, value: &Value) -> Option<bool> {
+    matches!(value, Value::True).then_some(true)
+  }
+
+  fn list_len(&self, _: &Value) -> Option<usize> {
+    None
+  }
+
+  fn list_item(&mut self, _: &Value, _: usize) -> Value {
+    unreachable!("no position in this fixture has a list type")
+  }
+
+  fn type_name<'a>(&'a self, _: &'a Value) -> Option<&'a str> {
+    None
+  }
+
+  fn coerce_leaf(&mut self, value: Value, _: Leaf<'_>) -> Option<Value> {
+    Some(value)
+  }
+
+  fn variable(&mut self, name: &str) -> Option<Value> {
+    self.asked.push(name.as_bytes().to_vec());
+    self.supplied
+  }
+}
+
+// ------------------------------------------------------------------------------------------
+// the fixtures, assembled
+// ------------------------------------------------------------------------------------------
+
+fn span() -> SimpleSpan {
+  SimpleSpan::new(0, 0)
+}
+
+fn name(source: &'static [u8]) -> Name<&'static [u8]> {
+  Name::new(span(), source)
+}
+
+fn variable(spelling: &'static [u8]) -> InputValue<&'static [u8]> {
+  InputValue::Variable(VariableValue::new(span(), name(spelling)))
+}
+
+fn document(selections: Vec<Selection<&'static [u8]>>) -> ExecutableDocument<&'static [u8]> {
+  ExecutableDocument::new(
+    span(),
+    std::vec![Described::new(
+      span(),
+      None,
+      ExecutableDefinition::Operation(OperationDefinition::Shorthand(SelectionSet::new(
+        span(),
+        selections,
+      ))),
+    )],
+  )
+}
+
+/// `{ guarded(flag: $spelling) }` — draft §6.4.1 step 5.f's variable read.
+fn at_an_argument(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> {
+  document(std::vec![Selection::Field(Field::new(
+    span(),
+    None,
+    name(b"guarded"),
+    Some(ArgumentList::new(
+      span(),
+      std::vec![Argument::new(span(), name(b"flag"), variable(spelling))],
+    )),
+    None,
+    None,
+  ))])
+}
+
+/// `{ greeting @skip(if: $spelling) }` — draft §6.3 step 3.a's condition.
+fn at_a_condition(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> {
+  document(std::vec![Selection::Field(Field::new(
+    span(),
+    None,
+    name(b"greeting"),
+    None,
+    Some(Directives::new(
+      span(),
+      std::vec![Directive::new(
+        span(),
+        name(b"skip"),
+        Some(ArgumentList::new(
+          span(),
+          std::vec![Argument::new(span(), name(b"if"), variable(spelling))],
+        )),
+      )],
+    )),
+    None,
+  ))])
+}
+
+// ------------------------------------------------------------------------------------------
+// driving
+// ------------------------------------------------------------------------------------------
+
+/// What one execution did, from the driver's side and from the response's.
+struct Run {
+  /// Every name [`Values::variable`] was asked about, in order.
+  asked: Vec<Vec<u8>>,
+  /// Every `ArgumentSource::Variable` name handed to the driver with a resolved argument.
+  received: Vec<Vec<u8>>,
+  /// The response's `errors`, classified.
+  kinds: Vec<Kind>,
+  /// The response's `errors`, rendered.
+  messages: Vec<String>,
+}
+
+fn run(
+  schema: &Schema,
+  document: &ExecutableDocument<&'static [u8]>,
+  supplied: Option<Value>,
+) -> Run {
+  let mut space = Space::new(supplied);
+  let mut executor = Executor::new(schema, document);
+  executor
+    .start(&mut space, None, Value::Text)
+    .expect("the operation resolves");
+  loop {
+    let Some(request) = executor.poll_resolve(&mut space) else {
+      break;
+    };
+    let id = request.id();
+    let received: Vec<Vec<u8>> = request
+      .arguments()
+      .iter()
+      .filter_map(|argument| match argument.source() {
+        ArgumentSource::Variable { name, .. } => Some(name.as_bytes().to_vec()),
+        _ => None,
+      })
+      .collect();
+    space.received.extend(received);
+    executor.handle_resolved(&mut space, id, Value::Text);
+  }
+  let response = executor.poll_response().expect("nothing is outstanding");
+  let kinds = response.errors().map(|error| error.kind()).collect();
+  let messages = response.errors().map(|error| error.to_string()).collect();
+  Run {
+    asked: space.asked,
+    received: space.received,
+    kinds,
+    messages,
+  }
+}
+
+fn schema() -> Schema {
+  let sdl = Parser::with_parser::<
+    GraphqlLexer<'_, str>,
+    TypeSystemDocument<&str>,
+    GraphqlErrors<&str>,
+    _,
+    GraphQL,
+  >(type_system_document)
+  .parse_str(SDL)
+  .expect("the SDL parses");
+  Schema::build(&sdl).expect("the SDL is a schema")
+}
+
+// ------------------------------------------------------------------------------------------
+// the properties
+// ------------------------------------------------------------------------------------------
+
+/// The control: a readable spelling reaches the driver, unchanged, from **both** paths.
+///
+/// Without it every assertion below is satisfiable by a harness that drives nothing, and the
+/// interesting ones are all assertions that something did *not* happen.
+#[test]
+fn a_readable_variable_name_reaches_the_driver_from_both_paths() {
+  let schema = schema();
+  let argument = run(&schema, &at_an_argument(READABLE), Some(Value::True));
+  let condition = run(&schema, &at_a_condition(READABLE), Some(Value::True));
+
+  assert_eq!(argument.asked, std::vec![READABLE.to_vec()]);
+  assert_eq!(condition.asked, std::vec![READABLE.to_vec()]);
+  assert_eq!(argument.asked, condition.asked);
+  assert_eq!(
+    argument.received,
+    std::vec![READABLE.to_vec()],
+    "the resolver is handed the spelling the document wrote"
+  );
+  assert!(argument.kinds.is_empty(), "{:?}", argument.messages);
+  assert!(condition.kinds.is_empty(), "{:?}", condition.messages);
+}
+
+/// The two paths take the same branch for the same unreadable spelling.
+///
+/// "The same branch" is *not* the same [`Kind`]: draft §6.4.1's error is raised at the field whose
+/// argument it is and draft §6.3's at the object whose selection set was being collected, so the
+/// classification differs by position and always has. What must agree is the decision — whether
+/// the driver is asked at all, and about what.
+#[test]
+fn the_two_paths_agree_about_an_unreadable_variable_name() {
+  let schema = schema();
+  let argument = run(&schema, &at_an_argument(UNREADABLE), Some(Value::True));
+  let condition = run(&schema, &at_a_condition(UNREADABLE), Some(Value::True));
+
+  assert_eq!(
+    argument.asked, condition.asked,
+    "draft §6.4.1 asked the driver {:?} and draft §6.3 asked it {:?} about the same spelling",
+    argument.asked, condition.asked
+  );
+  assert!(
+    argument.asked.is_empty(),
+    "the driver was asked about {:?}, and this document names no such variable",
+    argument.asked
+  );
+  assert_eq!(argument.kinds, std::vec![Kind::ArgumentVariableMissing]);
+  assert_eq!(condition.kinds, std::vec![Kind::DirectiveCondition]);
+}
+
+/// An unreadable name does not become a name the driver has a value for.
+///
+/// The driver here answers `Some` for every name it is asked, so a substituted spelling does not
+/// merely reach it — it *satisfies* draft §6.4.1 step 5.f, and the field resolves with a value no
+/// variable in the document supplied.
+#[test]
+fn an_unreadable_variable_name_does_not_supply_an_argument() {
+  let schema = schema();
+  let argument = run(&schema, &at_an_argument(UNREADABLE), Some(Value::True));
+
+  assert!(
+    argument.received.is_empty(),
+    "the resolver was handed a variable named {:?}",
+    argument.received
+  );
+  assert_eq!(argument.kinds, std::vec![Kind::ArgumentVariableMissing]);
+}
+
+/// Two unreadable spellings are two variables, not one.
+///
+/// The defect a fallback introduces is not that a name is lost; it is that **every** unreadable
+/// name becomes the *same* readable one, so distinct variables merge. Whatever the driver is told
+/// about one, it must not be the same thing it is told about the other by virtue of the failure.
+#[test]
+fn two_unreadable_names_do_not_collapse_onto_one() {
+  let schema = schema();
+  let first = run(&schema, &at_an_argument(UNREADABLE), Some(Value::True));
+  let second = run(&schema, &at_an_argument(ALSO_UNREADABLE), Some(Value::True));
+
+  assert!(
+    first.asked.is_empty() && second.asked.is_empty(),
+    "two distinct spellings reached the driver as {:?} and {:?}",
+    first.asked,
+    second.asked
+  );
+}
+
+/// Neither diagnostic quotes a variable it could not read.
+///
+/// Both messages have a spelling-free form for exactly this: "was provided a variable which was
+/// not provided a runtime value". Rendering `"$"` instead points the reader at a variable whose
+/// name is nothing.
+#[test]
+fn neither_diagnostic_renders_a_dollar_with_nothing_after_it() {
+  let schema = schema();
+  let argument = run(&schema, &at_an_argument(UNREADABLE), None);
+  let condition = run(&schema, &at_a_condition(UNREADABLE), None);
+
+  // Collected rather than asserted one at a time, because the two paths reach the same rendering
+  // by different routes — draft §6.4.1's through the substituted lookup key and draft §6.3's
+  // through the raw spelling it interns for the message — and stopping at the first would leave
+  // the second unmeasured and its repair unpinned.
+  let named_nothing: Vec<&String> = argument
+    .messages
+    .iter()
+    .chain(condition.messages.iter())
+    .filter(|message| message.contains("\"$\""))
+    .collect();
+  assert!(
+    named_nothing.is_empty(),
+    "these messages named a variable with the empty name: {named_nothing:#?}"
+  );
+  assert_eq!(argument.kinds, std::vec![Kind::ArgumentVariableMissing]);
+  assert_eq!(condition.kinds, std::vec![Kind::DirectiveCondition]);
+}

--- a/graphql-proto/tests/unreadable_name.rs
+++ b/graphql-proto/tests/unreadable_name.rs
@@ -16,12 +16,12 @@
 //! is worse than one that raises: it asks the driver about a variable the document does not
 //! contain, hands the resolver that invented name, and prints it in a diagnostic.
 
-use graphql_proto::{ArgumentSource, Executor, Kind, Leaf, Values};
+use graphql_proto::{ArgumentSource, Executor, Kind, Leaf, Node, Segment, Values};
 use smear_parser::{
   graphql::{
     GraphQL,
     ast::{
-      Argument, ArgumentList, Described, Directive, Directives, ExecutableDefinition,
+      Alias, Argument, ArgumentList, Described, Directive, Directives, ExecutableDefinition,
       ExecutableDocument, Field, InputValue, Name, OperationDefinition, Selection, SelectionSet,
       TypeSystemDocument, VariableValue,
     },
@@ -180,6 +180,23 @@ fn at_a_condition(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> 
   ))])
 }
 
+/// `{ spelling: greeting }` — draft §7.1.2's response key, which is the alias verbatim.
+///
+/// The *second* place a document's bytes have to become a `&str`, and the one the issue's census
+/// does not name. The field's own name is looked up in the schema and a miss simply omits the
+/// position, so an unreadable field name never reaches a response — an unreadable **alias** on a
+/// resolvable field does.
+fn at_a_response_key(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> {
+  document(std::vec![Selection::Field(Field::new(
+    span(),
+    Some(Alias::new(span(), name(spelling))),
+    name(b"greeting"),
+    None,
+    None,
+    None,
+  ))])
+}
+
 // ------------------------------------------------------------------------------------------
 // driving
 // ------------------------------------------------------------------------------------------
@@ -194,6 +211,8 @@ struct Run {
   kinds: Vec<Kind>,
   /// The response's `errors`, rendered.
   messages: Vec<String>,
+  /// Every key of `data`, in response order.
+  keys: Vec<String>,
 }
 
 fn run(
@@ -206,10 +225,7 @@ fn run(
   executor
     .start(&mut space, None, Value::Text)
     .expect("the operation resolves");
-  loop {
-    let Some(request) = executor.poll_resolve(&mut space) else {
-      break;
-    };
+  while let Some(request) = executor.poll_resolve(&mut space) {
     let id = request.id();
     let received: Vec<Vec<u8>> = request
       .arguments()
@@ -225,11 +241,21 @@ fn run(
   let response = executor.poll_response().expect("nothing is outstanding");
   let kinds = response.errors().map(|error| error.kind()).collect();
   let messages = response.errors().map(|error| error.to_string()).collect();
+  let keys = match response.data() {
+    Node::Object(children) => children
+      .map(|(key, _)| match key {
+        Segment::Field(key) => key.to_owned(),
+        Segment::Index(index) => index.to_string(),
+      })
+      .collect(),
+    _ => Vec::new(),
+  };
   Run {
     asked: space.asked,
     received: space.received,
     kinds,
     messages,
+    keys,
   }
 }
 
@@ -362,4 +388,31 @@ fn neither_diagnostic_renders_a_dollar_with_nothing_after_it() {
   );
   assert_eq!(argument.kinds, std::vec![Kind::ArgumentVariableMissing]);
   assert_eq!(condition.kinds, std::vec![Kind::DirectiveCondition]);
+}
+
+/// A response key that is not a name is reported, and no key stands in for it.
+///
+/// The second half of the census, and the one the issue does not name: `Segment::Field` handed
+/// back a `&str` read out of the executor's arena through `unwrap_or("")`, so two sibling keys it
+/// could not read became the same key — the same collapse as the variable, one step further on and
+/// reachable without a variable at all.
+#[test]
+fn an_unreadable_response_key_is_reported_rather_than_rendered_empty() {
+  let schema = schema();
+  let readable = run(&schema, &at_a_response_key(READABLE), None);
+  let unreadable = run(&schema, &at_a_response_key(UNREADABLE), None);
+
+  assert_eq!(
+    readable.keys,
+    std::vec![String::from_utf8(READABLE.to_vec()).expect("ASCII")],
+    "the control's alias is the response key, verbatim"
+  );
+  assert!(readable.kinds.is_empty(), "{:?}", readable.messages);
+
+  assert_eq!(unreadable.kinds, std::vec![Kind::ResponseKeyUnreadable]);
+  assert!(
+    !unreadable.keys.iter().any(String::is_empty),
+    "a key stood in for one that could not be read: {:?}",
+    unreadable.keys
+  );
 }

--- a/graphql-proto/tests/unreadable_name.rs
+++ b/graphql-proto/tests/unreadable_name.rs
@@ -4,11 +4,17 @@
 //! nothing about what those bytes are. Draft §2.1.9 makes a *lexed* name `[_A-Za-z][_0-9A-Za-z]*`,
 //! so a document that came out of the parser can only hold ASCII whatever `S` is — but a document
 //! that was **assembled** is the executor's input too, and a persisted-query store, a query
-//! rewriter or an FFI bridge holding foreign bytes assembles one. Every node of the AST has a
-//! public constructor for exactly that reason.
+//! rewriter or an FFI bridge holding foreign bytes assembles one.
 //!
 //! So the fixtures here are built rather than parsed. That is not a way of reaching a private
 //! branch: it is the only way to write down the input the executor's own signature admits.
+//!
+//! What can be written down is narrower than that signature, and worth knowing while reading
+//! these fixtures: `smear-parser` keeps `new` crate-private on every value leaf — `IntValue`,
+//! `FloatValue`, `StringValue`, `BooleanValue`, `NullValue`, `EnumValue` — so an assembled
+//! argument value can only be a variable, a list or an input object, never `1` or `"x"`. Nothing
+//! here needs a scalar literal, but the gap is why `VariableValue::new` is public at all; its own
+//! documentation carries the reason.
 //!
 //! Two paths read a variable's spelling — draft §6.4.1's `CoerceArgumentValues` at a field
 //! argument, and draft §6.3's `@skip`/`@include` condition — and they must reach the same

--- a/graphql-proto/tests/unreadable_name.rs
+++ b/graphql-proto/tests/unreadable_name.rs
@@ -16,14 +16,14 @@
 //! is worse than one that raises: it asks the driver about a variable the document does not
 //! contain, hands the resolver that invented name, and prints it in a diagnostic.
 
-use graphql_proto::{ArgumentSource, Executor, Kind, Leaf, Node, Segment, Values};
+use graphql_proto::{ArgumentSource, Executor, Kind, Leaf, Node, Segment, Values, variable_key};
 use smear_parser::{
   graphql::{
     GraphQL,
     ast::{
       Alias, Argument, ArgumentList, Described, Directive, Directives, ExecutableDefinition,
-      ExecutableDocument, Field, InputValue, Name, OperationDefinition, Selection, SelectionSet,
-      TypeSystemDocument, VariableValue,
+      ExecutableDocument, Field, InputValue, List, Name, Object, ObjectField, OperationDefinition,
+      Selection, SelectionSet, TypeSystemDocument, VariableValue,
     },
     error::GraphqlErrors,
     syntactic::{GraphqlLexer, type_system_document},
@@ -43,10 +43,40 @@ const ALSO_UNREADABLE: &[u8] = b"\xfe\x9f";
 /// The spelling the control uses, which every conversion succeeds on.
 const READABLE: &[u8] = b"flagged";
 
+/// Spellings a `&str` renders perfectly and draft §2.1.9 does not admit.
+///
+/// The half of al8n/smear#139 a UTF-8 check cannot answer. Each of these *converts*, so a
+/// conversion-shaped guard hands it to the driver as a lookup key — and a driver holding that key
+/// then satisfies an argument with a value no variable in the document declared. The empty
+/// spelling is the sharpest, because it is the exact key `from_utf8(..).unwrap_or("")` invented:
+/// the fallback is gone, and a `$` with nothing after it must not arrive by the honest route
+/// either.
+const NOT_NAMES: &[&[u8]] = &[
+  b"",                    // `$`
+  b"1abc",                // draft §2.1.9's first character is `[_A-Za-z]`
+  b"a b",                 // a space is in no position of the production
+  b"a-b",                 // and neither is a hyphen
+  "\u{1f642}".as_bytes(), // `$🙂`: four bytes, one `char`, and not ASCII
+];
+
+/// One spelling in its two Unicode normalisations, neither of which is a `Name`.
+///
+/// Two distinct `&str` keys here and one key in any driver that normalises before it looks up, so
+/// under a UTF-8 check these are two document variables that can resolve to one runtime value.
+/// That is the collapse this issue is about, arriving through the branch that *succeeds*.
+const NFC: &[u8] = "caf\u{e9}".as_bytes();
+const NFD: &[u8] = "cafe\u{301}".as_bytes();
+
 const SDL: &str = r"
 type Query {
   greeting: String
   guarded(flag: Boolean!): String
+  filtered(filter: Filter): String
+  listed(flags: [Boolean!]): String
+}
+
+input Filter {
+  flag: Boolean
 }
 ";
 
@@ -197,6 +227,51 @@ fn at_a_response_key(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8
   ))])
 }
 
+/// `{ filtered(filter: {flag: $spelling}) }` — a variable draft §6.4.1 step 5.j leaves to the
+/// driver.
+///
+/// The argument as a whole is a literal, so step 5's control flow decides about *it* and never
+/// looks inside. Coercing the contents is input coercion, whose product is a value in the
+/// service's representation, which is the one thing this crate cannot build — see
+/// [`ArgumentSource::Literal`].
+fn nested_in_an_object(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> {
+  argument_value(
+    b"filtered",
+    b"filter",
+    InputValue::Object(Object::new(
+      span(),
+      std::vec![ObjectField::new(span(), name(b"flag"), variable(spelling))],
+    )),
+  )
+}
+
+/// `{ listed(flags: [$spelling]) }` — the same boundary, one literal variant over.
+fn nested_in_a_list(spelling: &'static [u8]) -> ExecutableDocument<&'static [u8]> {
+  argument_value(
+    b"listed",
+    b"flags",
+    InputValue::List(List::new(span(), std::vec![variable(spelling)])),
+  )
+}
+
+fn argument_value(
+  field: &'static [u8],
+  argument: &'static [u8],
+  value: InputValue<&'static [u8]>,
+) -> ExecutableDocument<&'static [u8]> {
+  document(std::vec![Selection::Field(Field::new(
+    span(),
+    None,
+    name(field),
+    Some(ArgumentList::new(
+      span(),
+      std::vec![Argument::new(span(), name(argument), value)],
+    )),
+    None,
+    None,
+  ))])
+}
+
 // ------------------------------------------------------------------------------------------
 // driving
 // ------------------------------------------------------------------------------------------
@@ -207,6 +282,13 @@ struct Run {
   asked: Vec<Vec<u8>>,
   /// Every `ArgumentSource::Variable` name handed to the driver with a resolved argument.
   received: Vec<Vec<u8>>,
+  /// Every variable spelling that reached the driver *inside* an
+  /// [`ArgumentSource::Literal`](graphql_proto::ArgumentSource::Literal), in document order.
+  ///
+  /// Not a second reading of `received`: these are the ones the executor deliberately did not
+  /// read, so this is the walk draft §6.4.1 step 5.j puts on the driver, performed here because
+  /// nothing else performs it.
+  nested: Vec<Vec<u8>>,
   /// The response's `errors`, classified.
   kinds: Vec<Kind>,
   /// The response's `errors`, rendered.
@@ -215,12 +297,31 @@ struct Run {
   keys: Vec<String>,
 }
 
+/// Collects every variable spelling nested inside a literal, in document order.
+fn nested_variables<'a>(value: &InputValue<&'a [u8]>, out: &mut Vec<&'a [u8]>) {
+  match value {
+    InputValue::Variable(spelled) => out.push(spelled.name().source()),
+    InputValue::List(list) => {
+      for item in list.values() {
+        nested_variables(item, out);
+      }
+    }
+    InputValue::Object(object) => {
+      for field in object.fields() {
+        nested_variables(field.value(), out);
+      }
+    }
+    _ => {}
+  }
+}
+
 fn run(
   schema: &Schema,
   document: &ExecutableDocument<&'static [u8]>,
   supplied: Option<Value>,
 ) -> Run {
   let mut space = Space::new(supplied);
+  let mut nested: Vec<Vec<u8>> = Vec::new();
   let mut executor = Executor::new(schema, document);
   executor
     .start(&mut space, None, Value::Text)
@@ -235,6 +336,13 @@ fn run(
         _ => None,
       })
       .collect();
+    for argument in request.arguments() {
+      if let ArgumentSource::Literal(literal) = argument.source() {
+        let mut spellings = Vec::new();
+        nested_variables(literal, &mut spellings);
+        nested.extend(spellings.into_iter().map(<[u8]>::to_vec));
+      }
+    }
     space.received.extend(received);
     executor.handle_resolved(&mut space, id, Value::Text);
   }
@@ -253,6 +361,7 @@ fn run(
   Run {
     asked: space.asked,
     received: space.received,
+    nested,
     kinds,
     messages,
     keys,
@@ -415,4 +524,146 @@ fn an_unreadable_response_key_is_reported_rather_than_rendered_empty() {
     "a key stood in for one that could not be read: {:?}",
     unreadable.keys
   );
+}
+
+// ------------------------------------------------------------------------------------------
+// the key space is draft §2.1.9, and not UTF-8
+// ------------------------------------------------------------------------------------------
+
+/// A spelling that converts but is not a `Name` does not supply an argument.
+///
+/// The half a conversion-shaped guard cannot answer. Each of [`NOT_NAMES`] renders perfectly, so
+/// `from_utf8(..).ok()` hands every one of them to the driver as a lookup key — and this driver
+/// answers `Some` for every name it is asked, so reaching it does not merely leak a spelling, it
+/// *satisfies* draft §6.4.1 step 5.f and resolves the field with a value no variable in the
+/// document declared. The question the key space asks is not "can these bytes be printed" but
+/// "can these bytes be a key draft §6.1 could have bound", and only draft §2.1.9 answers it.
+#[test]
+fn a_variable_name_that_is_not_a_name_does_not_supply_an_argument() {
+  let schema = schema();
+  for spelling in NOT_NAMES {
+    let argument = run(&schema, &at_an_argument(spelling), Some(Value::True));
+    let condition = run(&schema, &at_a_condition(spelling), Some(Value::True));
+
+    assert!(
+      argument.asked.is_empty(),
+      "draft §6.4.1 asked the driver about {:?}, which is not a name",
+      argument.asked
+    );
+    assert_eq!(
+      argument.asked, condition.asked,
+      "the two readers disagreed about {spelling:?}"
+    );
+    assert!(
+      argument.received.is_empty(),
+      "the resolver was handed a variable named {:?}",
+      argument.received
+    );
+    assert_eq!(
+      argument.kinds,
+      std::vec![Kind::ArgumentVariableMissing],
+      "{:?}",
+      argument.messages
+    );
+    assert_eq!(
+      condition.kinds,
+      std::vec![Kind::DirectiveCondition],
+      "{:?}",
+      condition.messages
+    );
+  }
+}
+
+/// Two normalisations of one spelling are two variables, and neither is a key.
+///
+/// The empty-name collapse arriving through the branch that *succeeds*: both of these convert, so
+/// a UTF-8 guard hands the driver two distinct `&str` keys that any driver normalising before it
+/// looks up merges into one. Refusing both is what keeps "a spelling that is not a key names no
+/// variable" true of a pair as well as of a single name.
+#[test]
+fn two_normalisations_of_one_spelling_are_neither_of_them_a_key() {
+  assert_ne!(NFC, NFD, "the fixture must be two distinct byte strings");
+  assert!(
+    core::str::from_utf8(NFC).is_ok() && core::str::from_utf8(NFD).is_ok(),
+    "both must convert, or this tests the unreadable case over again"
+  );
+
+  let schema = schema();
+  let composed = run(&schema, &at_an_argument(NFC), Some(Value::True));
+  let decomposed = run(&schema, &at_an_argument(NFD), Some(Value::True));
+
+  assert!(
+    composed.asked.is_empty() && decomposed.asked.is_empty(),
+    "two normalisations reached the driver as {:?} and {:?}",
+    composed.asked,
+    decomposed.asked
+  );
+  assert_eq!(composed.kinds, std::vec![Kind::ArgumentVariableMissing]);
+  assert_eq!(decomposed.kinds, std::vec![Kind::ArgumentVariableMissing]);
+}
+
+/// [`variable_key`] is the whole key space, and a caller can ask it the same question.
+///
+/// The function is `pub` because the executor is not its only reader — see the nested-literal
+/// test below — so what it admits is API and pinned here rather than inferred from a response.
+#[test]
+fn variable_key_admits_exactly_the_name_production() {
+  assert_eq!(variable_key(READABLE), Some("flagged"));
+  assert_eq!(variable_key(b"_"), Some("_"));
+  assert_eq!(variable_key(b"_0aZ"), Some("_0aZ"));
+  for spelling in NOT_NAMES {
+    assert_eq!(variable_key(spelling), None, "admitted {spelling:?}");
+  }
+  assert_eq!(variable_key(UNREADABLE), None);
+  assert_eq!(variable_key(NFC), None);
+  assert_eq!(variable_key(NFD), None);
+}
+
+// ------------------------------------------------------------------------------------------
+// the boundary the executor does not cross
+// ------------------------------------------------------------------------------------------
+
+/// A variable inside a list or an input object reaches the driver unread, whatever it spells.
+///
+/// Draft §6.4.1 step 5.j — coercing a literal's contents — is the driver's, because its product is
+/// a value in the service's representation and this crate builds none. So the executor decides
+/// about the argument *as a whole*, hands the literal over, and never asks
+/// [`Values::variable`] about anything inside it. That is the contract
+/// [`ArgumentSource::Literal`](graphql_proto::ArgumentSource::Literal) states, and it predates
+/// this repair: it is where `ArgumentSource` has drawn the line since the executor was written.
+///
+/// What is pinned here is that the executor does not quietly start reading them — which would
+/// change *which* variables a request must supply — and that the spelling arrives verbatim, so
+/// the driver's own read is a read of the document's bytes and not of something substituted on
+/// the way. [`variable_key`] is what that read must be: the same refusal, in the same function,
+/// rather than a second `from_utf8` per driver.
+#[test]
+fn a_variable_nested_in_a_literal_reaches_the_driver_unread() {
+  let schema = schema();
+  for shape in [
+    nested_in_an_object as fn(&'static [u8]) -> ExecutableDocument<&'static [u8]>,
+    nested_in_a_list,
+  ] {
+    for spelling in [READABLE, UNREADABLE] {
+      let run = run(&schema, &shape(spelling), Some(Value::True));
+
+      assert!(
+        run.asked.is_empty(),
+        "the executor read a nested variable and asked the driver about {:?}",
+        run.asked
+      );
+      assert_eq!(
+        run.nested,
+        std::vec![spelling.to_vec()],
+        "the driver was handed a literal whose variable is not the one the document wrote"
+      );
+      assert!(run.kinds.is_empty(), "{:?}", run.messages);
+    }
+  }
+
+  // And the read the driver then performs is this one, which refuses the spelling the executor's
+  // own readers refuse. Without it every driver writes the conversion again, which is the shape
+  // al8n/smear#139 is about rather than any one occurrence of it.
+  assert_eq!(variable_key(READABLE), Some("flagged"));
+  assert_eq!(variable_key(UNREADABLE), None);
 }

--- a/smear-parser/src/name.rs
+++ b/smear-parser/src/name.rs
@@ -107,7 +107,13 @@ impl<S, Span, Lang: ?Sized> IntoComponents for FragmentName<S, Span, Lang> {
 }
 
 impl<S, Span, Lang: ?Sized> Name<S, Span, Lang> {
-  /// Creates a valid dialect name.
+  /// Creates a dialect name from a span and a spelling.
+  ///
+  /// It does not check the spelling, and the name says "valid" only of what the *productions*
+  /// build: a name that was lexed is a name, because the lexer's token production is draft
+  /// §2.1.9's. Nothing establishes that for a name assembled here, and a consumer that reads one
+  /// as text — `graphql_proto`'s response keys, its variable lookups — has to answer that question
+  /// itself rather than assume this constructor answered it.
   #[inline]
   pub const fn new(span: Span, source: S) -> Self {
     Self(Ident::new(span, source))

--- a/smear-parser/src/value/variable.rs
+++ b/smear-parser/src/value/variable.rs
@@ -62,13 +62,35 @@ where
 impl<Name, Span> VariableValue<Name, Span> {
   /// Creates a new variable from the given span and name.
   ///
-  /// Public because every other node of this AST is constructible — [`Name::new`], `Field::new`,
-  /// `Argument::new`, `Document::new` — and a document assembled rather than parsed is a
-  /// supported input: `graphql_proto::Executor::new` accepts any `&ExecutableDocument<S>`
-  /// whatever built it. This one was `pub(crate)` with no recorded reason, which left `$name` the
-  /// single production a rewriter, a persisted-query store or an FFI bridge could not spell, and
-  /// made a whole class of executor input unreachable *and* untestable rather than merely
-  /// unusual.
+  /// # A deliberate exception to this crate's rule, and the rule is real
+  ///
+  /// An earlier revision of this comment said the node was `pub(crate)` "with no recorded reason"
+  /// and that every other node of this AST is constructible. Both halves are wrong, and the
+  /// compiler says so: [`IntValue`](crate::value::IntValue),
+  /// [`FloatValue`](crate::value::FloatValue), [`StringValue`](crate::value::StringValue),
+  /// [`BooleanValue`](crate::value::BooleanValue), [`NullValue`](crate::value::NullValue) and
+  /// [`EnumValue`](crate::value::EnumValue) all keep `new` crate-private, so an
+  /// `InputValue` built from outside this crate cannot be a scalar literal at all — `f(x: 1)` is
+  /// unspellable. The rule the crate actually applies is that a node **carrying a lexeme** is
+  /// constructed by the production that lexed it, and a **structural** node — `Field`, `Argument`,
+  /// `List`, `Object`, `SelectionSet`, `Document` — is public. This node is `$` and a lexeme, so
+  /// the rule puts it with the leaves.
+  ///
+  /// It is public anyway, for one reason that survives: `graphql_proto::Executor::new` accepts any
+  /// `&ExecutableDocument<S>` for any `S: AsRef<[u8]>`, and what execution does with a spelling
+  /// that is not a draft §2.1.9 `Name` is behaviour that has to be *writable* to be pinned. It is
+  /// pinned, in `graphql-proto/tests/unreadable_name.rs`, and every fixture there needs this
+  /// constructor. The narrower door — keep this crate-private and add a checked builder — was
+  /// considered and does not pay for itself: `Executor::new`'s bound is a caller-implemented
+  /// trait with no purity requirement, so a check here binds nothing the executor reads later;
+  /// this node adds no rule of its own to check; and the sibling names inside the very same
+  /// literal, an [`Object`](crate::value::Object) field's or an alias's, are built from the public
+  /// and unchecked [`Name::new`] regardless.
+  ///
+  /// So what is missing is an admission story for the AST as a whole — a `Name` that is checked
+  /// once at its own door, and value leaves an assembler can spell — and not a guard on this one
+  /// node. Until there is one, this constructor admits exactly what [`Name::new`] admits, and the
+  /// refusal that matters is `graphql_proto::variable_key`'s, on the side that owns the key space.
   ///
   /// [`FragmentName::new`](crate::name::FragmentName) is deliberately not public and stays so:
   /// its exclusion of `on` is a grammar rule the syntactic productions establish, and a

--- a/smear-parser/src/value/variable.rs
+++ b/smear-parser/src/value/variable.rs
@@ -61,8 +61,21 @@ where
 
 impl<Name, Span> VariableValue<Name, Span> {
   /// Creates a new variable from the given span and name.
+  ///
+  /// Public because every other node of this AST is constructible — [`Name::new`], `Field::new`,
+  /// `Argument::new`, `Document::new` — and a document assembled rather than parsed is a
+  /// supported input: `graphql_proto::Executor::new` accepts any `&ExecutableDocument<S>`
+  /// whatever built it. This one was `pub(crate)` with no recorded reason, which left `$name` the
+  /// single production a rewriter, a persisted-query store or an FFI bridge could not spell, and
+  /// made a whole class of executor input unreachable *and* untestable rather than merely
+  /// unusual.
+  ///
+  /// [`FragmentName::new`](crate::name::FragmentName) is deliberately not public and stays so:
+  /// its exclusion of `on` is a grammar rule the syntactic productions establish, and a
+  /// constructor would let a caller past it. There is no analogous rule here — draft §2.1.9's
+  /// name production is [`Name`]'s, and this node adds only the `$`.
   #[inline]
-  pub(crate) const fn new(span: Span, name: Name) -> Self {
+  pub const fn new(span: Span, name: Name) -> Self {
     Self { span, name }
   }
 


### PR DESCRIPTION
Closes #139.
